### PR TITLE
fix: Replace MathieuSoysal with peaceiris for Javadoc deployment

### DIFF
--- a/.github/workflows/release-javadoc.yml
+++ b/.github/workflows/release-javadoc.yml
@@ -31,11 +31,7 @@ jobs:
         run: ./gradlew javadocAll --no-daemon
         
       - name: Deploy JavaDoc 🚀
-        uses: MathieuSoysal/Javadoc-publisher.yml@v3.0.2
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          javadoc-branch: gh-pages
-          java-version: 17
-          target-folder: /
-          project: gradle
-          javadoc-source-folder: build/docs/javadoc
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/docs/javadoc


### PR DESCRIPTION
## Problem

The merged PR #193 included workflow changes, but the GitHub Actions is still using MathieuSoysal/Javadoc-publisher.yml which:
- Runs fixed `gradle javadoc` command instead of our `javadocAll` task
- Results in NO-SOURCE error because default javadoc task has no sources
- Fails to deploy the unified Javadoc we created

## Solution

Replace MathieuSoysal/Javadoc-publisher.yml with peaceiris/actions-gh-pages:
- ✅ Direct control over Gradle task execution (`./gradlew javadocAll`)
- ✅ Simple deployment from `build/docs/javadoc` to gh-pages branch
- ✅ No complex configuration required

## Expected Result

After this PR merges, the next push to develop will:
1. Execute `./gradlew javadocAll` to generate unified Javadoc
2. Deploy the generated docs to GitHub Pages successfully
3. Resolve the failing Javadoc workflow issue