### PR TITLE
docs: remove Factory Pattern references from documentation

### DIFF
--- a/docs/AUTO_LOGGING.md
+++ b/docs/AUTO_LOGGING.md
@@ -4,13 +4,12 @@ StreamConverterは包括的な自動ログ出力機能を提供し、大容量�
 
 ## 概要
 
-自動ログ機能は以下の3層アプローチで実装されています：
+自動ログ機能は以下の2層アプローチで実装されています：
 
 1. **Level 1**: `AbstractStreamCommand` - 基本的な実行ログ（実行時間、メモリ、データサイズ測定）
 2. **Level 2**: `LoggingDecorator` - カスタムコマンド向けログ追加（デコレーターパターン）
-3. **Level 3**: `CommandFactory` - 統一的な生成管理とログ重複回避（ファクトリーパターン）
 
-**重要**: AbstractStreamCommandを継承するコマンドは自動的にログ機能を持つため、LoggingDecoratorによる重複ラップは行われません。
+**重要**: AbstractStreamCommandを継承するコマンドは自動的にログ機能を持つため、LoggingDecoratorによる重複ラップは不要です。
 
 ## 基本的な使用方法
 
@@ -30,29 +29,25 @@ IStreamCommand loggedCommand = new LoggingDecorator(csvCommand);
 StreamConverter converter = StreamConverter.create(loggedCommand);
 ```
 
-### CommandFactoryを使用した自動ログ設定
+### 複数コマンドのパイプライン作成例
 
 ```java
-import com.streamConverter.command.CommandFactory;
+import com.streamConverter.command.LoggingDecorator;
 import com.streamConverter.command.impl.CsvNavigateCommand;
+import com.streamConverter.command.impl.SendHttpCommand;
+import com.streamConverter.command.impl.json.JsonNavigateCommand;
 
-// ファクトリーでコマンド作成（自動的にログ機能が追加される）
-IStreamCommand command = CommandFactory.createWithLogging(
-    CsvNavigateCommand.class, "productName"
-);
+// 各コマンドを作成
+IStreamCommand csvCommand = new CsvNavigateCommand("productName");
+IStreamCommand httpCommand = new SendHttpCommand("http://api.example.com");
+IStreamCommand jsonCommand = new JsonNavigateCommand("$.result");
 
-// 複数コマンドのパイプライン作成例
-IStreamCommand csvCommand = CommandFactory.createWithLogging(
-    CsvNavigateCommand.class, "productName"
-);
-IStreamCommand httpCommand = CommandFactory.createWithLogging(
-    SendHttpCommand.class, "http://api.example.com"
-);
-IStreamCommand jsonCommand = CommandFactory.createWithLogging(
-    JsonNavigateCommand.class, "$.result"
-);
+// 必要に応じてログ機能を追加
+IStreamCommand loggedCsvCommand = new LoggingDecorator(csvCommand);
+IStreamCommand loggedHttpCommand = new LoggingDecorator(httpCommand);
+IStreamCommand loggedJsonCommand = new LoggingDecorator(jsonCommand);
 
-IStreamCommand[] pipeline = {csvCommand, httpCommand, jsonCommand};
+IStreamCommand[] pipeline = {loggedCsvCommand, loggedHttpCommand, loggedJsonCommand};
 StreamConverter converter = StreamConverter.create(pipeline);
 ```
 
@@ -102,21 +97,7 @@ ERROR [AbstractStreamCommand] Command execution failed: SendHttpCommand (1523ms,
 java.net.SocketTimeoutException: Connect timed out
 ```
 
-## CommandFactoryの高度な使用方法
-
-### ログ重複回避の仕組み
-
-```java
-// AbstractStreamCommand継承クラス → ログ機能あり（重複回避）
-IStreamCommand csvCmd = CommandFactory.createWithLogging(CsvNavigateCommand.class, "fieldName");
-// → 直接インスタンス生成、LoggingDecoratorでラップしない
-
-// カスタムIStreamCommand実装 → LoggingDecoratorで自動ラップ
-IStreamCommand customCmd = CommandFactory.createWithLogging(MyCustomCommand.class);
-// → LoggingDecorator でラップして返す
-```
-
-### ExecutionContext対応のログ機能
+## ExecutionContext対応のログ機能
 
 ```java
 // ExecutionContext作成
@@ -127,8 +108,8 @@ ExecutionContext context = ExecutionContext.builder()
 
 // コンテキスト付きStreamConverter作成
 IStreamCommand[] commands = {
-    CommandFactory.createWithLogging(CsvNavigateCommand.class, "productName"),
-    CommandFactory.createWithLogging(SendHttpCommand.class, "http://api.example.com")
+    new CsvNavigateCommand("productName"),
+    new SendHttpCommand("http://api.example.com")
 };
 
 StreamConverter converter = StreamConverter.createWithContext(context, commands);
@@ -226,17 +207,19 @@ CommandConfig largeFileConfig = new CommandConfig()
 ### 3. パイプライン全体のログ統合
 
 ```java
