### PR TITLE
docs: establish Japanese-first language policy (#373)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,35 @@ This project uses [Spotless](https://github.com/diffplug/spotless) with Google J
 
 This will automatically format your code according to the project's style guidelines.
 
+## Documentation Language Policy
+
+This project adopts a **Japanese-first documentation strategy** with the following guidelines:
+
+### Primary Language: Japanese (日本語)
+- All user-facing documentation should be written in Japanese
+- This includes: README.md, guides, tutorials, API documentation, and feature descriptions
+
+### Exceptions: English for AI/Tool Integration
+- AI assistant configuration files (e.g., CLAUDE.md) may be written in English
+- Tool integration documentation targeting international developer tools may be in English
+- Technical specifications intended for automated processing may be in English
+
+### Internationalization (i18n)
+- Future internationalization will be handled through machine translation
+- We do not currently maintain parallel English documentation
+- Contributors are not required to provide translations
+- Community-contributed translations are welcome but not required
+
+### Contributing Documentation
+When contributing documentation:
+1. **New documentation**: Write in Japanese unless it falls under the exceptions above
+2. **Existing documentation**: Follow the language of the existing document
+3. **Code comments**: English or Japanese is acceptable
+4. **Commit messages**: Follow Conventional Commits in English (as per standard practice)
+
+### Rationale
+This policy reflects the project's primary user base and development team composition while keeping maintenance costs manageable. Machine translation technology has advanced sufficiently to provide adequate internationalization when needed.
+
 ## Pull Request Process
 
 1. Ensure your code follows the style guidelines of this project

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,8 +93,8 @@ This will automatically format your code according to the project's style guidel
 This project adopts a **Japanese-first documentation strategy** with the following guidelines:
 
 ### Primary Language: Japanese (日本語)
-- All user-facing documentation should be written in Japanese
-- This includes: README.md, guides, tutorials, API documentation, and feature descriptions
+- "User-facing documentation" includes (but is not limited to): README.md, usage guides, tutorials, API documentation, and feature descriptions
+- It does **not** include developer-oriented files such as CONTRIBUTING.md, changelogs, or internal technical notes unless otherwise specified
 
 ### Exceptions: English for AI/Tool Integration
 - AI assistant configuration files (e.g., CLAUDE.md) may be written in English
@@ -106,6 +106,13 @@ This project adopts a **Japanese-first documentation strategy** with the followi
 - We do not currently maintain parallel English documentation
 - Contributors are not required to provide translations
 - Community-contributed translations are welcome but not required
+
+#### Machine Translation Implementation Details
+- **Process**: Machine translation will be performed manually by project maintainers as needed (e.g., for major releases or significant documentation updates). There is currently no automated translation pipeline.
+- **Responsibility**: The project maintainers are responsible for initiating and reviewing machine translations. Contributors may suggest or request translations, but are not obligated to provide them.
+- **Triggers**: Translations may be generated when there is significant demand from the community, upon major documentation changes, or when requested by contributors or users.
+- **Community Involvement**: Community-contributed translations (manual or via machine translation) are welcome. If you wish to contribute a translation, please open an Issue or Pull Request for discussion and review.
+- **Review**: All translations, whether machine-generated or community-contributed, will be reviewed by maintainers for accuracy and clarity before being merged.
 
 ### Contributing Documentation
 When contributing documentation:


### PR DESCRIPTION
## Summary
Added a clear language policy to CONTRIBUTING.md establishing Japanese as the primary documentation language, with exceptions for AI/tool integration documentation and a plan for machine translation-based internationalization.

## Changes

### CONTRIBUTING.md
- Added "Documentation Language Policy" section
- Specified Japanese as primary language for user-facing documentation
- Defined exceptions: AI assistant configs (CLAUDE.md) and tool integrations may use English
- Documented internationalization approach: machine translation for future needs
- Provided clear guidelines for contributors on language choice

## Policy Details

**Primary Language**: Japanese (日本語)
- User-facing docs (README, guides, tutorials, API docs)

**Exceptions**: English allowed for
- AI assistant configuration files (CLAUDE.md)
- International developer tool integrations
- Automated processing specifications

**Internationalization Strategy**
- No parallel English documentation maintenance
- Future i18n via machine translation
- Community translations welcome but not required

## Rationale
- Reflects primary user base (Japanese)
- Matches development team composition
- Keeps maintenance costs manageable
- Modern machine translation sufficient for international users

## Impact
- Clear guidance for contributors on documentation language
- Reduces confusion about mixed language documentation
- Sets expectations for internationalization approach
- Maintains focus on primary audience while remaining open to global users

## Related
- Closes #373
- Part of #375 (Documentation Consistency Meta Issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)