### PR TITLE
docs: replace command architecture link

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ for (CommandResult result : results) {
 
 - **[📚 ドキュメント一覧](docs/)** - 全ドキュメントのインデックス
 - **[🏗️ システムアーキテクチャ](docs/ARCHITECTURE.md)** - StreamConverter全体アーキテクチャと設計原則
-- **[🔧 コマンドアーキテクチャ](docs/COMMAND_ARCHITECTURE.md)** - コマンドパターンと拡張方法
+- **[🔧 コマンドアーキテクチャ](docs/ARCHITECTURE.md)** - コマンドパターンと拡張方法（旧ドキュメント: [`docs/archived/COMMAND_ARCHITECTURE.md`](docs/archived/COMMAND_ARCHITECTURE.md)）
 - **[📝 自動ログ機能](docs/AUTO_LOGGING.md)** - ログ機能の詳細と設定
 - **[🔗 コンテキスト伝播](docs/reports/CONTEXT_PROPAGATION_ARCHITECTURE.md)** - マルチスレッド環境でのMDC管理
 - **[🔢 バージョン管理](docs/VERSION_MANAGEMENT.md)** - サポートバージョンとポリシー
@@ -185,7 +185,7 @@ open build/docs/javadoc/index.html
 
 - **[テスト戦略とガイド](docs/TESTING.md)** - 包括的なテスト実行方法とベンチマーク
 - **[システムアーキテクチャ](docs/ARCHITECTURE.md)** - StreamConverter全体の設計思想と4層アーキテクチャ
-- **[コマンドアーキテクチャ](docs/COMMAND_ARCHITECTURE.md)** - コマンドパターンとController層の設計
+- **[コマンドアーキテクチャ](docs/ARCHITECTURE.md)** - コマンドパターンとController層の設計（旧ドキュメント: [`docs/archived/COMMAND_ARCHITECTURE.md`](docs/archived/COMMAND_ARCHITECTURE.md)）
 - **[セキュリティ分析](docs/SECURITY_ANALYSIS.md)** - セキュリティ対策と脆弱性分析
 - **[ベンチマーク実装](docs/BENCHMARK_IMPLEMENTATION.md)** - 大容量データ処理のパフォーマンス測定
 - **[自動ログ機能](docs/AUTO_LOGGING.md)** - MDCとコンテキスト伝播の詳細


### PR DESCRIPTION
## Summary
- update README to reference `docs/ARCHITECTURE.md` instead of removed `COMMAND_ARCHITECTURE.md`
- note archived location of the old command architecture document

## Testing
- `./gradlew test` *(fails: There were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b659676d0c8325904f1280154604de