### PR TITLE
docs: fix example links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,12 @@ for (CommandResult result : results) {
 
 詳細な使用例は以下のサンプルコードを参照してください：
 
-- **[QuickStart.java](streamconverter-examples/src/main/java/com/streamConverter/QuickStart.java)** - 基本的な使用方法
-- **[AutoLoggingDemo.java](streamconverter-examples/src/main/java/com/streamConverter/AutoLoggingDemo.java)** - ログ機能のデモ
-- **[ContextPropagationDemo.java](streamconverter-examples/src/main/java/com/streamConverter/ContextPropagationDemo.java)** - コンテキスト伝播のデモ
-- **[MDCMultiThreadExample.java](streamconverter-examples/src/main/java/com/streamConverter/MDCMultiThreadExample.java)** - MDCマルチスレッド検証
-- **[DataProcessingExamples.java](streamconverter-examples/src/main/java/com/streamConverter/DataProcessingExamples.java)** - 実用的な処理例
-- **[EnterpriseIntegrationPatterns.java](streamconverter-examples/src/main/java/com/streamConverter/EnterpriseIntegrationPatterns.java)** - エンタープライズパターン
+- **[QuickStart.java](examples/streamconverter-examples/src/main/java/com/streamConverter/QuickStart.java)** - 基本的な使用方法
+- **[AutoLoggingDemo.java](examples/streamconverter-examples/src/main/java/com/streamConverter/AutoLoggingDemo.java)** - ログ機能のデモ
+- **[ContextPropagationDemo.java](examples/streamconverter-examples/src/main/java/com/streamConverter/ContextPropagationDemo.java)** - コンテキスト伝播のデモ
+- **[MDCMultiThreadExample.java](examples/streamconverter-examples/src/main/java/com/streamConverter/MDCMultiThreadExample.java)** - MDCマルチスレッド検証
+- **[DataProcessingExamples.java](examples/streamconverter-examples/src/main/java/com/streamConverter/DataProcessingExamples.java)** - 実用的な処理例
+- **[EnterpriseIntegrationPatterns.java](examples/streamconverter-examples/src/main/java/com/streamConverter/EnterpriseIntegrationPatterns.java)** - エンタープライズパターン
 
 ## 🛠️ ビルドとテスト
 


### PR DESCRIPTION
## Summary
- prefix example paths with `examples/` in usage section

## Testing
- `./gradlew test` *(fails: 361 tests completed, 1 failed, 6 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b64a95ffd88325bb181c299535e263