### PR TITLE
fix: resolve Javadoc deployment failure with Gradle 9.1.0

### DIFF
--- a/.github/workflows/release-javadoc.yml
+++ b/.github/workflows/release-javadoc.yml
@@ -22,13 +22,13 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         
       - name: Generate unified Javadoc
-        run: ./gradlew javadocAll --no-daemon
+        run: ./gradlew javadocAll --no-daemon --no-configuration-cache
         
       - name: Deploy JavaDoc 🚀
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
## Summary

Fixes Javadoc deployment failure caused by Gradle 9.1.0's stricter configuration cache requirements.

## Problem

The Javadoc deployment was failing with:
```
Resolution of the configuration ':streamconverter-examples:compileClasspath' was attempted without an exclusive lock. 
This is unsafe and not allowed.
```

## Solution

• **Update Java version**: Use Java 21 for consistency with main build system
• **Disable configuration cache**: Add `--no-configuration-cache` to resolve Gradle 9.1.0 constraint
• **Fix multi-module classpath resolution**: Avoid concurrent configuration resolution issues

## Test Plan

- [x] Workflow syntax is valid
- [x] Java 21 setup matches main CI configuration
- [x] Configuration cache disabled for javadocAll task
- [ ] Verify Javadoc deployment succeeds after merge

🤖 Generated with [Claude Code](https://claude.ai/code)