### PR TITLE
Use virtual threads for StreamConverter command execution

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
@@ -14,6 +14,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
@@ -160,9 +161,9 @@ public class StreamConverter {
    * @return an optimally configured ExecutorService
    */
   private ExecutorService createOptimalExecutor() {
-    int availableCores = Runtime.getRuntime().availableProcessors();
-    int optimalSize = Math.min(this.commands.size(), Math.max(2, availableCores));
-    return Executors.newFixedThreadPool(optimalSize);
+    ThreadFactory threadFactory =
+        Thread.ofVirtual().name("stream-converter-", 0).factory();
+    return Executors.newThreadPerTaskExecutor(threadFactory);
   }
 
   /**


### PR DESCRIPTION
## Summary
- replace the StreamConverter executor with a virtual thread per task executor to run commands on virtual threads

## Testing
- ./gradlew :streamconverter-core:test

------
https://chatgpt.com/codex/tasks/task_e_68f9d63265f8832591bb08553c6d2646