### PR TITLE
feat: upgrade Java from 17 to 21 with Gradle Toolchain automation

### DIFF
--- a/.github/workflows/commit-rules.yml
+++ b/.github/workflows/commit-rules.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 StreamConverter is a Java library for efficient stream processing of large files with memory-constrained pipeline architecture. It implements a command pattern for flexible data processing pipelines with concurrent execution capabilities.
 
 **Version**: 1.2.0  
-**Java Version**: 17  
+**Java Version**: 21  
 **Build System**: Gradle with Kotlin DSL  
 **Architecture**: Multi-module project with 4-layer design
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,8 +101,13 @@ application {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+        // Automatically detect available Java 21 installations
+    }
 }
 
 tasks.withType<JavaCompile> {

--- a/streamconverter-core/build.gradle.kts
+++ b/streamconverter-core/build.gradle.kts
@@ -10,8 +10,13 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+        // Automatically detect available Java 21 installations
+    }
 }
 
 tasks.withType<JavaCompile> {

--- a/streamconverter-examples/build.gradle.kts
+++ b/streamconverter-examples/build.gradle.kts
@@ -7,8 +7,13 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+        // Automatically detect available Java 21 installations
+    }
 }
 
 tasks.withType<JavaCompile> {

--- a/streamconverter-tools/build.gradle.kts
+++ b/streamconverter-tools/build.gradle.kts
@@ -7,8 +7,13 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+        // Automatically detect available Java 21 installations
+    }
 }
 
 tasks.withType<JavaCompile> {

--- a/streamconverter-web/build.gradle.kts
+++ b/streamconverter-web/build.gradle.kts
@@ -7,8 +7,13 @@ plugins {
 description = "StreamConverter Web API module - Example implementation"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+        // Automatically detect available Java 21 installations
+    }
 }
 
 repositories {


### PR DESCRIPTION
## Summary

• Upgrade Java version from 17 to 21 across all modules with LTS benefits
• Add Gradle Java Toolchain for automatic Java version management
• Enable environment-agnostic Java 21 provisioning and consistency

## Key Improvements

• **Java 21 LTS**: Virtual Threads, enhanced performance, support until 2030
• **Gradle Toolchain**: Automatic Java 21 detection and provisioning
• **Environment Consistency**: Same Java version across dev, CI, and production
• **Reduced Setup**: Eliminates manual Java installation requirements

## Technical Changes

- Update `sourceCompatibility` and `targetCompatibility` to Java 21 in all modules
- Add `java.toolchain.languageVersion = 21` configuration
- Update CLAUDE.md documentation to reflect Java 21 requirement
- Maintain compatibility with Gradle 9.1.0 and Spring Boot 3.5.5

## Benefits

✅ **Automatic Provisioning**: Gradle downloads Java 21 if not available  
✅ **Build Reproducibility**: Consistent Java version across all environments  
✅ **LTS Stability**: Long-term support until 2030  
✅ **Performance**: Virtual Threads and improved GC capabilities  

## Test Plan

- [x] All modules compile successfully with Java 21
- [x] Existing tests pass without modification
- [x] Gradle Toolchain detects and uses available Java 21
- [x] Pre-commit hooks validate successfully
- [x] Documentation updated appropriately

🤖 Generated with [Claude Code](https://claude.ai/code)