### PR TITLE
Update package names to 'com.streamconverter'

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,7 +97,7 @@ spotless {
 }
 
 application {
-    mainClass.set(project.findProperty("mainClass")?.toString() ?: "com.streamConverter.Main")
+    mainClass.set(project.findProperty("mainClass")?.toString() ?: "com.streamconverter.Main")
 }
 
 java {
@@ -154,15 +154,15 @@ tasks.jacocoTestReport {
 
 // PITレポートの設定
 tasks.pitest {
-    targetClasses.set(listOf("com.streamConverter.*")) // テスト対象のクラスを指定
+    targetClasses.set(listOf("com.streamconverter.*")) // テスト対象のクラスを指定
     outputFormats.set(listOf("HTML")) // 出力形式を指定
     // タイムアウト設定を追加
     timeoutConstInMillis.set(10000) // 10秒でタイムアウト
     timeoutFactor.set(BigDecimal("1.5")) // 1.5倍のマージン
     // 対象クラスを絞り込んでパフォーマンスを向上
     excludedClasses.set(listOf(
-        "com.streamConverter.examples.*", // サンプルコードを除外
-        "com.streamConverter.demo.*"      // デモコードを除外
+        "com.streamconverter.examples.*", // サンプルコードを除外
+        "com.streamconverter.demo.*"      // デモコードを除外
     ))
     // テスト後にレポートを生成
     // dependsOn(tasks.test)
@@ -244,7 +244,7 @@ tasks.named("check") {
 
 // Root project configuration for multi-module build
 allprojects {
-    group = "com.streamConverter"
+    group = "com.streamconverter"
     version = "1.2.0"
 
     tasks.withType<Test>().configureEach {

--- a/streamconverter-core/build.gradle.kts
+++ b/streamconverter-core/build.gradle.kts
@@ -142,15 +142,15 @@ tasks.jacocoTestReport {
 
 // PITレポートの設定
 tasks.pitest {
-    targetClasses.set(listOf("com.streamConverter.*")) // テスト対象のクラスを指定
+    targetClasses.set(listOf("com.streamconverter.*")) // テスト対象のクラスを指定
     outputFormats.set(listOf("HTML")) // 出力形式を指定
     // タイムアウト設定を追加
     timeoutConstInMillis.set(10000) // 10秒でタイムアウト
     timeoutFactor.set(BigDecimal("1.5")) // 1.5倍のマージン
     // 対象クラスを絞り込んでパフォーマンスを向上
     excludedClasses.set(listOf(
-        "com.streamConverter.examples.*", // サンプルコードを除外
-        "com.streamConverter.demo.*"      // デモコードを除外
+        "com.streamconverter.examples.*", // サンプルコードを除外
+        "com.streamconverter.demo.*"      // デモコードを除外
     ))
 }
 
@@ -228,7 +228,7 @@ tasks.register("convertPmdReport", JavaExec::class) {
     
     dependsOn(tasks.compileJava, tasks.pmdMain)
     classpath = sourceSets.main.get().runtimeClasspath
-    mainClass.set("com.streamConverter.analysis.PmdReportConverter")
+    mainClass.set("com.streamconverter.analysis.PmdReportConverter")
     
     // PMD XMLレポートのパスを引数として渡す
     args("build/reports/pmd/main.xml", "build/reports/pmd/converted")
@@ -250,8 +250,8 @@ tasks.register("analyzeTestFailures", JavaExec::class) {
     
     dependsOn(tasks.compileJava)
     classpath = sourceSets.main.get().runtimeClasspath
-    mainClass.set("com.streamConverter.test.TestFailureAnalyzer")
-    
+    mainClass.set("com.streamconverter.test.TestFailureAnalyzer")
+
     // テスト結果ディレクトリをパラメータとして渡す
     args("build/test-results/test")
     
@@ -268,8 +268,8 @@ tasks.register("testPmdConverter", JavaExec::class) {
     
     dependsOn(tasks.compileJava, tasks.pmdMain)
     classpath = sourceSets.main.get().runtimeClasspath
-    mainClass.set("com.streamConverter.test.PmdConverterTest")
-    
+    mainClass.set("com.streamconverter.test.PmdConverterTest")
+
     // PMD実行後にのみ実行されるよう条件付きで設定
     onlyIf {
         file("build/reports/pmd/main.xml").exists()

--- a/streamconverter-core/src/main/java/com/streamConverter/CommandResult.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/CommandResult.java
@@ -1,4 +1,4 @@
-package com.streamConverter;
+package com.streamconverter;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/streamconverter-core/src/main/java/com/streamConverter/Main.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/Main.java
@@ -1,7 +1,7 @@
-package com.streamConverter;
+package com.streamconverter;
 
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-core/src/main/java/com/streamConverter/StreamConverter.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/StreamConverter.java
@@ -1,7 +1,7 @@
-package com.streamConverter;
+package com.streamconverter;
 
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.context.ExecutionContext;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.context.ExecutionContext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/StreamProcessingException.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/StreamProcessingException.java
@@ -1,4 +1,4 @@
-package com.streamConverter;
+package com.streamconverter;
 
 /**
  * Custom exception for stream processing errors.

--- a/streamconverter-core/src/main/java/com/streamConverter/command/AbstractStreamCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/AbstractStreamCommand.java
@@ -1,7 +1,7 @@
-package com.streamConverter.command;
+package com.streamconverter.command;
 
-import com.streamConverter.util.MeasuredInputStream;
-import com.streamConverter.util.MeasuredOutputStream;
+import com.streamconverter.util.MeasuredInputStream;
+import com.streamconverter.util.MeasuredOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/CommandConfig.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/CommandConfig.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command;
+package com.streamconverter.command;
 
 /**
  * コマンド設定クラス

--- a/streamconverter-core/src/main/java/com/streamConverter/command/ConsumerCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/ConsumerCommand.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command;
+package com.streamconverter.command;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/ContextPropagatingDecorator.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/ContextPropagatingDecorator.java
@@ -1,6 +1,6 @@
-package com.streamConverter.command;
+package com.streamconverter.command;
 
-import com.streamConverter.context.ExecutionContext;
+import com.streamconverter.context.ExecutionContext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/IStreamCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/IStreamCommand.java
@@ -1,6 +1,6 @@
-package com.streamConverter.command;
+package com.streamconverter.command;
 
-import com.streamConverter.context.ExecutionContext;
+import com.streamconverter.context.ExecutionContext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/LoggingDecorator.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/LoggingDecorator.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command;
+package com.streamconverter.command;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/LineEndingNormalizeCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/LineEndingNormalizeCommand.java
@@ -1,6 +1,6 @@
-package com.streamConverter.command.impl;
+package com.streamconverter.command.impl;
 
-import com.streamConverter.command.AbstractStreamCommand;
+import com.streamconverter.command.AbstractStreamCommand;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/SampleStreamCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/SampleStreamCommand.java
@@ -1,6 +1,6 @@
-package com.streamConverter.command.impl;
+package com.streamconverter.command.impl;
 
-import com.streamConverter.command.AbstractStreamCommand;
+import com.streamconverter.command.AbstractStreamCommand;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/SendHttpCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/SendHttpCommand.java
@@ -10,10 +10,10 @@
  *
  * <p>レスポンスを受信してOutputStreamに書き込むことができます。
  */
-package com.streamConverter.command.impl;
+package com.streamconverter.command.impl;
 
 import com.google.common.net.InetAddresses;
-import com.streamConverter.command.AbstractStreamCommand;
+import com.streamconverter.command.AbstractStreamCommand;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/charcode/CharacterConvertCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/charcode/CharacterConvertCommand.java
@@ -1,6 +1,6 @@
-package com.streamConverter.command.impl.charcode;
+package com.streamconverter.command.impl.charcode;
 
-import com.streamConverter.command.AbstractStreamCommand;
+import com.streamconverter.command.AbstractStreamCommand;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/csv/CsvFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/csv/CsvFilterCommand.java
@@ -1,7 +1,7 @@
-package com.streamConverter.command.impl.csv;
+package com.streamconverter.command.impl.csv;
 
-import com.streamConverter.command.AbstractStreamCommand;
-import com.streamConverter.path.CSVPath;
+import com.streamconverter.command.AbstractStreamCommand;
+import com.streamconverter.path.CSVPath;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/csv/CsvNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/csv/CsvNavigateCommand.java
@@ -1,9 +1,9 @@
-package com.streamConverter.command.impl.csv;
+package com.streamconverter.command.impl.csv;
 
-import com.streamConverter.command.AbstractStreamCommand;
-import com.streamConverter.command.rule.IRule;
-import com.streamConverter.path.CSVPath;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.command.AbstractStreamCommand;
+import com.streamconverter.command.rule.IRule;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/csv/CsvValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/csv/CsvValidateCommand.java
@@ -1,9 +1,9 @@
-package com.streamConverter.command.impl.csv;
+package com.streamconverter.command.impl.csv;
 
 import com.opencsv.CSVReader;
 import com.opencsv.exceptions.CsvException;
-import com.streamConverter.StreamProcessingException;
-import com.streamConverter.command.ConsumerCommand;
+import com.streamconverter.StreamProcessingException;
+import com.streamconverter.command.ConsumerCommand;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/json/JsonFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/json/JsonFilterCommand.java
@@ -1,9 +1,9 @@
-package com.streamConverter.command.impl.json;
+package com.streamconverter.command.impl.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.streamConverter.command.AbstractStreamCommand;
-import com.streamConverter.path.IPath;
+import com.streamconverter.command.AbstractStreamCommand;
+import com.streamconverter.path.IPath;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/json/JsonNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/json/JsonNavigateCommand.java
@@ -1,13 +1,13 @@
-package com.streamConverter.command.impl.json;
+package com.streamconverter.command.impl.json;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.streamConverter.command.AbstractStreamCommand;
-import com.streamConverter.command.rule.IRule;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.command.AbstractStreamCommand;
+import com.streamconverter.command.rule.IRule;
+import com.streamconverter.path.TreePath;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/json/JsonStreamingValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/json/JsonStreamingValidateCommand.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.impl.json;
+package com.streamconverter.command.impl.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -6,8 +6,8 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
-import com.streamConverter.StreamProcessingException;
-import com.streamConverter.command.ConsumerCommand;
+import com.streamconverter.StreamProcessingException;
+import com.streamconverter.command.ConsumerCommand;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/json/JsonValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/json/JsonValidateCommand.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.impl.json;
+package com.streamconverter.command.impl.json;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -7,8 +7,8 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
-import com.streamConverter.StreamProcessingException;
-import com.streamConverter.command.ConsumerCommand;
+import com.streamconverter.StreamProcessingException;
+import com.streamconverter.command.ConsumerCommand;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/xml/ConvertCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/xml/ConvertCommand.java
@@ -1,9 +1,9 @@
-package com.streamConverter.command.impl.xml;
+package com.streamconverter.command.impl.xml;
 
-import com.streamConverter.StreamProcessingException;
-import com.streamConverter.command.AbstractStreamCommand;
-import com.streamConverter.command.rule.IRule;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.StreamProcessingException;
+import com.streamconverter.command.AbstractStreamCommand;
+import com.streamconverter.command.rule.IRule;
+import com.streamconverter.path.TreePath;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/xml/ValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/xml/ValidateCommand.java
@@ -1,9 +1,9 @@
-package com.streamConverter.command.impl.xml;
+package com.streamconverter.command.impl.xml;
 
-import com.streamConverter.StreamProcessingException;
-import com.streamConverter.command.ConsumerCommand;
-import com.streamConverter.config.SecurityConfigurationManager;
-import com.streamConverter.security.SecureXmlConfiguration;
+import com.streamconverter.StreamProcessingException;
+import com.streamconverter.command.ConsumerCommand;
+import com.streamconverter.config.SecurityConfigurationManager;
+import com.streamconverter.security.SecureXmlConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/xml/XmlFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/xml/XmlFilterCommand.java
@@ -1,7 +1,7 @@
-package com.streamConverter.command.impl.xml;
+package com.streamconverter.command.impl.xml;
 
-import com.streamConverter.command.AbstractStreamCommand;
-import com.streamConverter.path.IPath;
+import com.streamconverter.command.AbstractStreamCommand;
+import com.streamconverter.path.IPath;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/xml/XmlNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/xml/XmlNavigateCommand.java
@@ -1,8 +1,8 @@
-package com.streamConverter.command.impl.xml;
+package com.streamconverter.command.impl.xml;
 
-import com.streamConverter.command.AbstractStreamCommand;
-import com.streamConverter.command.rule.IRule;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.command.AbstractStreamCommand;
+import com.streamconverter.command.rule.IRule;
+import com.streamconverter.path.TreePath;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/rule/DatabaseConnectionPool.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/rule/DatabaseConnectionPool.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.rule;
+package com.streamconverter.command.rule;
 
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/rule/DatabaseFetchRule.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/rule/DatabaseFetchRule.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.rule;
+package com.streamconverter.command.rule;
 
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/rule/HikariConnectionPoolConfig.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/rule/HikariConnectionPoolConfig.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.rule;
+package com.streamconverter.command.rule;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/rule/IRule.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/rule/IRule.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.rule;
+package com.streamconverter.command.rule;
 
 /**
  * ルールインターフェース

--- a/streamconverter-core/src/main/java/com/streamConverter/command/rule/PassThroughRule.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/rule/PassThroughRule.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.rule;
+package com.streamconverter.command.rule;
 
 /**
  * Pass-through rule implementation

--- a/streamconverter-core/src/main/java/com/streamConverter/command/rule/PooledDatabaseFetchRule.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/rule/PooledDatabaseFetchRule.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.rule;
+package com.streamconverter.command.rule;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/rule/impl/casing/CamelToSnakeCaseRule.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/rule/impl/casing/CamelToSnakeCaseRule.java
@@ -1,6 +1,6 @@
-package com.streamConverter.command.rule.impl.casing;
+package com.streamconverter.command.rule.impl.casing;
 
-import com.streamConverter.command.rule.IRule;
+import com.streamconverter.command.rule.IRule;
 
 /**
  * Transforms camelCase strings to snake_case format.

--- a/streamconverter-core/src/main/java/com/streamConverter/command/rule/impl/casing/SnakeToCamelCaseRule.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/rule/impl/casing/SnakeToCamelCaseRule.java
@@ -1,6 +1,6 @@
-package com.streamConverter.command.rule.impl.casing;
+package com.streamconverter.command.rule.impl.casing;
 
-import com.streamConverter.command.rule.IRule;
+import com.streamconverter.command.rule.IRule;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/streamconverter-core/src/main/java/com/streamConverter/command/rule/impl/composite/ChainRule.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/rule/impl/composite/ChainRule.java
@@ -1,6 +1,6 @@
-package com.streamConverter.command.rule.impl.composite;
+package com.streamconverter.command.rule.impl.composite;
 
-import com.streamConverter.command.rule.IRule;
+import com.streamconverter.command.rule.IRule;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/streamconverter-core/src/main/java/com/streamConverter/command/rule/impl/string/LowerCaseRule.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/rule/impl/string/LowerCaseRule.java
@@ -1,6 +1,6 @@
-package com.streamConverter.command.rule.impl.string;
+package com.streamconverter.command.rule.impl.string;
 
-import com.streamConverter.command.rule.IRule;
+import com.streamconverter.command.rule.IRule;
 import java.util.Locale;
 
 /**

--- a/streamconverter-core/src/main/java/com/streamConverter/command/rule/impl/string/TrimRule.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/rule/impl/string/TrimRule.java
@@ -1,6 +1,6 @@
-package com.streamConverter.command.rule.impl.string;
+package com.streamconverter.command.rule.impl.string;
 
-import com.streamConverter.command.rule.IRule;
+import com.streamconverter.command.rule.IRule;
 
 /**
  * Trims leading and trailing whitespace from strings.

--- a/streamconverter-core/src/main/java/com/streamConverter/config/SecurityConfigurationManager.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/config/SecurityConfigurationManager.java
@@ -1,4 +1,4 @@
-package com.streamConverter.config;
+package com.streamconverter.config;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/context/ExecutionContext.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/context/ExecutionContext.java
@@ -1,4 +1,4 @@
-package com.streamConverter.context;
+package com.streamconverter.context;
 
 import java.time.Instant;
 import java.util.Collections;

--- a/streamconverter-core/src/main/java/com/streamConverter/controller/AbstractStreamController.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/controller/AbstractStreamController.java
@@ -1,9 +1,9 @@
-package com.streamConverter.controller;
+package com.streamconverter.controller;
 
-import com.streamConverter.CommandResult;
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.CommandConfig;
-import com.streamConverter.command.IStreamCommand;
+import com.streamconverter.CommandResult;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.CommandConfig;
+import com.streamconverter.command.IStreamCommand;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/controller/CsvProcessingController.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/controller/CsvProcessingController.java
@@ -1,8 +1,8 @@
-package com.streamConverter.controller;
+package com.streamconverter.controller;
 
-import com.streamConverter.command.CommandConfig;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.CommandConfig;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
 
 /**
  * Controller for CSV data processing operations.

--- a/streamconverter-core/src/main/java/com/streamConverter/controller/IStreamController.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/controller/IStreamController.java
@@ -1,6 +1,6 @@
-package com.streamConverter.controller;
+package com.streamconverter.controller;
 
-import com.streamConverter.CommandResult;
+import com.streamconverter.CommandResult;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/controller/JsonProcessingController.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/controller/JsonProcessingController.java
@@ -1,9 +1,9 @@
-package com.streamConverter.controller;
+package com.streamconverter.controller;
 
-import com.streamConverter.command.CommandConfig;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
-import com.streamConverter.command.impl.json.JsonValidateCommand;
+import com.streamconverter.command.CommandConfig;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.json.JsonValidateCommand;
 
 /**
  * Controller for JSON data processing operations.

--- a/streamconverter-core/src/main/java/com/streamConverter/path/AbstractPath.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/path/AbstractPath.java
@@ -1,4 +1,4 @@
-package com.streamConverter.path;
+package com.streamconverter.path;
 
 /**
  * 最小限のPath基底クラス

--- a/streamconverter-core/src/main/java/com/streamConverter/path/CSVPath.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/path/CSVPath.java
@@ -1,4 +1,4 @@
-package com.streamConverter.path;
+package com.streamconverter.path;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/streamconverter-core/src/main/java/com/streamConverter/path/IPath.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/path/IPath.java
@@ -1,4 +1,4 @@
-package com.streamConverter.path;
+package com.streamconverter.path;
 
 /**
  * 最小限のPathインターフェース

--- a/streamconverter-core/src/main/java/com/streamConverter/path/TreePath.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/path/TreePath.java
@@ -1,4 +1,4 @@
-package com.streamConverter.path;
+package com.streamconverter.path;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/streamconverter-core/src/main/java/com/streamConverter/security/SecureXPathValidator.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/security/SecureXPathValidator.java
@@ -1,6 +1,6 @@
-package com.streamConverter.security;
+package com.streamconverter.security;
 
-import com.streamConverter.config.SecurityConfigurationManager;
+import com.streamconverter.config.SecurityConfigurationManager;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/streamconverter-core/src/main/java/com/streamConverter/security/SecureXmlConfiguration.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/security/SecureXmlConfiguration.java
@@ -1,6 +1,6 @@
-package com.streamConverter.security;
+package com.streamconverter.security;
 
-import com.streamConverter.config.SecurityConfigurationManager;
+import com.streamconverter.config.SecurityConfigurationManager;
 import java.io.InputStream;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;

--- a/streamconverter-core/src/main/java/com/streamConverter/tools/PmdAutoFixer.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/tools/PmdAutoFixer.java
@@ -1,4 +1,4 @@
-package com.streamConverter.tools;
+package com.streamconverter.tools;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/streamconverter-core/src/main/java/com/streamConverter/util/MeasuredInputStream.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/util/MeasuredInputStream.java
@@ -1,4 +1,4 @@
-package com.streamConverter.util;
+package com.streamconverter.util;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/util/MeasuredOutputStream.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/util/MeasuredOutputStream.java
@@ -1,4 +1,4 @@
-package com.streamConverter.util;
+package com.streamconverter.util;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/streamconverter-core/src/main/java/com/streamConverter/validation/ValidationResult.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/validation/ValidationResult.java
@@ -1,4 +1,4 @@
-package com.streamConverter.validation;
+package com.streamconverter.validation;
 
 import java.time.Instant;
 import java.util.ArrayList;

--- a/streamconverter-core/src/test/java/com/streamConverter/StreamConverterIntegrationTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/StreamConverterIntegrationTest.java
@@ -1,9 +1,9 @@
-package com.streamConverter;
+package com.streamconverter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.SendHttpCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.SendHttpCommand;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-core/src/test/java/com/streamConverter/StreamConverterMDCIntegrationTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/StreamConverterMDCIntegrationTest.java
@@ -1,10 +1,10 @@
-package com.streamConverter;
+package com.streamconverter;
 
-import static com.streamConverter.test.TestUtils.createTestData;
+import static com.streamconverter.test.TestUtils.createTestData;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.context.ExecutionContext;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.context.ExecutionContext;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-core/src/test/java/com/streamConverter/StreamConverterTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/StreamConverterTest.java
@@ -1,9 +1,9 @@
-package com.streamConverter;
+package com.streamconverter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-core/src/test/java/com/streamConverter/StreamProcessingExceptionTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/StreamProcessingExceptionTest.java
@@ -1,4 +1,4 @@
-package com.streamConverter;
+package com.streamconverter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/AbstractStreamCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/AbstractStreamCommandTest.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command;
+package com.streamconverter.command;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/FilterCommandBasicTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/FilterCommandBasicTest.java
@@ -1,15 +1,15 @@
-package com.streamConverter.command.impl;
+package com.streamconverter.command.impl;
 
-import static com.streamConverter.test.TestUtils.createTestData;
+import static com.streamconverter.test.TestUtils.createTestData;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.command.impl.csv.CsvFilterCommand;
-import com.streamConverter.command.impl.json.JsonFilterCommand;
-import com.streamConverter.command.impl.xml.XmlFilterCommand;
-import com.streamConverter.path.CSVPath;
-import com.streamConverter.path.TreePath;
-import com.streamConverter.test.StreamingTestUtils.MonitoringOutputStream;
-import com.streamConverter.test.StreamingTestUtils.TrackingInputStream;
+import com.streamconverter.command.impl.csv.CsvFilterCommand;
+import com.streamconverter.command.impl.json.JsonFilterCommand;
+import com.streamconverter.command.impl.xml.XmlFilterCommand;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
+import com.streamconverter.test.StreamingTestUtils.MonitoringOutputStream;
+import com.streamconverter.test.StreamingTestUtils.TrackingInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/LineEndingNormalizeCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/LineEndingNormalizeCommandTest.java
@@ -1,10 +1,10 @@
-package com.streamConverter.command.impl;
+package com.streamconverter.command.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.command.impl.LineEndingNormalizeCommand.LineEndingType;
-import com.streamConverter.test.StreamingTestUtils.MonitoringOutputStream;
-import com.streamConverter.test.StreamingTestUtils.TrackingInputStream;
+import com.streamconverter.command.impl.LineEndingNormalizeCommand.LineEndingType;
+import com.streamconverter.test.StreamingTestUtils.MonitoringOutputStream;
+import com.streamconverter.test.StreamingTestUtils.TrackingInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/SampleStreamCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/SampleStreamCommandTest.java
@@ -1,9 +1,9 @@
-package com.streamConverter.command.impl;
+package com.streamconverter.command.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.test.StreamingTestUtils.MonitoringOutputStream;
-import com.streamConverter.test.StreamingTestUtils.TrackingInputStream;
+import com.streamconverter.test.StreamingTestUtils.MonitoringOutputStream;
+import com.streamconverter.test.StreamingTestUtils.TrackingInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/SendHttpCommandSecurityTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/SendHttpCommandSecurityTest.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.impl;
+package com.streamconverter.command.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/SendHttpCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/SendHttpCommandTest.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.impl;
+package com.streamconverter.command.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/charcode/ConvertTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/charcode/ConvertTest.java
@@ -1,9 +1,9 @@
-package com.streamConverter.command.impl.charcode;
+package com.streamconverter.command.impl.charcode;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.test.StreamingTestUtils.MonitoringOutputStream;
-import com.streamConverter.test.StreamingTestUtils.TrackingInputStream;
+import com.streamconverter.test.StreamingTestUtils.MonitoringOutputStream;
+import com.streamconverter.test.StreamingTestUtils.TrackingInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/csv/CsvNavigateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/csv/CsvNavigateCommandTest.java
@@ -1,14 +1,14 @@
-package com.streamConverter.command.impl.csv;
+package com.streamconverter.command.impl.csv;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.CSVPath;
-import com.streamConverter.test.StreamingTestUtils.MonitoringOutputStream;
-import com.streamConverter.test.StreamingTestUtils.TrackingInputStream;
-import com.streamConverter.test.TestUtils;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.test.StreamingTestUtils.MonitoringOutputStream;
+import com.streamconverter.test.StreamingTestUtils.TrackingInputStream;
+import com.streamconverter.test.TestUtils;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/csv/CsvValidateCommandTest.java
@@ -1,9 +1,9 @@
-package com.streamConverter.command.impl.csv;
+package com.streamconverter.command.impl.csv;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.StreamProcessingException;
-import com.streamConverter.test.StreamingTestUtils.TrackingInputStream;
+import com.streamconverter.StreamProcessingException;
+import com.streamconverter.test.StreamingTestUtils.TrackingInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/json/JsonNavigateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/json/JsonNavigateCommandTest.java
@@ -1,13 +1,13 @@
-package com.streamConverter.command.impl.json;
+package com.streamconverter.command.impl.json;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.TreePath;
-import com.streamConverter.test.StreamingTestUtils.MonitoringOutputStream;
-import com.streamConverter.test.StreamingTestUtils.TrackingInputStream;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.TreePath;
+import com.streamconverter.test.StreamingTestUtils.MonitoringOutputStream;
+import com.streamconverter.test.StreamingTestUtils.TrackingInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/json/JsonValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/json/JsonValidateCommandTest.java
@@ -1,9 +1,9 @@
-package com.streamConverter.command.impl.json;
+package com.streamconverter.command.impl.json;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.StreamProcessingException;
-import com.streamConverter.test.StreamingTestUtils.TrackingInputStream;
+import com.streamconverter.StreamProcessingException;
+import com.streamconverter.test.StreamingTestUtils.TrackingInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/xml/ConvertCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/xml/ConvertCommandTest.java
@@ -1,11 +1,11 @@
-package com.streamConverter.command.impl.xml;
+package com.streamconverter.command.impl.xml;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.command.rule.TestRule;
-import com.streamConverter.path.TreePath;
-import com.streamConverter.test.StreamingTestUtils.MonitoringOutputStream;
-import com.streamConverter.test.StreamingTestUtils.TrackingInputStream;
+import com.streamconverter.command.rule.TestRule;
+import com.streamconverter.path.TreePath;
+import com.streamconverter.test.StreamingTestUtils.MonitoringOutputStream;
+import com.streamconverter.test.StreamingTestUtils.TrackingInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -124,7 +124,7 @@ public class ConvertCommandTest {
 
     // Should throw StreamProcessingException for invalid XML
     assertThrows(
-        com.streamConverter.StreamProcessingException.class,
+        com.streamconverter.StreamProcessingException.class,
         () -> command.execute(inputStream, outputStream));
   }
 

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/xml/ValidateTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/xml/ValidateTest.java
@@ -1,9 +1,9 @@
-package com.streamConverter.command.impl.xml;
+package com.streamconverter.command.impl.xml;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.test.StreamingTestUtils.MonitoringOutputStream;
-import com.streamConverter.test.StreamingTestUtils.TrackingInputStream;
+import com.streamconverter.test.StreamingTestUtils.MonitoringOutputStream;
+import com.streamconverter.test.StreamingTestUtils.TrackingInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -89,7 +89,7 @@ class ValidateTest {
 
       // StreamProcessingExceptionが発生することを期待
       assertThrows(
-          com.streamConverter.StreamProcessingException.class,
+          com.streamconverter.StreamProcessingException.class,
           () -> {
             command.execute(inputStream, outputStream);
           });
@@ -144,7 +144,7 @@ class ValidateTest {
     // 存在しないスキーマファイルでのコンストラクタテスト（セキュリティ強化により、コンストラクタで例外が発生）
     // StreamProcessingExceptionが発生することを期待（存在しないスキーマファイル）
     assertThrows(
-        com.streamConverter.StreamProcessingException.class,
+        com.streamconverter.StreamProcessingException.class,
         () -> {
           new ValidateCommand("non-existent-schema.xsd");
         });
@@ -161,7 +161,7 @@ class ValidateTest {
 
       // StreamProcessingExceptionが発生することを期待（空のXMLは無効）
       assertThrows(
-          com.streamConverter.StreamProcessingException.class,
+          com.streamconverter.StreamProcessingException.class,
           () -> {
             command.execute(inputStream, outputStream);
           });

--- a/streamconverter-core/src/test/java/com/streamConverter/command/impl/xml/XmlNavigateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/impl/xml/XmlNavigateCommandTest.java
@@ -1,11 +1,11 @@
-package com.streamConverter.command.impl.xml;
+package com.streamconverter.command.impl.xml;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/rule/DatabaseFetchRuleIntegrationTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/rule/DatabaseFetchRuleIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.rule;
+package com.streamconverter.command.rule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/rule/DatabaseFetchRuleTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/rule/DatabaseFetchRuleTest.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.rule;
+package com.streamconverter.command.rule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/rule/PooledDatabaseFetchRuleIntegrationTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/rule/PooledDatabaseFetchRuleIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.rule;
+package com.streamconverter.command.rule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/rule/TestRule.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/rule/TestRule.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.rule;
+package com.streamconverter.command.rule;
 
 import java.util.Objects;
 

--- a/streamconverter-core/src/test/java/com/streamConverter/command/rule/impl/TransformationRuleIntegrationTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/rule/impl/TransformationRuleIntegrationTest.java
@@ -1,15 +1,15 @@
-package com.streamConverter.command.rule.impl;
+package com.streamconverter.command.rule.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
-import com.streamConverter.command.rule.impl.casing.CamelToSnakeCaseRule;
-import com.streamConverter.command.rule.impl.casing.SnakeToCamelCaseRule;
-import com.streamConverter.command.rule.impl.composite.ChainRule;
-import com.streamConverter.command.rule.impl.string.LowerCaseRule;
-import com.streamConverter.command.rule.impl.string.TrimRule;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.rule.impl.casing.CamelToSnakeCaseRule;
+import com.streamconverter.command.rule.impl.casing.SnakeToCamelCaseRule;
+import com.streamconverter.command.rule.impl.composite.ChainRule;
+import com.streamconverter.command.rule.impl.string.LowerCaseRule;
+import com.streamconverter.command.rule.impl.string.TrimRule;
+import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;

--- a/streamconverter-core/src/test/java/com/streamConverter/command/rule/impl/casing/CamelToSnakeCaseRuleTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/rule/impl/casing/CamelToSnakeCaseRuleTest.java
@@ -1,4 +1,4 @@
-package com.streamConverter.command.rule.impl.casing;
+package com.streamconverter.command.rule.impl.casing;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/streamconverter-core/src/test/java/com/streamConverter/command/rule/impl/composite/ChainRuleTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/command/rule/impl/composite/ChainRuleTest.java
@@ -1,11 +1,11 @@
-package com.streamConverter.command.rule.impl.composite;
+package com.streamconverter.command.rule.impl.composite;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.command.rule.IRule;
-import com.streamConverter.command.rule.impl.casing.CamelToSnakeCaseRule;
-import com.streamConverter.command.rule.impl.string.LowerCaseRule;
-import com.streamConverter.command.rule.impl.string.TrimRule;
+import com.streamconverter.command.rule.IRule;
+import com.streamconverter.command.rule.impl.casing.CamelToSnakeCaseRule;
+import com.streamconverter.command.rule.impl.string.LowerCaseRule;
+import com.streamconverter.command.rule.impl.string.TrimRule;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 

--- a/streamconverter-core/src/test/java/com/streamConverter/config/SecurityConfigurationManagerTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/config/SecurityConfigurationManagerTest.java
@@ -1,4 +1,4 @@
-package com.streamConverter.config;
+package com.streamconverter.config;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/streamconverter-core/src/test/java/com/streamConverter/context/ExecutionContextTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/context/ExecutionContextTest.java
@@ -1,4 +1,4 @@
-package com.streamConverter.context;
+package com.streamconverter.context;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/streamconverter-core/src/test/java/com/streamConverter/integration/DatabaseRuleIntegrationTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/integration/DatabaseRuleIntegrationTest.java
@@ -1,12 +1,12 @@
-package com.streamConverter.integration;
+package com.streamconverter.integration;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.command.impl.csv.CsvNavigateCommand;
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
-import com.streamConverter.command.rule.DatabaseFetchRule;
-import com.streamConverter.path.CSVPath;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.rule.DatabaseFetchRule;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-core/src/test/java/com/streamConverter/path/TreePathTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/path/TreePathTest.java
@@ -1,4 +1,4 @@
-package com.streamConverter.path;
+package com.streamconverter.path;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/streamconverter-core/src/test/java/com/streamConverter/security/SecureXPathValidatorTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/security/SecureXPathValidatorTest.java
@@ -1,4 +1,4 @@
-package com.streamConverter.security;
+package com.streamconverter.security;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/streamconverter-core/src/test/java/com/streamConverter/test/CrossPlatformTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/test/CrossPlatformTest.java
@@ -1,6 +1,6 @@
-package com.streamConverter.test;
+package com.streamconverter.test;
 
-import static com.streamConverter.test.TestUtils.*;
+import static com.streamconverter.test.TestUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;

--- a/streamconverter-core/src/test/java/com/streamConverter/test/StreamingTestUtils.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/test/StreamingTestUtils.java
@@ -1,4 +1,4 @@
-package com.streamConverter.test;
+package com.streamconverter.test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/streamconverter-core/src/test/java/com/streamConverter/test/TestFailureAnalyzer.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/test/TestFailureAnalyzer.java
@@ -1,4 +1,4 @@
-package com.streamConverter.test;
+package com.streamconverter.test;
 
 import java.io.File;
 import java.io.IOException;

--- a/streamconverter-core/src/test/java/com/streamConverter/test/TestUtils.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/test/TestUtils.java
@@ -1,4 +1,4 @@
-package com.streamConverter.test;
+package com.streamconverter.test;
 
 import java.util.Arrays;
 

--- a/streamconverter-core/src/test/java/com/streamConverter/validation/ValidationResultTest.java
+++ b/streamconverter-core/src/test/java/com/streamConverter/validation/ValidationResultTest.java
@@ -1,4 +1,4 @@
-package com.streamConverter.validation;
+package com.streamconverter.validation;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/AutoLoggingDemo.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/AutoLoggingDemo.java
@@ -1,14 +1,14 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.LoggingDecorator;
-import com.streamConverter.command.impl.csv.CsvNavigateCommand;
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
-import com.streamConverter.command.impl.xml.XmlNavigateCommand;
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.CSVPath;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.LoggingDecorator;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/ComplexPipelineExample.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/ComplexPipelineExample.java
@@ -1,9 +1,9 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.csv.CsvValidateCommand;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.csv.CsvValidateCommand;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/ComplexXmlProcessingPipeline.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/ComplexXmlProcessingPipeline.java
@@ -1,12 +1,12 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.SendHttpCommand;
-import com.streamConverter.command.impl.xml.XmlNavigateCommand;
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.SendHttpCommand;
+import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/ContextPropagationDemo.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/ContextPropagationDemo.java
@@ -1,9 +1,9 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.context.ExecutionContext;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.context.ExecutionContext;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/DataProcessingExamples.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/DataProcessingExamples.java
@@ -1,14 +1,14 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.csv.CsvNavigateCommand;
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
-import com.streamConverter.command.impl.xml.XmlNavigateCommand;
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.CSVPath;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/DatabaseRuleDemo.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/DatabaseRuleDemo.java
@@ -1,12 +1,12 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.csv.CsvNavigateCommand;
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
-import com.streamConverter.command.rule.DatabaseFetchRule;
-import com.streamConverter.path.CSVPath;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.rule.DatabaseFetchRule;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.sql.Connection;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/DirectApiDemo.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/DirectApiDemo.java
@@ -1,14 +1,14 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.CommandResult;
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.csv.CsvNavigateCommand;
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
-import com.streamConverter.command.impl.xml.XmlNavigateCommand;
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.CSVPath;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.CommandResult;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/EnterpriseIntegrationPatterns.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/EnterpriseIntegrationPatterns.java
@@ -1,11 +1,11 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.xml.XmlNavigateCommand;
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/MDCMultiThreadExample.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/MDCMultiThreadExample.java
@@ -1,7 +1,7 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/PerformanceOptimizationExamples.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/PerformanceOptimizationExamples.java
@@ -1,13 +1,13 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.csv.CsvNavigateCommand;
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.CSVPath;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/QuickStart.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/QuickStart.java
@@ -1,14 +1,14 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.csv.CsvNavigateCommand;
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
-import com.streamConverter.command.impl.xml.XmlNavigateCommand;
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.CSVPath;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/SendHttpCommandDemo.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/SendHttpCommandDemo.java
@@ -1,11 +1,11 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SendHttpCommand;
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SendHttpCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/StreamConverterDemo.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/StreamConverterDemo.java
@@ -1,14 +1,14 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.csv.CsvNavigateCommand;
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
-import com.streamConverter.command.impl.xml.XmlNavigateCommand;
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.CSVPath;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/StreamConverterMDCDemo.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/StreamConverterMDCDemo.java
@@ -1,12 +1,12 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.CommandResult;
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.csv.CsvNavigateCommand;
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.context.ExecutionContext;
-import com.streamConverter.path.CSVPath;
+import com.streamconverter.CommandResult;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.context.ExecutionContext;
+import com.streamconverter.path.CSVPath;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/ValidationExample.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/ValidationExample.java
@@ -1,8 +1,8 @@
 package com.streamconverter.examples;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.csv.CsvValidateCommand;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.csv.CsvValidateCommand;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/streamconverter-tools/build.gradle.kts
+++ b/streamconverter-tools/build.gradle.kts
@@ -136,7 +136,7 @@ tasks.test {
 
 // Main class configuration - DatabaseInspector as default
 application {
-    mainClass.set("com.streamConverter.tools.DatabaseInspector")
+    mainClass.set("com.streamconverter.tools.DatabaseInspector")
 }
 
 // spotlessCheck タスクを無効化

--- a/streamconverter-tools/src/main/java/com/streamconverter/benchmark/PerformanceAnalyzer.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/benchmark/PerformanceAnalyzer.java
@@ -1,6 +1,6 @@
 package com.streamconverter.benchmark;
 
-import com.streamConverter.CommandResult;
+import com.streamconverter.CommandResult;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Instant;

--- a/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToCsvCommand.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToCsvCommand.java
@@ -2,7 +2,7 @@ package com.streamconverter.command.impl.analysis;
 
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import com.streamConverter.command.AbstractStreamCommand;
+import com.streamconverter.command.AbstractStreamCommand;
 import com.streamconverter.command.impl.analysis.PmdXmlToMarkdownCommand.PmdViolation;
 import java.io.IOException;
 import java.io.InputStream;

--- a/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToJsonCommand.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToJsonCommand.java
@@ -2,7 +2,7 @@ package com.streamconverter.command.impl.analysis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.streamConverter.command.AbstractStreamCommand;
+import com.streamconverter.command.AbstractStreamCommand;
 import com.streamconverter.command.impl.analysis.PmdXmlToMarkdownCommand.PmdViolation;
 import java.io.IOException;
 import java.io.InputStream;

--- a/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToMarkdownCommand.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToMarkdownCommand.java
@@ -1,6 +1,6 @@
 package com.streamconverter.command.impl.analysis;
 
-import com.streamConverter.command.AbstractStreamCommand;
+import com.streamconverter.command.AbstractStreamCommand;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/streamconverter-tools/src/main/java/com/streamconverter/controller/PmdAnalysisController.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/controller/PmdAnalysisController.java
@@ -1,7 +1,6 @@
 package com.streamconverter.controller;
 
-import com.streamConverter.command.CommandConfig;
-import com.streamConverter.controller.AbstractStreamController;
+import com.streamconverter.command.CommandConfig;
 import com.streamconverter.command.impl.analysis.PmdXmlToCsvCommand;
 import com.streamconverter.command.impl.analysis.PmdXmlToJsonCommand;
 import com.streamconverter.command.impl.analysis.PmdXmlToMarkdownCommand;

--- a/streamconverter-tools/src/test/java/com/streamconverter/MemoryEfficiencyTest.java
+++ b/streamconverter-tools/src/test/java/com/streamconverter/MemoryEfficiencyTest.java
@@ -2,11 +2,9 @@ package com.streamconverter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.CommandResult;
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
 import com.streamconverter.benchmark.LargeDataGenerator;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
 import java.io.*;
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/streamconverter-tools/src/test/java/com/streamconverter/benchmark/BenchmarkInfrastructureTest.java
+++ b/streamconverter-tools/src/test/java/com/streamconverter/benchmark/BenchmarkInfrastructureTest.java
@@ -2,9 +2,9 @@ package com.streamconverter.benchmark;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.*;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
+import com.streamconverter.*;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
 import java.io.*;
 import java.util.List;
 import org.junit.jupiter.api.*;

--- a/streamconverter-tools/src/test/java/com/streamconverter/benchmark/LargeDataBenchmark.java
+++ b/streamconverter-tools/src/test/java/com/streamconverter/benchmark/LargeDataBenchmark.java
@@ -2,16 +2,16 @@ package com.streamconverter.benchmark;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.*;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.charcode.CharacterConvertCommand;
-import com.streamConverter.command.impl.csv.CsvNavigateCommand;
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
-import com.streamConverter.command.impl.xml.XmlNavigateCommand;
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.CSVPath;
-import com.streamConverter.path.TreePath;
+import com.streamconverter.*;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.charcode.CharacterConvertCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
 import com.streamconverter.test.PlatformAdaptiveTestUtils;
 import java.io.*;
 import java.nio.file.Files;

--- a/streamconverter-tools/src/test/java/com/streamconverter/benchmark/MemoryEfficiencyQuickTest.java
+++ b/streamconverter-tools/src/test/java/com/streamconverter/benchmark/MemoryEfficiencyQuickTest.java
@@ -1,8 +1,8 @@
 package com.streamconverter.benchmark;
 
-import com.streamConverter.*;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.charcode.CharacterConvertCommand;
+import com.streamconverter.*;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.charcode.CharacterConvertCommand;
 import java.io.*;
 import java.util.*;
 import org.junit.jupiter.api.*;

--- a/streamconverter-tools/src/test/java/com/streamconverter/benchmark/QuickSmokeTest.java
+++ b/streamconverter-tools/src/test/java/com/streamconverter/benchmark/QuickSmokeTest.java
@@ -2,9 +2,9 @@ package com.streamconverter.benchmark;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamConverter.*;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
+import com.streamconverter.*;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.*;

--- a/streamconverter-tools/src/test/java/com/streamconverter/test/PmdConverterTest.java
+++ b/streamconverter-tools/src/test/java/com/streamconverter/test/PmdConverterTest.java
@@ -1,6 +1,6 @@
 package com.streamconverter.test;
 
-import com.streamConverter.CommandResult;
+import com.streamconverter.CommandResult;
 import com.streamconverter.controller.PmdAnalysisController;
 import java.io.*;
 import java.nio.file.Files;

--- a/streamconverter-web/src/main/java/com/streamconverter/web/StreamProcessingController.java
+++ b/streamconverter-web/src/main/java/com/streamconverter/web/StreamProcessingController.java
@@ -1,14 +1,5 @@
 package com.streamconverter.web;
 
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.IStreamCommand;
-import com.streamConverter.command.impl.SampleStreamCommand;
-import com.streamConverter.command.impl.csv.CsvNavigateCommand;
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
-import com.streamConverter.command.rule.PassThroughRule;
-import com.streamConverter.path.CSVPath;
-import com.streamConverter.path.TreePath;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -21,6 +12,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.SampleStreamCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 


### PR DESCRIPTION
Changed all package declarations from 'com.streamConverter' to 'com.streamconverter' across core, examples, and tools modules for consistency and to resolve potential import issues.
closed #295 
<!-- GitHub Copilot コードレビューへの指示： このプルリクエストをレビューしてコメントする際は日本語で行うこと -->