### PR TITLE
Add maven publish and install alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,14 @@ npm install --save-dev @commitlint/cli @commitlint/config-conventional
 ```bash
 ./gradlew spotlessApply
 ```
+
+### ローカルMavenリポジトリへのインストール
+
+依存解決の失敗を避けるため、生成物をローカルリポジトリへ公開できます。
+
+```bash
+./gradlew install
+```
+
+これにより `mavenLocal()` が最優先で参照されるため、この環境だけで依存関係を解決できます。
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,8 @@ plugins {
     id("application")
     id("com.diffplug.spotless") version "7.0.4"
     id("info.solidsoft.pitest") version "1.15.0"
+    // Add Maven publishing capabilities
+    id("maven-publish")
 }
 
 // Spotless configuration for code formatting
@@ -38,11 +40,16 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
+group = "com.streamConverter"
+version = "1.0-SNAPSHOT"
+
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
 }
 
 repositories {
+    // Check local repository first to avoid resolution errors
+    mavenLocal()
     mavenCentral()
 }
 
@@ -115,4 +122,17 @@ tasks.named("spotlessCheck") {
 // check タスクの実行時に spotlessApply を依存タスクとして実行する
 tasks.named("check") {
     dependsOn("spotlessApply")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+        }
+    }
+}
+
+// Provide an "install" task similar to Maven's behavior
+tasks.register("install") {
+    dependsOn("publishToMavenLocal")
 }


### PR DESCRIPTION
## Summary
- enable Maven publishing for Java module
- search mavenLocal first so Gradle can resolve local dependencies
- add an `install` task that publishes to the local Maven repository

## Testing
- `./gradlew build`
- `./gradlew install`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6841457ee19c832596f1fdf5a904ab4b