### PR TITLE
fix: add factory constructor for JsonValidateCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ for (CommandResult result : results) {
 | | `xml.XmlFilterCommand` | XML 要素フィルタリング | `new XmlFilterCommand("//element/path")` |
 | **通信** | `SendHttpCommand` | HTTP リクエスト | `new SendHttpCommand("http://api.example.com")` |
 | **検証** | `csv.CsvValidateCommand` | CSV 構造検証 | `new CsvValidateCommand(requiredColumns)` |
-| | `json.JsonValidateCommand` | JSON スキーマ検証 | `new JsonValidateCommand("schema.json")` |
+| | `json.JsonValidateCommand` | JSON スキーマ検証 | `JsonValidateCommand.create("schema.json")` |
 | | `json.JsonStreamingValidateCommand` | JSON ストリーミング検証 | `new JsonStreamingValidateCommand("schema.json")` |
 | | `xml.ValidateCommand` | XML スキーマ検証 | `new ValidateCommand("schema.xsd")` |
 

--- a/docs/development/INTEGRATION_EXAMPLES.md
+++ b/docs/development/INTEGRATION_EXAMPLES.md
@@ -196,7 +196,7 @@ public class AdvancedStreamController {
                 // バリデーションコマンドを動的作成
                 IStreamCommand validator = switch (dataType.toLowerCase()) {
                     case "csv" -> new CsvValidateCommand(parseValidationRules(validationRules));
-                    case "json" -> new JsonValidateCommand(validationRules);
+                    case "json" -> JsonValidateCommand.create(validationRules);
                     case "xml" -> new ValidateCommand(validationRules);
                     default -> throw new IllegalArgumentException("Unsupported data type: " + dataType);
                 };

--- a/docs/features/VALIDATION.md
+++ b/docs/features/VALIDATION.md
@@ -73,7 +73,7 @@ try {
 import com.streamConverter.command.impl.json.JsonValidateCommand;
 
 // JSON Schemaファイルを指定
-JsonValidateCommand validator = new JsonValidateCommand("user-schema.json");
+JsonValidateCommand validator = JsonValidateCommand.create("user-schema.json");
 
 // 使用例
 IStreamCommand[] pipeline = {
@@ -215,7 +215,7 @@ CsvValidateCommand customValidator = new CsvValidateCommand(
 );
 
 // JSONカスタムバリデーション（独自フォーマット）
-JsonValidateCommand customJsonValidator = new JsonValidateCommand(
+JsonValidateCommand customJsonValidator = JsonValidateCommand.create(
     "custom-schema.json",
     SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12)
 );
@@ -293,7 +293,7 @@ public void testCsvValidation_ValidData() {
 public void testJsonValidation_InvalidData() {
     // 無効なJSONデータでテスト
     String invalidJson = "{\\"name\\": \\"\\", \\"email\\": \\"invalid-email\\"}";
-    JsonValidateCommand validator = new JsonValidateCommand("user-schema.json");
+    JsonValidateCommand validator = JsonValidateCommand.create("user-schema.json");
     
     // バリデーションエラーの発生を確認
     assertThrows(StreamProcessingException.class, () -> {

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonValidateCommand.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * <p>使用例:
  *
  * <pre>
- * JsonValidateCommand validator = new JsonValidateCommand("schema/user.json");
+ * JsonValidateCommand validator = JsonValidateCommand.create("schema/user.json");
  * validator.consume(jsonInputStream);
  * </pre>
  */
@@ -49,26 +49,31 @@ public class JsonValidateCommand extends ConsumerCommand {
   private final SchemaRegistry schemaRegistry;
 
   /**
-   * コンストラクタ
+   * JsonValidateCommandのファクトリメソッド。
    *
    * @param schemaPath JSONスキーマファイルのパス
+   * @return 検証済みのスキーマパスに基づくJsonValidateCommand
    * @throws IllegalArgumentException スキーマパスがnullまたは空の場合
    */
-  public JsonValidateCommand(String schemaPath) {
-    this(schemaPath, DEFAULT_SCHEMA_REGISTRY);
+  public static JsonValidateCommand create(String schemaPath) {
+    return create(schemaPath, DEFAULT_SCHEMA_REGISTRY);
   }
 
-  public JsonValidateCommand(String schemaPath, SchemaRegistry schemaRegistry) {
-    this.schemaPath = validateSchemaPath(schemaPath);
-    if (schemaRegistry == null) {
-      throw new IllegalArgumentException("Schema registry cannot be null");
-    }
+  public static JsonValidateCommand create(String schemaPath, SchemaRegistry schemaRegistry) {
+    String validatedSchemaPath = validateSchemaPath(schemaPath);
+    SchemaRegistry validatedRegistry =
+        Objects.requireNonNull(schemaRegistry, "Schema registry cannot be null");
+    return new JsonValidateCommand(validatedSchemaPath, validatedRegistry);
+  }
+
+  private JsonValidateCommand(String schemaPath, SchemaRegistry schemaRegistry) {
+    this.schemaPath = schemaPath;
     this.schemaRegistry = schemaRegistry;
     this.objectMapper = new ObjectMapper();
   }
 
   /** スキーマパスの検証 */
-  private String validateSchemaPath(String path) {
+  private static String validateSchemaPath(String path) {
     if (path == null) {
       throw new IllegalArgumentException("Schema path cannot be null");
     }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonValidateCommandTest.java
@@ -72,7 +72,7 @@ public class JsonValidateCommandTest {
   void testConstructorWithValidSchemaPath() {
     assertDoesNotThrow(
         () -> {
-          JsonValidateCommand command = new JsonValidateCommand(validSchemaFile.toString());
+          JsonValidateCommand command = JsonValidateCommand.create(validSchemaFile.toString());
           assertNotNull(command);
         });
   }
@@ -81,7 +81,7 @@ public class JsonValidateCommandTest {
   @DisplayName("Constructor with null schema path throws exception")
   void testConstructorWithNullSchemaPath() {
     IllegalArgumentException exception =
-        assertThrows(IllegalArgumentException.class, () -> new JsonValidateCommand(null));
+        assertThrows(IllegalArgumentException.class, () -> JsonValidateCommand.create(null));
     assertEquals("Schema path cannot be null", exception.getMessage());
   }
 
@@ -89,7 +89,7 @@ public class JsonValidateCommandTest {
   @DisplayName("Constructor with empty schema path throws exception")
   void testConstructorWithEmptySchemaPath() {
     IllegalArgumentException exception =
-        assertThrows(IllegalArgumentException.class, () -> new JsonValidateCommand(""));
+        assertThrows(IllegalArgumentException.class, () -> JsonValidateCommand.create(""));
     assertEquals("Schema path cannot be empty", exception.getMessage());
   }
 
@@ -97,14 +97,14 @@ public class JsonValidateCommandTest {
   @DisplayName("Constructor with whitespace-only schema path throws exception")
   void testConstructorWithWhitespaceSchemaPath() {
     IllegalArgumentException exception =
-        assertThrows(IllegalArgumentException.class, () -> new JsonValidateCommand("   "));
+        assertThrows(IllegalArgumentException.class, () -> JsonValidateCommand.create("   "));
     assertEquals("Schema path cannot be empty", exception.getMessage());
   }
 
   @Test
   @DisplayName("Valid JSON validation succeeds")
   void testValidJsonValidationSuccess() throws IOException {
-    JsonValidateCommand command = new JsonValidateCommand(validSchemaFile.toString());
+    JsonValidateCommand command = JsonValidateCommand.create(validSchemaFile.toString());
 
     String validJson =
         """
@@ -125,7 +125,7 @@ public class JsonValidateCommandTest {
   @Test
   @DisplayName("Invalid JSON validation fails with detailed error")
   void testInvalidJsonValidationFailure() throws IOException {
-    JsonValidateCommand command = new JsonValidateCommand(validSchemaFile.toString());
+    JsonValidateCommand command = JsonValidateCommand.create(validSchemaFile.toString());
 
     String invalidJson =
         """
@@ -150,7 +150,7 @@ public class JsonValidateCommandTest {
   @Test
   @DisplayName("Missing required fields validation fails")
   void testMissingRequiredFieldsValidationFailure() throws IOException {
-    JsonValidateCommand command = new JsonValidateCommand(validSchemaFile.toString());
+    JsonValidateCommand command = JsonValidateCommand.create(validSchemaFile.toString());
 
     String jsonMissingRequired =
         """
@@ -176,7 +176,7 @@ public class JsonValidateCommandTest {
   @Test
   @DisplayName("Malformed JSON input throws exception")
   void testMalformedJsonInput() throws IOException {
-    JsonValidateCommand command = new JsonValidateCommand(validSchemaFile.toString());
+    JsonValidateCommand command = JsonValidateCommand.create(validSchemaFile.toString());
 
     String malformedJson =
         """
@@ -199,7 +199,7 @@ public class JsonValidateCommandTest {
   @Test
   @DisplayName("Empty JSON input throws exception")
   void testEmptyJsonInput() throws IOException {
-    JsonValidateCommand command = new JsonValidateCommand(validSchemaFile.toString());
+    JsonValidateCommand command = JsonValidateCommand.create(validSchemaFile.toString());
 
     ByteArrayInputStream inputStream =
         new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8));
@@ -215,7 +215,7 @@ public class JsonValidateCommandTest {
   void testNonExistentSchemaFile() {
     String nonExistentPath = tempDir.resolve("non-existent-schema.json").toString();
 
-    JsonValidateCommand command = new JsonValidateCommand(nonExistentPath);
+    JsonValidateCommand command = JsonValidateCommand.create(nonExistentPath);
     ByteArrayInputStream inputStream =
         new ByteArrayInputStream("{}".getBytes(StandardCharsets.UTF_8));
 
@@ -230,13 +230,13 @@ public class JsonValidateCommandTest {
   void testInvalidSchemaFile() {
     // 無効なキーワードを含むスキーマファイルは警告が出るが、例外はスローされない
     // （networknt JSON Schema ライブラリの仕様）
-    assertDoesNotThrow(() -> new JsonValidateCommand(invalidSchemaFile.toString()));
+    assertDoesNotThrow(() -> JsonValidateCommand.create(invalidSchemaFile.toString()));
   }
 
   @Test
   @DisplayName("Large JSON document validation")
   void testLargeJsonDocumentValidation() throws IOException {
-    JsonValidateCommand command = new JsonValidateCommand(validSchemaFile.toString());
+    JsonValidateCommand command = JsonValidateCommand.create(validSchemaFile.toString());
 
     // 大きなJSONドキュメントを作成（多数のプロパティを持つ）
     StringBuilder largeJson = new StringBuilder();
@@ -257,7 +257,7 @@ public class JsonValidateCommandTest {
   @Test
   @DisplayName("Null input stream throws exception")
   void testNullInputStream() throws IOException {
-    JsonValidateCommand command = new JsonValidateCommand(validSchemaFile.toString());
+    JsonValidateCommand command = JsonValidateCommand.create(validSchemaFile.toString());
 
     NullPointerException exception =
         assertThrows(NullPointerException.class, () -> command.consume(null));
@@ -300,7 +300,7 @@ public class JsonValidateCommandTest {
     Path complexSchemaFile = tempDir.resolve("complex-schema.json");
     Files.writeString(complexSchemaFile, complexSchema, StandardCharsets.UTF_8);
 
-    JsonValidateCommand command = new JsonValidateCommand(complexSchemaFile.toString());
+    JsonValidateCommand command = JsonValidateCommand.create(complexSchemaFile.toString());
 
     String validComplexJson =
         """
@@ -324,7 +324,7 @@ public class JsonValidateCommandTest {
   @Test
   @DisplayName("JSON with special characters validation")
   void testJsonWithSpecialCharactersValidation() throws IOException {
-    JsonValidateCommand command = new JsonValidateCommand(validSchemaFile.toString());
+    JsonValidateCommand command = JsonValidateCommand.create(validSchemaFile.toString());
 
     String jsonWithSpecialChars =
         """
@@ -345,7 +345,7 @@ public class JsonValidateCommandTest {
   @Test
   @DisplayName("Verify streaming JSON validation behavior")
   void testStreamingJsonValidationBehavior() throws IOException {
-    JsonValidateCommand command = new JsonValidateCommand(validSchemaFile.toString());
+    JsonValidateCommand command = JsonValidateCommand.create(validSchemaFile.toString());
 
     // Create a single valid JSON object for schema validation
     String singleJsonObject =
@@ -417,7 +417,7 @@ public class JsonValidateCommandTest {
     Path complexSchemaFile = tempDir.resolve("complex-schema.json");
     Files.writeString(complexSchemaFile, complexSchema, StandardCharsets.UTF_8);
 
-    JsonValidateCommand command = new JsonValidateCommand(complexSchemaFile.toString());
+    JsonValidateCommand command = JsonValidateCommand.create(complexSchemaFile.toString());
 
     // Create complex JSON data that matches the schema
     String complexJsonData =


### PR DESCRIPTION
## Summary
- add static factory methods for `JsonValidateCommand` and hide the direct constructors
- update documentation and integration examples to use the new factory method
- adjust `JsonValidateCommandTest` to construct commands through the factory helper

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_6901b0f4da0483259c1ffe27c8c9ccc2