### PR TITLE
docs: fix Java version inconsistency to Java 21 (#390)

### DIFF
--- a/docs/reference/TESTING.md
+++ b/docs/reference/TESTING.md
@@ -431,12 +431,12 @@ void testBenchmarkConsistency()          // 性能一貫性テスト
 ## テスト実行環境の要件
 
 ### 最小要件
-- Java 17以上
+- Java: See [VERSION_MANAGEMENT.md - Java Compatibility](VERSION_MANAGEMENT.md#java-compatibility)
 - ヒープメモリ: 512MB以上
 - 利用可能ディスク容量: 100MB以上
 
 ### 推奨要件
-- Java 17以上
+- Java: See [VERSION_MANAGEMENT.md - Java Compatibility](VERSION_MANAGEMENT.md#java-compatibility)
 - ヒープメモリ: 1GB以上 (`-Xmx1g`)
 - 利用可能ディスク容量: 500MB以上
 - ネットワーク接続（HTTPテスト用）

--- a/docs/reference/VERSION_MANAGEMENT.md
+++ b/docs/reference/VERSION_MANAGEMENT.md
@@ -57,12 +57,19 @@ For security issues, please refer to [SECURITY.md](../SECURITY.md).
 ## Compatibility
 
 ### Java Compatibility
-- **Minimum**: Java 17
-- **Tested**: Java 17, 21
-- **Recommended**: Java 21 LTS
+- **Required**: Java 21 or later
+- **Tested**: Java 21 LTS
+- **Build Configuration**: All modules use `JavaLanguageVersion.of(21)`
+
+**Why Java 21?**
+- Modern language features (Virtual Threads, Pattern Matching, Records)
+- LTS version with long-term support
+- Consistent toolchain across all modules
+
+**Note**: Java 17 is NOT supported. The project requires Java 21 as the minimum version.
 
 ### Dependencies
-See [build.gradle.kts](../build.gradle.kts) for current dependency versions.
+See [build.gradle.kts](../../build.gradle.kts) for current dependency versions.
 
 ## 関連ドキュメント
 


### PR DESCRIPTION
## Summary

Java バージョン要件の不整合を解消しました。一部のドキュメントで Java 17 と記載されていましたが、実際の build.gradle.kts では全モジュールで Java 21 が要求されています。

## Problem

| ファイル | 記載内容 | 正しい値 |
|---------|---------|---------|
| VERSION_MANAGEMENT.md | Java 17 | Java 21 |
| TESTING.md (2箇所) | Java 17 | Java 21 |

**build.gradle.kts の実際の設定**:
```kotlin
JavaLanguageVersion.of(21)  // 全モジュール共通
```

## Changes

### VERSION_MANAGEMENT.md
**Before**:
```markdown
- **Minimum**: Java 17
- **Tested**: Java 17, 21
- **Recommended**: Java 21 LTS
```

**After**:
```markdown
- **Required**: Java 21 or later
- **Tested**: Java 21 LTS
- **Build Configuration**: All modules use `JavaLanguageVersion.of(21)`

**Why Java 21?**
- Modern language features (Virtual Threads, Pattern Matching, Records)
- LTS version with long-term support
- Consistent toolchain across all modules

**Note**: Java 17 is NOT supported.
```

### TESTING.md
**Before**:
```markdown
- Java 17以上
```

**After**:
```markdown
- Java: See [VERSION_MANAGEMENT.md - Java Compatibility](VERSION_MANAGEMENT.md#java-compatibility)
```

## Benefits

✅ **Single Source of Truth**: VERSION_MANAGEMENT.md が Java 要件の唯一の情報源  
✅ **一貫性**: すべてのドキュメントが同じバージョン要件を示す  
✅ **正確性**: build.gradle.kts の設定と一致  
✅ **メンテナンス性**: 今後の変更は VERSION_MANAGEMENT.md のみ

## Verification

- [x] build.gradle.kts で Java 21 が設定されていることを確認
- [x] VERSION_MANAGEMENT.md を更新
- [x] TESTING.md を参照に変更
- [x] README.md と quickstart/basic-usage.md は既に正しい値

## Related Issues

Closes #390

Part of #388 (DRY 原則によるドキュメント整合性向上)

🤖 Generated with [Claude Code](https://claude.com/claude-code)