### PR TITLE
docs: add bidirectional cross-references to handbook (#392)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # StreamConverter Architecture
 
+> 💡 **クイック概要**: まず [Architecture Handbook](handbook/architecture.md) で What/Why/How を理解することをお勧めします。
+
 This document describes the simplified StreamConverter architecture after factory pattern elimination:
 
 **External Systems → Direct Instantiation → StreamConverter → Commands**

--- a/docs/AUTO_LOGGING.md
+++ b/docs/AUTO_LOGGING.md
@@ -1,5 +1,7 @@
 # Auto-Logging Infrastructure
 
+> 💡 **クイック概要**: まず [Logging Handbook](handbook/logging.md) で What/Why/How を理解することをお勧めします。
+
 StreamConverterは包括的な自動ログ出力機能を提供し、大容量ファイル処理時のトラブルシューティングとモニタリングを支援します。
 
 ## 概要

--- a/docs/WEB_API.md
+++ b/docs/WEB_API.md
@@ -1,5 +1,7 @@
 # StreamConverter Web API
 
+> 💡 **クイック概要**: まず [Web API Handbook](handbook/web-api.md) で What/Why/How を理解することをお勧めします。
+
 StreamConverterの既存機能をWebAPIとして提供するRESTfulサービスです。
 
 ## 🚀 起動方法

--- a/docs/features/VALIDATION.md
+++ b/docs/features/VALIDATION.md
@@ -1,6 +1,6 @@
 # バリデーション機能ガイド
 
-詳しい概要は[Validation ハンドブック](../handbook/validation.md)の What / Why / How セクションを参照してください。
+> 💡 **クイック概要**: まず [Validation Handbook](../handbook/validation.md) で What/Why/How を理解することをお勧めします。
 
 ## 📋 概要
 


### PR DESCRIPTION
## Summary

詳細ドキュメントからhandbookへの逆参照を追加し、双方向ナビゲーションを実現しました。

## Problem

handbookファイル（簡潔なWhat/Why/How形式）から詳細ドキュメントへの参照はありましたが、逆方向の参照がなかったため：
- 詳細ドキュメントを読んでいるユーザーが簡潔な概要の存在を知らない
- 初心者が詳細から入ってしまい、複雑さに圧倒される

## Changes

4つの詳細ドキュメントにhandbookへの参照を追加：

### 追加した参照

1. **AUTO_LOGGING.md** → handbook/logging.md
2. **features/VALIDATION.md** → handbook/validation.md (表現を統一)
3. **WEB_API.md** → handbook/web-api.md
4. **ARCHITECTURE.md** → handbook/architecture.md

### 統一されたフォーマット

すべての参照で同じパターンを使用：

```markdown
> 💡 **クイック概要**: まず [Topic Handbook](path) で What/Why/How を理解することをお勧めします。
```

## Benefits

✅ **双方向ナビゲーション**: 概要 ⇄ 詳細を自由に行き来可能  
✅ **Handbook の発見性向上**: ユーザーが簡潔な概要を見つけやすくなる  
✅ **UX 改善**: 初心者にやさしいドキュメント構造  
✅ **一貫性**: すべての参照で同じ表現を使用

## Examples

**Before (AUTO_LOGGING.md)**:
```markdown
# Auto-Logging Infrastructure

StreamConverterは包括的な自動ログ出力機能を提供し...
```

**After**:
```markdown
# Auto-Logging Infrastructure

> 💡 **クイック概要**: まず [Logging Handbook](handbook/logging.md) で What/Why/How を理解することをお勧めします。

StreamConverterは包括的な自動ログ出力機能を提供し...
```

## Related Issues

Closes #392

Part of #388 (DRY 原則によるドキュメント整合性向上)

🤖 Generated with [Claude Code](https://claude.com/claude-code)