### PR TITLE
Stop logging passed tests in Gradle builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ tasks.register<Test>("benchmarkLargeData") {
     jvmArgs("-Xmx3g", "-Xms1g")
     
     testLogging {
-        events("passed", "skipped", "failed")
+        events("skipped", "failed")
         showStandardStreams = true
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     }
@@ -103,7 +103,7 @@ tasks.register<Test>("benchmarkInfrastructure") {
     jvmArgs("-Xmx1g", "-Xms512m")
     
     testLogging {
-        events("passed", "skipped", "failed")
+        events("skipped", "failed")
         showStandardStreams = true
     }
 }
@@ -114,7 +114,7 @@ tasks.register<Test>("benchmarkMemoryEfficiency") {
     useJUnitPlatform()
     include("**/MemoryEfficiencyTest*")
     testLogging {
-        events("passed", "skipped", "failed")
+        events("skipped", "failed")
         showStandardStreams = true
     }
     // Increase heap size for memory efficiency tests
@@ -127,7 +127,7 @@ tasks.register<Test>("benchmarkAll") {
     useJUnitPlatform()
     include("**/benchmark/**/*Test*", "**/MemoryEfficiencyTest*")
     testLogging {
-        events("passed", "skipped", "failed")
+        events("skipped", "failed")
         showStandardStreams = true
     }
     // Increase heap size for all benchmarks
@@ -248,7 +248,7 @@ tasks.test {
     
     // テスト実行時の詳細ログを表示
     testLogging {
-        events("passed", "skipped", "failed")
+        events("skipped", "failed")
         showStandardStreams = true
     }
     

--- a/streamconverter-core/build.gradle.kts
+++ b/streamconverter-core/build.gradle.kts
@@ -114,7 +114,7 @@ tasks.test {
     
     // テスト実行時の詳細ログを表示
     testLogging {
-        events("passed", "skipped", "failed")
+        events("skipped", "failed")
         showStandardStreams = true
     }
     

--- a/streamconverter-examples/build.gradle.kts
+++ b/streamconverter-examples/build.gradle.kts
@@ -108,7 +108,7 @@ tasks.test {
     useJUnitPlatform()
     
     testLogging {
-        events("passed", "skipped", "failed")
+        events("skipped", "failed")
         showStandardStreams = true
     }
 }

--- a/streamconverter-tools/build.gradle.kts
+++ b/streamconverter-tools/build.gradle.kts
@@ -59,7 +59,7 @@ tasks.register<Test>("benchmarkLargeData") {
     jvmArgs("-Xmx3g", "-Xms1g")
     
     testLogging {
-        events("passed", "skipped", "failed")
+        events("skipped", "failed")
         showStandardStreams = true
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     }
@@ -74,7 +74,7 @@ tasks.register<Test>("benchmarkInfrastructure") {
     jvmArgs("-Xmx1g", "-Xms512m")
     
     testLogging {
-        events("passed", "skipped", "failed")
+        events("skipped", "failed")
         showStandardStreams = true
     }
 }
@@ -85,7 +85,7 @@ tasks.register<Test>("benchmarkMemoryEfficiency") {
     useJUnitPlatform()
     include("**/MemoryEfficiencyTest*")
     testLogging {
-        events("passed", "skipped", "failed")
+        events("skipped", "failed")
         showStandardStreams = true
     }
     // Increase heap size for memory efficiency tests
@@ -98,7 +98,7 @@ tasks.register<Test>("benchmarkAll") {
     useJUnitPlatform()
     include("**/benchmark/**/*Test*", "**/MemoryEfficiencyTest*")
     testLogging {
-        events("passed", "skipped", "failed")
+        events("skipped", "failed")
         showStandardStreams = true
     }
     // Increase heap size for all benchmarks
@@ -129,7 +129,7 @@ tasks.test {
     exclude("**/benchmark/**", "**/*Benchmark*", "**/MemoryEfficiencyTest*")
 
     testLogging {
-        events("passed", "skipped", "failed")
+        events("skipped", "failed")
         showStandardStreams = true
     }
 }


### PR DESCRIPTION
## Summary
- log only skipped or failed test events in root and module build scripts

## Testing
- `./gradlew test`
- `grep -n 'PASSED' /tmp/test.log | head -n 20`
- `grep -n 'SKIPPED' /tmp/test.log | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b6eaebd6e483259f3282d71ce543a6