### PR TITLE
Bump com.diffplug.spotless from 6.25.0 to 7.0.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     id("java")
     id("jacoco")
     id("application")
-    id("com.diffplug.spotless") version "6.25.0"
+    id("com.diffplug.spotless") version "7.0.2"
 }
 
 // Spotless configuration for code formatting


### PR DESCRIPTION
Bumps com.diffplug.spotless from 6.25.0 to 7.0.2.

---
updated-dependencies:
- dependency-name: com.diffplug.spotless dependency-type: direct:production update-type: version-update:semver-major ...