### PR TITLE
feat: introduce threading strategy for StreamConverter

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
@@ -63,6 +62,7 @@ public class StreamConverter {
   private static final int DEFAULT_BUFFER_SIZE = 64 * 1024; // 64KB buffer
   private List<IStreamCommand> commands;
   private ExecutionContext defaultContext;
+  private ThreadingStrategy threadingStrategy = ThreadingStrategy.virtualThreadPerTask();
 
   /**
    * Constructs a StreamConverter with the specified array of commands.
@@ -155,14 +155,49 @@ public class StreamConverter {
   }
 
   /**
+   * Creates a StreamConverter with a custom threading strategy and specified commands.
+   *
+   * @param strategy the threading strategy to use for executor creation
+   * @param commands the array of commands to be executed in sequence
+   * @return a new StreamConverter instance with the provided strategy
+   */
+  public static StreamConverter create(ThreadingStrategy strategy, IStreamCommand... commands) {
+    StreamConverter converter = new StreamConverter(commands);
+    converter.threadingStrategy = ThreadingStrategy.requireNonNull(strategy);
+    return converter;
+  }
+
+  /**
+   * Creates a StreamConverter with a custom threading strategy and command list.
+   *
+   * @param strategy the threading strategy to use for executor creation
+   * @param commands the list of commands to be executed in sequence
+   * @return a new StreamConverter instance with the provided strategy
+   */
+  public static StreamConverter create(ThreadingStrategy strategy, List<IStreamCommand> commands) {
+    StreamConverter converter = new StreamConverter(commands);
+    converter.threadingStrategy = ThreadingStrategy.requireNonNull(strategy);
+    return converter;
+  }
+
+  /**
+   * Overrides the threading strategy used for executor creation.
+   *
+   * @param strategy the threading strategy to use
+   * @return the current StreamConverter instance for fluent configuration
+   */
+  public StreamConverter withThreadingStrategy(ThreadingStrategy strategy) {
+    this.threadingStrategy = ThreadingStrategy.requireNonNull(strategy);
+    return this;
+  }
+
+  /**
    * Creates an optimal executor service based on available system resources and command count.
    *
    * @return an optimally configured ExecutorService
    */
   private ExecutorService createOptimalExecutor() {
-    int availableCores = Runtime.getRuntime().availableProcessors();
-    int optimalSize = Math.min(this.commands.size(), Math.max(2, availableCores));
-    return Executors.newFixedThreadPool(optimalSize);
+    return threadingStrategy.createExecutor(this.commands.size());
   }
 
   /**

--- a/streamconverter-core/src/main/java/com/streamconverter/ThreadingStrategy.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/ThreadingStrategy.java
@@ -1,0 +1,75 @@
+package com.streamconverter;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Strategy interface for creating executor services used by {@link StreamConverter}.
+ *
+ * <p>Provides built-in factories for virtual-thread-per-task execution and platform thread pools.
+ */
+@FunctionalInterface
+public interface ThreadingStrategy {
+
+  /**
+   * Creates an executor service tailored for the provided command count.
+   *
+   * @param commandCount number of commands scheduled for execution
+   * @return a newly created executor service
+   */
+  ExecutorService createExecutor(int commandCount);
+
+  /**
+   * Returns a strategy that spins up a new virtual thread for each submitted task.
+   *
+   * <p>Virtual threads dramatically reduce the cost of blocking operations, making them a great fit
+   * for the I/O-heavy work typically performed by StreamConverter commands.
+   *
+   * @return a threading strategy backed by virtual threads
+   */
+  static ThreadingStrategy virtualThreadPerTask() {
+    ThreadFactory factory = Thread.ofVirtual().name("stream-converter-virtual-", 0).factory();
+    return commandCount -> Executors.newThreadPerTaskExecutor(factory);
+  }
+
+  /**
+   * Returns a strategy that uses a fixed-size pool of platform threads sized to the workload.
+   *
+   * @param desiredParallelism preferred level of parallelism; must be positive
+   * @return a platform thread-based strategy capped at the desired parallelism
+   */
+  static ThreadingStrategy platformThreadPool(int desiredParallelism) {
+    if (desiredParallelism <= 0) {
+      throw new IllegalArgumentException("desiredParallelism must be greater than zero");
+    }
+    ThreadFactory factory = Thread.ofPlatform().name("stream-converter-platform-", 0).factory();
+    return commandCount ->
+        Executors.newFixedThreadPool(Math.min(commandCount, desiredParallelism), factory);
+  }
+
+  /**
+   * Returns a platform thread strategy tuned to available processors and command count.
+   *
+   * @return a platform thread pool strategy sized adaptively
+   */
+  static ThreadingStrategy adaptivePlatformThreadPool() {
+    ThreadFactory factory = Thread.ofPlatform().name("stream-converter-platform-", 0).factory();
+    return commandCount -> {
+      int availableCores = Runtime.getRuntime().availableProcessors();
+      int optimalSize = Math.min(commandCount, Math.max(2, availableCores));
+      return Executors.newFixedThreadPool(optimalSize, factory);
+    };
+  }
+
+  /**
+   * Utility to guard against null strategies while offering fluent overrides.
+   *
+   * @param strategy the strategy to validate
+   * @return the provided strategy if it is non-null
+   */
+  static ThreadingStrategy requireNonNull(ThreadingStrategy strategy) {
+    return Objects.requireNonNull(strategy, "threadingStrategy cannot be null");
+  }
+}


### PR DESCRIPTION
## Summary
- add a ThreadingStrategy interface with virtual-thread and platform-thread executors for StreamConverter
- allow StreamConverter to accept custom threading strategies while defaulting to virtual threads

## Testing
- ./gradlew :streamconverter-core:test
- ./gradlew :streamconverter-core:spotlessApply

------
https://chatgpt.com/codex/tasks/task_e_68f9da1acf388325b8451f162b473133