### PR TITLE
docs: clarify XmlNavigateCommand example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ for (CommandResult result : results) {
 |----------|----------|------|--------|
 | **データ変換** | `csv.CsvNavigateCommand` | CSV 特定列の変換 | `new CsvNavigateCommand("name")` |
 | | `json.JsonNavigateCommand` | JSON 特定パスの変換 | `new JsonNavigateCommand("$.user.id")` |
-| | `xml.XmlNavigateCommand` | XML 特定要素の変換 | `new XmlNavigateCommand("//item/@id")` |
+| | `xml.XmlNavigateCommand` | XML 特定要素の変換（IRule 必須） | `new XmlNavigateCommand(new XPath("//item/@id"), rule)` |
 | | `CharacterConvertCommand` | 文字エンコーディング変換 | `new CharacterConvertCommand("UTF-8", "Shift_JIS")` |
 | | `LineEndingNormalizeCommand` | 改行コード正規化 | `new LineEndingNormalizeCommand(LineEndingType.UNIX)` |
 | | `xml.ConvertCommand` | XSLT 変換 | `new ConvertCommand(rule, "style.xsl")` |


### PR DESCRIPTION
## Summary
- document that `XmlNavigateCommand` requires an `IRule`
- update usage example to show `new XPath()` argument

## Testing
- `./gradlew test` *(fails: 361 tests completed, 1 failed, 6 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b69e23a7b48325a96fb768ef62816f