### PR TITLE
docs: update ConvertCommand usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ for (CommandResult result : results) {
 | | `xml.XmlNavigateCommand` | XML 特定要素の変換 | `new XmlNavigateCommand("//item/@id")` |
 | | `CharacterConvertCommand` | 文字エンコーディング変換 | `new CharacterConvertCommand("UTF-8", "Shift_JIS")` |
 | | `LineEndingNormalizeCommand` | 改行コード正規化 | `new LineEndingNormalizeCommand(LineEndingType.UNIX)` |
-| | `xml.ConvertCommand` | XSLT 変換 | `new ConvertCommand("style.xsl")` |
+| | `xml.ConvertCommand` | XSLT 変換 | `new ConvertCommand(rule, "style.xsl")` |
 | **フィルタリング** | `csv.CsvFilterCommand` | CSV 行フィルタリング | `new CsvFilterCommand("columnName", true)` |
 | | `json.JsonFilterCommand` | JSON 要素フィルタリング | `new JsonFilterCommand("$.path")` |
 | | `xml.XmlFilterCommand` | XML 要素フィルタリング | `new XmlFilterCommand("//element/path")` |


### PR DESCRIPTION
## Summary
- clarify xml.ConvertCommand usage to accept both a rule and XPath in README command table

## Testing
- `./gradlew test` *(fails: NoRouteToHostException in SendHttpCommandTest)*

------
https://chatgpt.com/codex/tasks/task_e_68b6987691fc83259cd674b8e440595b