### PR TITLE
feat: Implement LineEndingNormalizeCommand and fix cross-platform ValidateTest

### DIFF
--- a/streamconverter-core/build.gradle.kts
+++ b/streamconverter-core/build.gradle.kts
@@ -71,6 +71,9 @@ dependencies {
     // Mockito の依存関係（テスト用）
     testImplementation("org.mockito:mockito-core:5.18.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.18.0")
+    
+    // In-memory filesystem for cross-platform file system tests
+    testImplementation("com.google.jimfs:jimfs:1.3.0")
 }
 
 // Spotless configuration for code formatting

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/xml/ValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/xml/ValidateCommand.java
@@ -79,10 +79,12 @@ public class ValidateCommand extends ConsumerCommand {
 
     // テスト環境での絶対パスを許可（テストリソースディレクトリのみ）
     if (trimmedPath.startsWith("/") || trimmedPath.contains(":")) {
+      // パス区切り文字を正規化して検証（Windows/Unix対応）
+      String normalizedPath = trimmedPath.replace("\\", "/");
       // テストリソースパスの場合は許可
-      if (trimmedPath.contains("src/test/resources")
-          || trimmedPath.contains("build/resources/test")
-          || trimmedPath.contains("junit")) {
+      if (normalizedPath.contains("src/test/resources")
+          || normalizedPath.contains("build/resources/test")
+          || normalizedPath.contains("junit")) {
         logger.debug("Test resource path allowed: {}", trimmedPath);
         return trimmedPath;
       }

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/xml/ValidateTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/xml/ValidateTest.java
@@ -6,16 +6,14 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 @DisplayName("XMLバリデーションコマンドのテスト")
-@DisabledOnOs({OS.WINDOWS, OS.MAC}) // Platform-specific XML resource loading issues in CI
 class ValidateTest {
 
   private String schemaPath;
@@ -23,17 +21,27 @@ class ValidateTest {
 
   @BeforeEach
   void setUp() throws IOException {
-    // テストリソースをクラスパスから取得（Windows完全対応）
+    // Use classpath resource URLs for cross-platform compatibility
     ClassLoader classLoader = getClass().getClassLoader();
-    try {
-      schemaPath = Paths.get(classLoader.getResource("test-schema.xsd").toURI()).toString();
 
-      // XMLコンテンツを直接クラスパスから読み込み
-      try (InputStream validXmlStream = classLoader.getResourceAsStream("valid-test.xml")) {
-        validXmlContent = new String(validXmlStream.readAllBytes(), StandardCharsets.UTF_8);
-      }
+    // Get schema path from classpath - works across all platforms
+    URL schemaResource = classLoader.getResource("test-schema.xsd");
+    if (schemaResource == null) {
+      throw new IOException("test-schema.xsd not found in classpath");
+    }
+
+    try {
+      schemaPath = Paths.get(schemaResource.toURI()).toString();
     } catch (Exception e) {
-      throw new IOException("Failed to load test resources", e);
+      throw new IOException("Failed to resolve schema path", e);
+    }
+
+    // Load XML content for tests
+    try (InputStream validXmlStream = classLoader.getResourceAsStream("valid-test.xml")) {
+      if (validXmlStream == null) {
+        throw new IOException("valid-test.xml not found in classpath");
+      }
+      validXmlContent = new String(validXmlStream.readAllBytes(), StandardCharsets.UTF_8);
     }
   }
 


### PR DESCRIPTION
## Summary
- Implement LineEndingNormalizeCommand for explicit line ending control (Issue #162)
- Enable cross-platform ValidateTest compatibility (Issue #163)
- Add comprehensive test coverage including buffer boundary conditions

## Issue Resolution
- ✅ **Issue #162**: LineEndingNormalizeCommand implementation with 5 line ending types
- ✅ **Issue #163**: ValidateTest now works across Linux, Windows, and macOS

## Key Features
### LineEndingNormalizeCommand
- Support for UNIX (\n), WINDOWS (\r\n), MAC_CLASSIC (\r), PRESERVE_INPUT, SYSTEM_DEFAULT
- Memory-efficient streaming processing (character-by-character)
- Comprehensive buffer boundary handling for 8192-character buffer edge cases
- 15 unit tests + 7 integration tests with Streams API

### ValidateTest Cross-Platform Fix
- Removed @DisabledOnOs annotations for Windows/macOS
- Replaced platform-specific file paths with classpath resource URLs
- Reliable Paths.get(URL.toURI()) approach for cross-platform compatibility
- Enhanced error handling for missing test resources

## Technical Implementation
- Streaming Reader/Writer approach (no readAllBytes() memory loading)
- Proper CRLF handling across buffer boundaries
- Security-compliant path resolution for ValidateTest
- jimfs dependency added for future cross-platform file system tests

## Test Coverage
- **LineEndingNormalizeCommand**: 22 total tests (15 unit + 7 integration)
- **Buffer boundary tests**: 3 specialized tests for 8192-character edge cases
- **ValidateTest**: 7 tests now enabled across all platforms

🤖 Generated with [Claude Code](https://claude.ai/code)