### PR TITLE
fix(core): enforce UTF-8 in JsonNavigateCommand error output

### DIFF
--- a/streamconverter-core/src/main/java/com/streamConverter/command/impl/json/JsonNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamConverter/command/impl/json/JsonNavigateCommand.java
@@ -11,6 +11,7 @@ import com.streamconverter.path.TreePath;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -164,7 +165,7 @@ public class JsonNavigateCommand extends AbstractStreamCommand {
   /** Handle JSON parsing exceptions */
   private void handleJsonParseException(OutputStream outputStream, Exception e) throws IOException {
     String errorMessage = String.format("JSON parsing error: %s", e.getMessage());
-    outputStream.write(errorMessage.getBytes());
+    outputStream.write(errorMessage.getBytes(StandardCharsets.UTF_8));
     outputStream.flush();
   }
 }


### PR DESCRIPTION
Summary: Fixes default-encoding usage in JsonNavigateCommand error handling to avoid DM_DEFAULT_ENCODING without using suppressions.\n\nChanges:\n- Use String#getBytes(StandardCharsets.UTF_8) for error message output bytes.\n- No behavior change beyond consistent UTF-8 bytes for error messages.\n\nRationale:\n- Aligns with encoding guidelines and the "no suppression" policy for static analysis issues.\n\nValidation:\n- Build passes across modules: ./gradlew build -x benchmarkAll\n- SpotBugs: Test-time warnings persist but do not fail build (ignoreFailures=true).\n- PMD: Violations reported as warnings per current configuration.\n\nImpact:\n- Affects only core JsonNavigateCommand error path. No API changes; examples and web unaffected.\n\nChecklist:\n- [x] No suppressions added\n- [x] Spotless/PMD/SpotBugs executed by build\n- [x] UTF-8 enforced on error output

Closes #293