### PR TITLE
Fix pipeline streams in StreamConverter

### DIFF
--- a/src/main/java/com/streamConverter/StreamConverter.java
+++ b/src/main/java/com/streamConverter/StreamConverter.java
@@ -87,7 +87,7 @@ public class StreamConverter {
                 try (OutputStream currentOut1 = currentOut;
                     InputStream currentIn1 = currentIn; ) {
                   // コマンド実行
-                  command.execute(inputStream, outputStream);
+                  command.execute(currentIn1, currentOut1);
                 } catch (IOException e) {
                   throw new RuntimeException(e);
                 }


### PR DESCRIPTION
## Summary
- use the streams created for each command when executing in StreamConverter

## Testing
- `gradle test --no-daemon` *(fails: Plugin `com.diffplug.spotless` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841317605848325aed797e3c08772f9