### PR TITLE
feat(core): Remove single command optimization for Issue #125

### DIFF
--- a/src/main/java/com/streamConverter/StreamConverter.java
+++ b/src/main/java/com/streamConverter/StreamConverter.java
@@ -173,81 +173,11 @@ public class StreamConverter {
         commands.size(),
         context.getExecutionId());
 
-    if (this.commands.size() == 1) {
-      // 単一コマンドの場合は直接実行（メモリ効率最優先）
-      return executeSingleCommandWithMDC(inputStream, outputStream, context);
-    }
-
-    // 複数コマンドの場合はPipedStreamで並行処理（MDC対応）
+    // PipedStreamで並行処理（MDC対応）
     return executeMultipleCommandsWithMDC(inputStream, outputStream, context);
   }
 
-  /** 単一コマンドをMDC同期付きで実行 */
-  private List<CommandResult> executeSingleCommandWithMDC(
-      InputStream inputStream, OutputStream outputStream, ExecutionContext context)
-      throws IOException {
-    IStreamCommand command = this.commands.get(0);
-
-    // コマンド実行前のMDC設定
-    int sequence = context.getNextCommandSequence();
-    String stageName = command.getClass().getSimpleName() + "-" + sequence;
-    context.applyToMDCWithStage(stageName);
-
-    log.info(
-        "Executing single command: {} (sequence: {})",
-        command.getClass().getSimpleName(),
-        sequence);
-
-    long startTime = System.currentTimeMillis();
-    java.time.Instant startInstant = java.time.Instant.now();
-
-    try {
-      // コマンド実行（MDCは自動的に利用可能）
-      command.execute(inputStream, outputStream);
-
-      long endTime = System.currentTimeMillis();
-      java.time.Instant endInstant = java.time.Instant.now();
-
-      List<CommandResult> results = new ArrayList<>();
-      results.add(
-          CommandResult.success(
-              command.getClass().getSimpleName(),
-              endTime - startTime,
-              0L, // 入力バイト数は現在の実装では取得困難
-              0L, // 出力バイト数は現在の実装では取得困難
-              startInstant,
-              endInstant));
-
-      log.info(
-          "Completed single command: {} (sequence: {})",
-          command.getClass().getSimpleName(),
-          sequence);
-      return results;
-
-    } catch (Exception e) {
-      long endTime = System.currentTimeMillis();
-      java.time.Instant endInstant = java.time.Instant.now();
-
-      List<CommandResult> results = new ArrayList<>();
-      results.add(
-          CommandResult.failure(
-              command.getClass().getSimpleName(),
-              endTime - startTime,
-              e.getMessage(),
-              startInstant,
-              endInstant));
-
-      log.error(
-          "Single command failed: {} (sequence: {}) - {}",
-          command.getClass().getSimpleName(),
-          sequence,
-          e.getMessage(),
-          e);
-      throw e; // 例外は再スロー
-    }
-  }
-
-  /** 複数コマンドをMDC同期付きで並列実行 */
+  /** コマンドをMDC同期付きで並列実行 */
   private List<CommandResult> executeMultipleCommandsWithMDC(
       InputStream inputStream, OutputStream outputStream, ExecutionContext context)
       throws IOException {

--- a/src/main/java/com/streamConverter/StreamConverter.java
+++ b/src/main/java/com/streamConverter/StreamConverter.java
@@ -177,7 +177,7 @@ public class StreamConverter {
     return executeMultipleCommandsWithMDC(inputStream, outputStream, context);
   }
 
-  /** コマンドをMDC同期付きで並列実行 */
+  /** コマンド（単一または複数）をMDC同期付きで並列実行 */
   private List<CommandResult> executeMultipleCommandsWithMDC(
       InputStream inputStream, OutputStream outputStream, ExecutionContext context)
       throws IOException {

--- a/src/test/java/com/streamConverter/StreamConverterTest.java
+++ b/src/test/java/com/streamConverter/StreamConverterTest.java
@@ -205,7 +205,9 @@ class StreamConverterTest {
         };
 
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    StreamConverter converter = StreamConverter.create(new SampleStreamCommand("large-test"));
+    StreamConverter converter =
+        StreamConverter.create(
+            new SampleStreamCommand("large-test-1"), new SampleStreamCommand("large-test-2"));
 
     // メモリ使用量監視しながら実行
     long startTime = System.currentTimeMillis();


### PR DESCRIPTION
## Summary

- Remove single command execution optimization to focus library value on 2+ command pipeline processing
- Unify all command execution through the same pipeline processing path
- Maintain backward compatibility while removing performance optimization

## Changes Made

### Core Implementation Changes
- **StreamConverter.java**: Remove single command branching logic and `executeSingleCommandWithMDC()` method
- Force all commands (1 or more) through unified `executeMultipleCommandsWithMDC()` pipeline
- Simplify execution logic while maintaining same external interface

### Test Updates  
- **StreamConverterTest.java**: Update memory efficiency test to use dual commands instead of single command
- Ensure test coverage maintains the same intent while conforming to new architecture

## Technical Details

### Before (Removed Code)
```java
if (this.commands.size() == 1) {
  return executeSingleCommandWithMDC(inputStream, outputStream, context);
}
```

### After (Unified Path)
```java
// All executions now go through unified pipeline processing
return executeMultipleCommandsWithMDC(inputStream, outputStream, context);
```

## Test Results

✅ All StreamConverter tests pass (11/11)  
✅ Memory efficiency test successfully updated to dual command pattern  
✅ Pre-commit checks passed  
✅ No breaking changes to public API

## Performance Impact

- Single command execution will use slightly more memory due to pipeline overhead
- Performance difference is minimal for single commands
- Overall architecture becomes simpler and more maintainable
- Library focus remains on multi-command pipeline value proposition

## Closes

Closes #125

🤖 Generated with [Claude Code](https://claude.ai/code)