### PR TITLE
feat: Migrate connection pool management to HikariCP and upgrade PiTest plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     id("jacoco")
     id("application")
     id("com.diffplug.spotless") version "7.2.1"
-    id("info.solidsoft.pitest") version "1.15.0"
+    id("info.solidsoft.pitest") version "1.19.0-rc.1"
     id("org.springframework.boot") version "3.4.1"
     id("io.spring.dependency-management") version "1.1.7"
 }
@@ -185,7 +185,8 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.18.2")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2")
     
-    // Database support (H2 for testing)
+    // Database support
+    implementation("com.zaxxer:HikariCP:6.2.1")
     testImplementation("com.h2database:h2:2.2.224")
     
     // Spring Boot Test

--- a/src/main/java/com/streamConverter/command/rule/HikariConnectionPoolConfig.java
+++ b/src/main/java/com/streamConverter/command/rule/HikariConnectionPoolConfig.java
@@ -149,7 +149,7 @@ public class HikariConnectionPoolConfig implements AutoCloseable {
       return "HikariCP[CLOSED]";
     }
 
-    var mxBean = dataSource.getHikariPoolMXBean();
+    com.zaxxer.hikari.HikariPoolMXBean mxBean = dataSource.getHikariPoolMXBean();
     return String.format(
         "HikariCP Details[active=%d, idle=%d, total=%d, waiting=%d, url=%s]",
         mxBean.getActiveConnections(),
@@ -183,7 +183,7 @@ public class HikariConnectionPoolConfig implements AutoCloseable {
    *
    * @deprecated {@link #close()} を使用してください
    */
-  @Deprecated
+  @Deprecated(since = "1.2", forRemoval = true)
   public void shutdown() {
     close();
   }

--- a/src/main/java/com/streamConverter/command/rule/HikariConnectionPoolConfig.java
+++ b/src/main/java/com/streamConverter/command/rule/HikariConnectionPoolConfig.java
@@ -1,0 +1,190 @@
+package com.streamConverter.command.rule;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * HikariCP接続プール設定クラス
+ *
+ * <p>HikariCPを使用したデータベース接続プールの実装です。 DatabaseConnectionPoolの置き換えとして高性能で信頼性の高い接続プール管理を提供します。
+ *
+ * <p>機能:
+ *
+ * <ul>
+ *   <li>業界標準のHikariCP接続プール
+ *   <li>自動的な接続リーク検出
+ *   <li>接続プールメトリクス
+ *   <li>設定可能なプールサイズと接続タイムアウト
+ *   <li>接続の検証と回復
+ * </ul>
+ *
+ * <p>使用例:
+ *
+ * <pre>{@code
+ * // HikariCP接続プールの作成
+ * HikariConnectionPoolConfig pool = new HikariConnectionPoolConfig("jdbc:h2:mem:testdb");
+ *
+ * // 接続の取得
+ * try (Connection connection = pool.getConnection()) {
+ *     // データベース操作
+ * }
+ *
+ * // プールのシャットダウン
+ * pool.close();
+ * }</pre>
+ */
+public class HikariConnectionPoolConfig implements AutoCloseable {
+  private static final Logger logger = LoggerFactory.getLogger(HikariConnectionPoolConfig.class);
+
+  private final HikariDataSource dataSource;
+  private final String databaseUrl;
+
+  /**
+   * デフォルト設定で接続プールを初期化
+   *
+   * @param databaseUrl データベースURL
+   * @throws IllegalArgumentException URLが無効な場合
+   */
+  public HikariConnectionPoolConfig(String databaseUrl) {
+    this(databaseUrl, 10, Duration.ofSeconds(30));
+  }
+
+  /**
+   * カスタム設定で接続プールを初期化
+   *
+   * @param databaseUrl データベースURL
+   * @param maximumPoolSize 最大プールサイズ
+   * @param connectionTimeout 接続タイムアウト
+   * @throws IllegalArgumentException パラメータが無効な場合
+   */
+  public HikariConnectionPoolConfig(
+      String databaseUrl, int maximumPoolSize, Duration connectionTimeout) {
+    Objects.requireNonNull(databaseUrl, "Database URL cannot be null");
+    if (maximumPoolSize <= 0) {
+      throw new IllegalArgumentException("Maximum pool size must be positive");
+    }
+    Objects.requireNonNull(connectionTimeout, "Connection timeout cannot be null");
+
+    this.databaseUrl = databaseUrl;
+
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl(databaseUrl);
+    config.setMaximumPoolSize(maximumPoolSize);
+    config.setMinimumIdle(Math.min(5, maximumPoolSize / 2)); // 最小接続数は最大値の半分または5
+    config.setConnectionTimeout(connectionTimeout.toMillis());
+    config.setIdleTimeout(Duration.ofMinutes(10).toMillis()); // アイドル接続のタイムアウト
+    config.setMaxLifetime(Duration.ofMinutes(30).toMillis()); // 接続の最大生存時間
+    config.setLeakDetectionThreshold(Duration.ofMinutes(2).toMillis()); // 接続リーク検出
+
+    // 接続プールの名前を設定（デバッグ用）
+    config.setPoolName("StreamConverter-Pool");
+
+    // 接続検証クエリ（H2データベース用）
+    if (databaseUrl.contains(":h2:")) {
+      config.setConnectionTestQuery("SELECT 1");
+    }
+
+    // プロパティの設定
+    config.addDataSourceProperty("cachePrepStmts", "true");
+    config.addDataSourceProperty("prepStmtCacheSize", "250");
+    config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+
+    this.dataSource = new HikariDataSource(config);
+
+    logger.info(
+        "HikariCP connection pool initialized - URL: {}, MaxPoolSize: {}, ConnectionTimeout: {}ms",
+        databaseUrl,
+        maximumPoolSize,
+        connectionTimeout.toMillis());
+  }
+
+  /**
+   * プールから接続を取得
+   *
+   * @return データベース接続
+   * @throws SQLException 接続取得に失敗した場合
+   */
+  public Connection getConnection() throws SQLException {
+    try {
+      Connection connection = dataSource.getConnection();
+      logger.debug("Connection obtained from HikariCP pool");
+      return connection;
+    } catch (SQLException e) {
+      logger.error("Failed to get connection from HikariCP pool: {}", e.getMessage());
+      throw e;
+    }
+  }
+
+  /**
+   * プールの現在の統計情報を取得
+   *
+   * @return 統計情報文字列
+   */
+  public String getPoolStats() {
+    if (dataSource.isClosed()) {
+      return "HikariCP[CLOSED]";
+    }
+
+    return String.format(
+        "HikariCP[active=%d, idle=%d, total=%d, waiting=%d]",
+        dataSource.getHikariPoolMXBean().getActiveConnections(),
+        dataSource.getHikariPoolMXBean().getIdleConnections(),
+        dataSource.getHikariPoolMXBean().getTotalConnections(),
+        dataSource.getHikariPoolMXBean().getThreadsAwaitingConnection());
+  }
+
+  /**
+   * プールの詳細統計情報を取得
+   *
+   * @return 詳細統計情報文字列
+   */
+  public String getDetailedStats() {
+    if (dataSource.isClosed()) {
+      return "HikariCP[CLOSED]";
+    }
+
+    var mxBean = dataSource.getHikariPoolMXBean();
+    return String.format(
+        "HikariCP Details[active=%d, idle=%d, total=%d, waiting=%d, url=%s]",
+        mxBean.getActiveConnections(),
+        mxBean.getIdleConnections(),
+        mxBean.getTotalConnections(),
+        mxBean.getThreadsAwaitingConnection(),
+        databaseUrl);
+  }
+
+  /**
+   * プールがクローズ済みかどうかを確認
+   *
+   * @return クローズ済みの場合true
+   */
+  public boolean isClosed() {
+    return dataSource.isClosed();
+  }
+
+  /** プールをシャットダウンし、全ての接続をクローズ */
+  @Override
+  public void close() {
+    if (!dataSource.isClosed()) {
+      logger.info("Shutting down HikariCP connection pool");
+      dataSource.close();
+      logger.info("HikariCP connection pool shutdown completed");
+    }
+  }
+
+  /**
+   * DatabaseConnectionPoolとの互換性のためのメソッド
+   *
+   * @deprecated {@link #close()} を使用してください
+   */
+  @Deprecated
+  public void shutdown() {
+    close();
+  }
+}

--- a/src/main/java/com/streamConverter/command/rule/PooledDatabaseFetchRule.java
+++ b/src/main/java/com/streamConverter/command/rule/PooledDatabaseFetchRule.java
@@ -11,16 +11,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * コネクションプール対応のデータベースフェッチルール
+ * HikariCP対応のデータベースフェッチルール
  *
- * <p>DatabaseFetchRuleの高性能版です。DatabaseConnectionPoolを使用して接続の再利用により
- * パフォーマンスを大幅に向上させます。特に大量のデータ処理や高頻度のデータベースアクセスが 必要な場合に効果的です。
+ * <p>DatabaseFetchRuleの高性能版です。HikariCPを使用して接続の再利用により パフォーマンスを大幅に向上させます。特に大量のデータ処理や高頻度のデータベースアクセスが
+ * 必要な場合に効果的です。
  *
  * <p>使用例:
  *
  * <pre>{@code
- * // コネクションプールを作成
- * DatabaseConnectionPool pool = new DatabaseConnectionPool("jdbc:h2:mem:testdb", 10, 30000);
+ * // HikariCP接続プールを作成
+ * HikariConnectionPoolConfig pool = new HikariConnectionPoolConfig("jdbc:h2:mem:testdb", 10, Duration.ofSeconds(30));
  *
  * // プール対応ルールを作成
  * PooledDatabaseFetchRule rule = new PooledDatabaseFetchRule(
@@ -34,16 +34,16 @@ import org.slf4j.LoggerFactory;
  * }
  *
  * // 使用後はプールをシャットダウン
- * pool.shutdown();
+ * pool.close();
  * }</pre>
  *
  * <p>DatabaseFetchRuleとの違い:
  *
  * <ul>
- *   <li>接続プール使用によりパフォーマンス大幅向上
- *   <li>リソース使用量の最適化
+ *   <li>業界標準HikariCP使用によりパフォーマンス大幅向上
+ *   <li>接続リーク検出と自動回復
  *   <li>複数スレッドからの同時アクセス対応
- *   <li>接続の自動検証と回復
+ *   <li>詳細なプールメトリクス
  * </ul>
  */
 public class PooledDatabaseFetchRule implements IRule {
@@ -55,18 +55,18 @@ public class PooledDatabaseFetchRule implements IRule {
           "(?i).*(union|insert|update|delete|drop|create|alter|exec|execute|sp_|xp_).*",
           Pattern.CASE_INSENSITIVE);
 
-  private final DatabaseConnectionPool connectionPool;
+  private final HikariConnectionPoolConfig connectionPool;
   private final String query;
 
   /**
    * コンストラクタ
    *
-   * @param connectionPool データベース接続プール
+   * @param connectionPool HikariCP接続プール
    * @param query データベースクエリ（SELECTクエリのみ許可）
    * @throws IllegalArgumentException 無効なパラメータが指定された場合
    * @throws SecurityException セキュリティ違反が検出された場合
    */
-  public PooledDatabaseFetchRule(DatabaseConnectionPool connectionPool, String query) {
+  public PooledDatabaseFetchRule(HikariConnectionPoolConfig connectionPool, String query) {
     Objects.requireNonNull(connectionPool, "Connection pool cannot be null");
     Objects.requireNonNull(query, "Query cannot be null");
 
@@ -76,7 +76,7 @@ public class PooledDatabaseFetchRule implements IRule {
     logger.info(
         "PooledDatabaseFetchRule initialized - Query length: {}, Pool: {}",
         this.query.length(),
-        connectionPool.getPoolStats());
+        connectionPool.getDetailedStats());
   }
 
   /**

--- a/src/test/java/com/streamConverter/command/rule/PooledDatabaseFetchRuleIntegrationTest.java
+++ b/src/test/java/com/streamConverter/command/rule/PooledDatabaseFetchRuleIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -19,14 +20,14 @@ import org.junit.jupiter.api.Test;
 /**
  * PooledDatabaseFetchRuleの統合テスト
  *
- * <p>H2インメモリデータベースとコネクションプールを使用してPooledDatabaseFetchRuleの パフォーマンスと並行処理能力をテストします。
+ * <p>H2インメモリデータベースとHikariCP接続プールを使用してPooledDatabaseFetchRuleの パフォーマンスと並行処理能力をテストします。
  */
 public class PooledDatabaseFetchRuleIntegrationTest {
 
   private static final String DB_URL_BASE = "jdbc:h2:mem:pooltest";
   private String dbUrl;
   private Connection connection;
-  private DatabaseConnectionPool connectionPool;
+  private HikariConnectionPoolConfig connectionPool;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -51,14 +52,14 @@ public class PooledDatabaseFetchRuleIntegrationTest {
       }
     }
 
-    // コネクションプールを初期化
-    connectionPool = new DatabaseConnectionPool(dbUrl, 5, 30000);
+    // HikariCP接続プールを初期化
+    connectionPool = new HikariConnectionPoolConfig(dbUrl, 5, Duration.ofSeconds(30));
   }
 
   @AfterEach
   public void tearDown() throws Exception {
     if (connectionPool != null) {
-      connectionPool.shutdown();
+      connectionPool.close();
     }
     if (connection != null && !connection.isClosed()) {
       connection.close();
@@ -88,10 +89,10 @@ public class PooledDatabaseFetchRuleIntegrationTest {
         new PooledDatabaseFetchRule(connectionPool, "SELECT name FROM users WHERE id = ?");
 
     String stats = rule.getPoolStats();
-    assertTrue(stats.contains("ConnectionPool"));
+    assertTrue(stats.contains("HikariCP"));
     assertTrue(stats.contains("active="));
-    assertTrue(stats.contains("pooled="));
-    assertTrue(stats.contains("max=5"));
+    assertTrue(stats.contains("idle="));
+    assertTrue(stats.contains("total="));
   }
 
   @Test
@@ -168,7 +169,8 @@ public class PooledDatabaseFetchRuleIntegrationTest {
   @DisplayName("プール枯渇時の動作テスト")
   public void testPoolExhaustion() throws InterruptedException {
     // 小さなプールを作成（最大2接続）
-    DatabaseConnectionPool smallPool = new DatabaseConnectionPool(dbUrl, 2, 1000);
+    HikariConnectionPoolConfig smallPool =
+        new HikariConnectionPoolConfig(dbUrl, 2, Duration.ofSeconds(1));
 
     try {
       PooledDatabaseFetchRule rule =
@@ -199,7 +201,7 @@ public class PooledDatabaseFetchRuleIntegrationTest {
 
       executor.shutdown();
     } finally {
-      smallPool.shutdown();
+      smallPool.close();
     }
   }
 
@@ -252,7 +254,8 @@ public class PooledDatabaseFetchRuleIntegrationTest {
   @Test
   @DisplayName("プールシャットダウン後の動作テスト")
   public void testPoolShutdownBehavior() {
-    DatabaseConnectionPool testPool = new DatabaseConnectionPool(dbUrl, 3, 5000);
+    HikariConnectionPoolConfig testPool =
+        new HikariConnectionPoolConfig(dbUrl, 3, Duration.ofSeconds(5));
 
     PooledDatabaseFetchRule rule =
         new PooledDatabaseFetchRule(testPool, "SELECT data FROM performance_test WHERE id = ?");
@@ -262,7 +265,7 @@ public class PooledDatabaseFetchRuleIntegrationTest {
     assertEquals("Data 1", result);
 
     // プールをシャットダウン
-    testPool.shutdown();
+    testPool.close();
 
     // シャットダウン後はエラーになることを確認
     result = rule.apply("2");


### PR DESCRIPTION
## Summary
- Replace custom DatabaseConnectionPool with industry-standard HikariCP for better performance and reliability
- Upgrade PiTest plugin to resolve deprecation warnings
- Add comprehensive connection pool configuration with leak detection and metrics

## Changes Made
• **HikariCP Migration**
  - Created new `HikariConnectionPoolConfig` class with industry-standard connection pooling
  - Updated `PooledDatabaseFetchRule` to use HikariCP instead of custom connection pool
  - Added HikariCP dependency (6.2.1) to build configuration
  - Migrated all integration tests to work with new HikariCP configuration

• **PiTest Plugin Upgrade** 
  - Upgraded from version 1.15.0 to 1.19.0-rc.1
  - Resolved `ReportingExtension.getBaseDir()` deprecation warning
  - Maintained full compatibility with existing PiTest configuration

## Benefits
- **Performance**: Industry-standard connection pooling with optimized performance
- **Reliability**: Automatic connection leak detection and recovery mechanisms  
- **Monitoring**: Detailed pool metrics and statistics for better observability
- **Thread Safety**: Enhanced concurrent access handling
- **Standards Compliance**: Eliminates deprecated API usage warnings

## Test Results
- ✅ All existing integration tests pass with HikariCP
- ✅ Connection pool statistics and monitoring work correctly
- ✅ Concurrent access tests validate thread-safety improvements
- ✅ Pool exhaustion scenarios handled gracefully
- ✅ PiTest deprecation warnings resolved

Closes #152, #84

🤖 Generated with [Claude Code](https://claude.ai/code)