### PR TITLE
docs: unify version information across all documentation (#369)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 StreamConverter is a Java library for efficient stream processing of large files with memory-constrained pipeline architecture. It implements a command pattern for flexible data processing pipelines with concurrent execution capabilities.
 
-**Version**: 1.2.0  
-**Java Version**: 21  
-**Build System**: Gradle with Kotlin DSL  
+**Version**: 0.0.0 (in development)
+**Java Version**: 21
+**Build System**: Gradle with Kotlin DSL
 **Architecture**: Multi-module project with 4-layer design
 
 ### Module Structure
@@ -223,7 +223,7 @@ Always start with the **[Documentation Index](docs/INDEX.md)** for comprehensive
 ### Multi-Module Considerations
 - Cross-module dependencies managed via Gradle composite builds
 - Unified Javadoc generation across all modules with `./gradlew javadocAll`
-- Consistent versioning strategy (currently 1.2.0)
+- Consistent versioning strategy (currently 0.0.0 - in development)
 - Module-specific test execution patterns
 - Security vulnerability management with explicit version overrides
 - Gradle Kotlin DSL used throughout for type-safe configuration

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ The following versions of StreamConverter are currently supported with security 
 
 | Version | Supported          | Notes                    |
 | ------- | ------------------ | ------------------------ |
-| 1.0.x   | :white_check_mark: | Current development      |
+| 0.0.0   | :white_check_mark: | Current development      |
 
-**Note**: This project is currently in development (1.0.0-SNAPSHOT). Production releases will follow semantic versioning.
+**Note**: This project is currently in development (0.0.0). Production releases will follow semantic versioning.
 
 ## Reporting a Vulnerability
 

--- a/docs/reference/VERSION_MANAGEMENT.md
+++ b/docs/reference/VERSION_MANAGEMENT.md
@@ -1,24 +1,24 @@
 # Version Management
 
 ## Current Version
-- **Version**: 1.2.0
-- **Status**: Active Development
-- **Java**: 17+
+- **Version**: 0.0.0 (in development)
+- **Status**: Pre-release Development
+- **Java**: 21+
 - **Gradle**: 8.13
 
 ## Supported Versions
 
 | Version | Support Status | Security Updates | End of Life |
 |---------|----------------|------------------|-------------|
-| 1.2.x   | ✅ Active      | ✅ Yes           | TBD         |
-| 1.1.x   | 🔄 Maintenance | ✅ Yes           | 2025-12-31  |
-| 1.0.x   | ❌ EOL         | ❌ No            | 2025-06-30  |
+| 0.0.0   | 🔄 Development | N/A              | TBD         |
+
+*Note: Project is currently in pre-release development. First stable release (1.0.0) is planned.*
 
 ## Version History
 
-### 1.2.0 (Current)
+### 0.0.0 (Current - In Development)
 - ExecutionContext and MDC integration for multi-threaded traceability
-- Enhanced CommandFactory with logging duplication avoidance
+- Direct instantiation pattern (Factory Pattern removed)
 - Reorganized command packages (csv/, json/, xml/ separation)
 - Comprehensive auto-logging infrastructure
 - Performance benchmarking tools (streamconverter-tools module)

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonValidateCommand.java
@@ -199,9 +199,7 @@ public class JsonValidateCommand extends ConsumerCommand {
 
       // ログに詳細を出力
       logger.error(
-          "JSON validation error - Path: {}, Message: {}",
-          instanceLocation,
-          error.getMessage());
+          "JSON validation error - Path: {}, Message: {}", instanceLocation, error.getMessage());
     }
 
     String errorMessage = errorBuilder.toString();

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonStreamingValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonStreamingValidateCommandTest.java
@@ -59,7 +59,8 @@ public class JsonStreamingValidateCommandTest {
   @DisplayName("Factory method rejects null schema path")
   void testFactoryWithNullSchemaPath() {
     IllegalArgumentException exception =
-        assertThrows(IllegalArgumentException.class, () -> JsonStreamingValidateCommand.create(null));
+        assertThrows(
+            IllegalArgumentException.class, () -> JsonStreamingValidateCommand.create(null));
     assertEquals("Schema path cannot be null", exception.getMessage());
   }
 
@@ -101,4 +102,3 @@ public class JsonStreamingValidateCommandTest {
     assertNotNull(command);
   }
 }
-


### PR DESCRIPTION
## Summary
Updated all documentation files to reflect the correct project version (0.0.0 - in development) as defined in build.gradle.kts.

## Changes

### CLAUDE.md
- Line 9: `1.2.0` → `0.0.0 (in development)`
- Line 226: `currently 1.2.0` → `currently 0.0.0 - in development`

### docs/reference/VERSION_MANAGEMENT.md
- Line 4: Updated current version from `1.2.0` to `0.0.0 (in development)`
- Lines 11-15: Removed unsupported version table entries (1.2.x, 1.1.x, 1.0.x)
- Line 13: Added development status note
- Line 19: Updated version history header
- Line 21: Updated to reflect Factory Pattern removal

### SECURITY.md
- Line 9: `1.0.x` → `0.0.0`
- Line 11: `1.0.0-SNAPSHOT` → `0.0.0`

### README.md
- Already correct (0.0.0（開発中）) - no changes needed

## Impact
- All documentation now consistently shows version 0.0.0 (in development)
- Users can accurately identify the current project state
- Eliminates confusion from conflicting version information
- Aligns with build.gradle.kts version property

## Verification
Source of truth: `build.gradle.kts` line 253: `version = "0.0.0"`

## Related
- Closes #369
- Part of #375 (Documentation Consistency Meta Issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)