### PR TITLE
docs: add handbook with what/why/how pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 Welcome to the StreamConverter documentation. This project provides efficient stream processing with a simplified, direct instantiation architecture.
 
+See the [handbook](handbook/README.md) for concise What / Why / How guides.
+
 ## 🚀 Quick Start
 
 ### Basic Usage
@@ -25,10 +27,10 @@ StreamConverter converter = new StreamConverter(new IStreamCommand[]{loggedComma
 ## 📚 Documentation Structure
 
 ### Core Documentation
-- **[ARCHITECTURE.md](ARCHITECTURE.md)** - Current simplified architecture
+- **[handbook/architecture.md](handbook/architecture.md)** - Architecture overview (What/Why/How)
 - **[ARCHITECTURE_DIAGRAMS.md](ARCHITECTURE_DIAGRAMS.md)** - Visual diagrams and class relationships
-- **[WEB_API.md](WEB_API.md)** - REST API documentation
-- **[AUTO_LOGGING.md](AUTO_LOGGING.md)** - Logging capabilities and usage
+- **[handbook/web-api.md](handbook/web-api.md)** - REST API documentation (What/Why/How)
+- **[handbook/logging.md](handbook/logging.md)** - Logging capabilities (What/Why/How)
 
 ### Development Guides
 - **[guides/PRE_COMMIT_SETUP.md](guides/PRE_COMMIT_SETUP.md)** - Setting up development environment

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -1,0 +1,18 @@
+# StreamConverter Handbook
+
+Welcome to the StreamConverter handbook. This guide provides an overview of the project through concise **What / Why / How** pages.
+
+## Table of Contents
+
+### Core Concepts
+- [Architecture](architecture.md) – how the pipeline is structured
+
+### Features
+- [Logging](logging.md) – built‑in auto‑logging support
+
+### Integrations
+- [Web API](web-api.md) – exposing StreamConverter over HTTP
+
+---
+
+Looking for more? See the [documentation index](../README.md).

--- a/docs/handbook/architecture.md
+++ b/docs/handbook/architecture.md
@@ -1,0 +1,19 @@
+# Architecture
+
+## What
+The StreamConverter architecture uses direct command instantiation. Commands are chained in a pipeline and executed by the `StreamConverter` core.
+
+## Why
+This approach removes factory complexity, avoids reflection overhead and keeps dependencies explicit. It results in a simpler and more performant system.
+
+## How
+1. Create commands with their required parameters.
+2. Combine them into an array and pass it to `StreamConverter`.
+3. Optionally wrap commands with the logging decorator for diagnostics.
+
+## See also
+- [Logging](logging.md)
+- [Web API](web-api.md)
+- [Handbook index](README.md)
+
+For full details, refer to the [original architecture document](../ARCHITECTURE.md).

--- a/docs/handbook/logging.md
+++ b/docs/handbook/logging.md
@@ -1,0 +1,19 @@
+# Logging
+
+## What
+StreamConverter provides an auto‑logging system for monitoring command execution and performance.
+
+## Why
+Detailed logs help troubleshoot large stream operations and give insight into timing, memory use and errors.
+
+## How
+1. Wrap any command in a `LoggingDecorator` to enable logs.
+2. Use `CommandFactory.createWithLogging` for automatic decorator application.
+3. Configure log levels through `CommandConfig` or logging frameworks.
+
+## See also
+- [Architecture](architecture.md)
+- [Web API](web-api.md)
+- [Handbook index](README.md)
+
+More examples are available in the [original auto‑logging guide](../AUTO_LOGGING.md).

--- a/docs/handbook/web-api.md
+++ b/docs/handbook/web-api.md
@@ -1,0 +1,19 @@
+# Web API
+
+## What
+The Web API exposes StreamConverter capabilities over HTTP using Spring Boot.
+
+## Why
+It allows remote systems to process streams without embedding the library, enabling integration with other services.
+
+## How
+1. Start the server with `./gradlew bootRun`.
+2. Use endpoints such as `/api/v1/stream/csv/extract` or `/api/v1/stream/json/extract`.
+3. Chain multiple commands by supplying an `X-Pipeline-Config` header.
+
+## See also
+- [Architecture](architecture.md)
+- [Logging](logging.md)
+- [Handbook index](README.md)
+
+Further endpoint examples are in the [original Web API guide](../WEB_API.md).


### PR DESCRIPTION
## Summary
- add a handbook directory with top-level index
- reorganize architecture, logging, and web API docs into What/Why/How pages
- link pages together and update the main docs index

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68bd5e5739688325a05c506168c1f48c