### PR TITLE
fix: tighten monitoring access and update docs

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -95,7 +95,7 @@ http {
 
             # Restrict access to monitoring tools
             allow 127.0.0.1;
-            allow 172.16.0.0/12;  # Docker networks
+            allow 172.18.0.0/16;  # Replace with your actual Docker network subnet
             deny all;
         }
 

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -10,7 +10,8 @@ scrape_configs:
   # StreamConverter application metrics
   - job_name: 'streamconverter'
     static_configs:
-      - targets: ['streamconverter-web:8080']
+      # Use environment variables or Docker Compose interpolation to adjust service address
+      - targets: ['${STREAMCONVERTER_SERVICE:-streamconverter-web}:${STREAMCONVERTER_PORT:-8080}']
     metrics_path: '/actuator/prometheus'
     scrape_interval: 30s
     scrape_timeout: 10s

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -206,8 +206,15 @@ docker compose up -d
 # ポート使用状況確認
 netstat -tulpn | grep :8080
 
-# 別ポートで起動
-docker compose up -d -p 8081:8080
+# docker-compose.override.yml でポートを上書き
+cat <<'EOF' > docker-compose.override.yml
+services:
+  streamconverter-web:
+    ports:
+      - "8081:8080"
+EOF
+
+docker compose up -d
 ```
 
 #### データベース接続エラー

--- a/docs/quickstart/basic-usage.md
+++ b/docs/quickstart/basic-usage.md
@@ -12,8 +12,8 @@
 ### 1. シンプルなCSVデータ抽出
 
 ```java
-import com.streamConverter.StreamConverter;
-import com.streamConverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
 
 // CSVファイルから特定の列を抽出
 IStreamCommand[] pipeline = {
@@ -27,7 +27,7 @@ converter.run(inputStream, outputStream);
 ### 2. JSON データの変換
 
 ```java
-import com.streamConverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
 
 // JSONから特定のパスの値を抽出
 IStreamCommand[] pipeline = {
@@ -57,7 +57,7 @@ List<CommandResult> results = converter.run(inputStream, outputStream);
 ### 実行追跡とログ連携
 
 ```java
-import com.streamConverter.context.ExecutionContext;
+import com.streamconverter.context.ExecutionContext;
 
 // 実行コンテキストを作成
 ExecutionContext context = ExecutionContext.builder()
@@ -98,9 +98,9 @@ for (CommandResult result : results) {
 
 ### サンプルコードの場所
 
-- `streamconverter-examples/src/main/java/com/streamConverter/examples/QuickStart.java`
-- `streamconverter-examples/src/main/java/com/streamConverter/examples/AutoLoggingDemo.java`
-- `streamconverter-examples/src/main/java/com/streamConverter/examples/ContextPropagationDemo.java`
+- `streamconverter-examples/src/main/java/com/streamconverter/examples/QuickStart.java`
+- `streamconverter-examples/src/main/java/com/streamconverter/examples/AutoLoggingDemo.java`
+- `streamconverter-examples/src/main/java/com/streamconverter/examples/ContextPropagationDemo.java`
 
 ## 利用可能なコマンド概要
 
@@ -164,7 +164,8 @@ new CharacterConvertCommand("UTF-8", "Shift_JIS")
 **HTTP接続エラー**
 ```java
 // タイムアウト設定付きHTTPコマンド
-new SendHttpCommand("http://api.example.com", 30000) // 30秒タイムアウト
+SendHttpCommand cmd = new SendHttpCommand("http://api.example.com"); // 基本的な使い方
+cmd.setTimeout(30000); // 30秒タイムアウト
 ```
 
 ## サポート


### PR DESCRIPTION
## Summary
- narrow the nginx monitoring allow list to the intended Docker network range and document customization
- make the Prometheus scrape target configurable through environment interpolation
- update quickstart and deployment docs with lowercase packages, corrected paths, and accurate port override instructions

## Testing
- not run (docs/config updates only)

------
https://chatgpt.com/codex/tasks/task_e_68caf6efebfc83258151ab9f7ef10afa