-CommandConfig config = new CommandConfig()
-    .enableLogging(true)
-    .setLogLevel("INFO");
+// ExecutionContext作成でログ統合を実現
+ExecutionContext context = ExecutionContext.builder()
+    .globalContext("environment", "production")
+    .globalContext("pipeline", "csv-http-json")
+    .build();
 
 IStreamCommand[] pipeline = {
-    CommandFactory.createCsvNavigateCommand("input", config),
-    CommandFactory.createSendHttpCommand("http://api.example.com", config),
-    CommandFactory.createJsonNavigateCommand("$.result", config)
+    new CsvNavigateCommand("input"),
+    new SendHttpCommand("http://api.example.com"),
+    new JsonNavigateCommand("$.result")
 };
 
-StreamConverter converter = StreamConverter.create(pipeline);
+StreamConverter converter = StreamConverter.createWithContext(context, pipeline);
 ```
 
 ## トラブルシューティング

--- a/docs/development/INTEGRATION_EXAMPLES.md
+++ b/docs/development/INTEGRATION_EXAMPLES.md
@@ -174,21 +174,19 @@ public class StreamConverterWebClient {
 
 ### 4. 高度な統合パターン
 
-#### カスタムコマンドファクトリとの統合
+#### 動的バリデーション統合
 
 ```java
 @RestController
 @RequestMapping("/api/v1/advanced")
 public class AdvancedStreamController {
-    
-    private final EnhancedCommandFactory commandFactory;
-    
+
     @PostMapping("/process-with-validation")
     public Mono<ResponseEntity<Flux<DataBuffer>>> processWithValidation(
         @RequestBody Flux<DataBuffer> inputData,
         @RequestParam String dataType,
         @RequestParam String validationRules) {
-        
+
         return inputData
             .collectList()
             .map(this::combineDataBuffers)
@@ -200,7 +198,7 @@ public class AdvancedStreamController {
                     case "xml" -> new ValidateCommand(validationRules);
                     default -> throw new IllegalArgumentException("Unsupported data type: " + dataType);
                 };
-                
+
                 return processWithStreamConverter(data, validator);
             })
             .map(result -> ResponseEntity.ok(createDataBufferFlux(result)))

--- a/docs/handbook/logging.md
+++ b/docs/handbook/logging.md
@@ -8,8 +8,8 @@ Detailed logs help troubleshoot large stream operations and give insight into ti
 
 ## How
 1. Wrap any command in a `LoggingDecorator` to enable logs.
-2. Use `CommandFactory.createWithLogging` for automatic decorator application.
-3. Configure log levels through `CommandConfig` or logging frameworks.
+2. Commands extending `AbstractStreamCommand` have automatic logging.
+3. Configure log levels through logging frameworks (e.g., logback).
 
 ## See also
 - [Architecture](architecture.md)

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonValidateCommand.java
@@ -199,9 +199,7 @@ public class JsonValidateCommand extends ConsumerCommand {
 
       // ログに詳細を出力
       logger.error(
-          "JSON validation error - Path: {}, Message: {}",
-          instanceLocation,
-          error.getMessage());
+          "JSON validation error - Path: {}, Message: {}", instanceLocation, error.getMessage());
     }
 
     String errorMessage = errorBuilder.toString();

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonStreamingValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonStreamingValidateCommandTest.java
@@ -59,7 +59,8 @@ public class JsonStreamingValidateCommandTest {
   @DisplayName("Factory method rejects null schema path")
   void testFactoryWithNullSchemaPath() {
     IllegalArgumentException exception =
-        assertThrows(IllegalArgumentException.class, () -> JsonStreamingValidateCommand.create(null));
+        assertThrows(
+            IllegalArgumentException.class, () -> JsonStreamingValidateCommand.create(null));
     assertEquals("Schema path cannot be null", exception.getMessage());
   }
 
@@ -101,4 +102,3 @@ public class JsonStreamingValidateCommandTest {
     assertNotNull(command);
   }
 }
-


### PR DESCRIPTION
## Summary
Removed all references to the deleted Factory Pattern (EnhancedCommandFactory, CommandFactory) from documentation files.

## Changes
### Documentation Updates
- **docs/AUTO_LOGGING.md**
  - Removed Level 3 (CommandFactory) from architecture description
  - Replaced CommandFactory usage examples with direct instantiation
  - Updated ExecutionContext examples to use direct instantiation
  - Removed "CommandFactoryの高度な使用方法" section

- **docs/handbook/logging.md** 
  - Removed reference to `CommandFactory.createWithLogging`
  - Updated to reflect AbstractStreamCommand automatic logging

- **docs/development/INTEGRATION_EXAMPLES.md**
  - Removed `EnhancedCommandFactory` field from AdvancedStreamController
  - Renamed section to "動的バリデーション統合"

### Code Formatting
- Minor formatting adjustments in JsonValidateCommand.java and JsonStreamingValidateCommandTest.java (spotless auto-format)

## Testing
- [x] Documentation reviewed for consistency
- [x] No broken code examples remain
- [x] All examples use current API (direct instantiation)

## Related Issues
- Closes #370
- Part of #375 (Documentation Consistency Meta Issue)

## Verification
All documentation now correctly reflects the direct instantiation pattern without any Factory references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>