### PR TITLE
docs: consolidate command examples to COMMAND_EXAMPLES.md (#389)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,11 +45,11 @@ This simplified architecture removes factory complexity while maintaining all fu
 
 ### 1. Direct Command Instantiation
 
+Commands are created directly with explicit parameters. For detailed examples, see [Command Examples](reference/COMMAND_EXAMPLES.md).
+
 ```java
-// Create commands directly with explicit parameters
-IStreamCommand csvCommand = new CsvNavigateCommand(new CSVPath("name"), new PassThroughRule());
-IStreamCommand jsonCommand = new JsonNavigateCommand(new JSONPath("user.name"), new PassThroughRule());
-IStreamCommand xmlCommand = new XmlNavigateCommand(new XPath("//user/name"), new PassThroughRule());
+// Example: CSV command
+IStreamCommand csvCommand = new CsvNavigateCommand("name");
 ```
 
 **Benefits**:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,7 +49,10 @@ Commands are created directly with explicit parameters. For detailed examples, s
 
 ```java
 // Example: CSV command
-IStreamCommand csvCommand = new CsvNavigateCommand("name");
+IStreamCommand csvCommand = new CsvNavigateCommand(
+    new CSVPath("name"),
+    new PassThroughRule()
+);
 ```
 
 **Benefits**:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -40,6 +40,7 @@
 - **[reference/CROSS_PLATFORM_TEST_CONSIDERATIONS.md](reference/CROSS_PLATFORM_TEST_CONSIDERATIONS.md)**: マルチプラットフォーム対応
 - **[reference/JAVADOC_MANAGEMENT.md](reference/JAVADOC_MANAGEMENT.md)**: API ドキュメント生成
 - **[reference/COMMAND_REFERENCE.md](reference/COMMAND_REFERENCE.md)**: Gradle/Git コマンドリファレンス
+- **[reference/COMMAND_EXAMPLES.md](reference/COMMAND_EXAMPLES.md)**: コマンド使用例（CSV/JSON/XML/HTTP）
 
 ## 🔐 Security & Operations
 - **[reference/SECURITY_ANALYSIS.md](reference/SECURITY_ANALYSIS.md)**: セキュリティレビュー

--- a/docs/reference/COMMAND_EXAMPLES.md
+++ b/docs/reference/COMMAND_EXAMPLES.md
@@ -1,0 +1,239 @@
+# Command Examples Reference
+
+StreamConverter で使用できるコマンドの基本的な使用例を示します。
+
+## CSV Commands
+
+### CsvNavigateCommand - CSV列抽出
+
+```java
+import com.streamConverter.command.csv.CsvNavigateCommand;
+
+// 特定の列を抽出
+IStreamCommand csvCommand = new CsvNavigateCommand("productName");
+
+StreamConverter converter = StreamConverter.create(new IStreamCommand[]{csvCommand});
+List<CommandResult> results = converter.run(inputStream, outputStream);
+```
+
+### CsvFilterCommand - CSV行フィルタ
+
+```java
+import com.streamConverter.command.csv.CsvFilterCommand;
+
+// 条件に一致する行のみ抽出
+IStreamCommand filterCommand = new CsvFilterCommand("price", value -> {
+    return Integer.parseInt(value) > 1000;
+});
+```
+
+### CsvValidateCommand - CSV検証
+
+```java
+import com.streamConverter.command.csv.CsvValidateCommand;
+
+// CSVファイルの構造を検証
+IStreamCommand validateCommand = new CsvValidateCommand(
+    Arrays.asList("id", "name", "price")  // 期待される列
+);
+```
+
+## JSON Commands
+
+### JsonNavigateCommand - JSON要素抽出
+
+```java
+import com.streamConverter.command.json.JsonNavigateCommand;
+
+// JSONPathで要素を抽出
+IStreamCommand jsonCommand = new JsonNavigateCommand("$.user.name");
+
+StreamConverter converter = StreamConverter.create(new IStreamCommand[]{jsonCommand});
+```
+
+### JsonFilterCommand - JSON要素フィルタ
+
+```java
+import com.streamConverter.command.json.JsonFilterCommand;
+
+// 条件に一致するJSON要素のみ抽出
+IStreamCommand filterCommand = new JsonFilterCommand("$.items[*]", item -> {
+    return item.get("price").asInt() > 1000;
+});
+```
+
+### JsonValidateCommand - JSON Schema検証
+
+```java
+import com.streamConverter.command.json.JsonValidateCommand;
+
+// JSONスキーマで検証
+IStreamCommand validateCommand = new JsonValidateCommand(schemaInputStream);
+```
+
+## XML Commands
+
+### XmlNavigateCommand - XML要素抽出
+
+```java
+import com.streamConverter.command.xml.XmlNavigateCommand;
+
+// XPathで要素を抽出
+IStreamCommand xmlCommand = new XmlNavigateCommand("/root/user/name");
+```
+
+### XmlFilterCommand - XML要素フィルタ
+
+```java
+import com.streamConverter.command.xml.XmlFilterCommand;
+
+// 条件に一致するXML要素のみ抽出
+IStreamCommand filterCommand = new XmlFilterCommand("/root/item", element -> {
+    return Integer.parseInt(element.getAttribute("price")) > 1000;
+});
+```
+
+### ValidateCommand - XML検証
+
+```java
+import com.streamConverter.command.xml.ValidateCommand;
+
+// XMLスキーマで検証
+IStreamCommand validateCommand = new ValidateCommand(xsdInputStream);
+```
+
+## HTTP Communication
+
+### SendHttpCommand - HTTP リクエスト送信
+
+```java
+import com.streamConverter.command.communication.SendHttpCommand;
+
+// HTTP POSTリクエストを送信
+IStreamCommand httpCommand = new SendHttpCommand("https://api.example.com/process");
+
+// パイプライン例: CSV → HTTP API → JSON
+IStreamCommand[] pipeline = {
+    new CsvNavigateCommand("productName"),
+    new SendHttpCommand("https://api.example.com/lookup"),
+    new JsonNavigateCommand("$.result")
+};
+```
+
+## Data Transformation
+
+### CharacterConvertCommand - 文字コード変換
+
+```java
+import com.streamConverter.command.CharacterConvertCommand;
+
+// Shift_JIS から UTF-8 に変換
+IStreamCommand convertCommand = new CharacterConvertCommand(
+    Charset.forName("Shift_JIS"),
+    Charset.forName("UTF-8")
+);
+```
+
+### LineEndingNormalizeCommand - 改行コード正規化
+
+```java
+import com.streamConverter.command.LineEndingNormalizeCommand;
+
+// 改行コードをLFに統一
+IStreamCommand normalizeCommand = new LineEndingNormalizeCommand("\n");
+```
+
+## Pipeline Patterns
+
+### 単純なパイプライン
+
+```java
+// CSV → 変換 → 出力
+IStreamCommand[] pipeline = {
+    new CsvNavigateCommand("name"),
+    new CharacterConvertCommand(Charset.forName("Shift_JIS"), StandardCharsets.UTF_8)
+};
+
+StreamConverter converter = StreamConverter.create(pipeline);
+List<CommandResult> results = converter.run(inputStream, outputStream);
+```
+
+### ExecutionContext を使用したパイプライン
+
+ExecutionContext の詳細な使用方法は [Basic Usage - Context and Metrics](../quickstart/basic-usage.md#3-context-and-metrics) を参照してください。
+
+```java
+// コンテキスト作成
+ExecutionContext context = ExecutionContext.builder()
+    .globalContext("requestId", "REQ-12345")
+    .globalContext("userId", "user789")
+    .build();
+
+// コンテキスト付きパイプライン実行
+StreamConverter converter = StreamConverter.createWithContext(context, pipeline);
+List<CommandResult> results = converter.run(inputStream, outputStream);
+```
+
+### 複雑なパイプライン例
+
+```java
+// CSV → HTTP API → JSON → 検証 → 出力
+IStreamCommand[] complexPipeline = {
+    new CsvNavigateCommand("productId"),
+    new SendHttpCommand("https://api.example.com/products"),
+    new JsonNavigateCommand("$.product.details"),
+    new JsonValidateCommand(schemaInputStream)
+};
+
+ExecutionContext context = ExecutionContext.builder()
+    .globalContext("traceId", UUID.randomUUID().toString())
+    .build();
+
+StreamConverter converter = StreamConverter.createWithContext(context, complexPipeline);
+```
+
+## エラーハンドリング
+
+### CommandResult を使用した結果確認
+
+```java
+List<CommandResult> results = converter.run(inputStream, outputStream);
+
+for (CommandResult result : results) {
+    if (!result.isSuccessful()) {
+        System.err.println("Command failed: " + result.getCommandName());
+        System.err.println("Error: " + result.getErrorMessage());
+    } else {
+        System.out.println("Success: " + result.getCommandName() +
+                         " (duration: " + result.getExecutionTimeMs() + "ms)");
+    }
+}
+```
+
+### try-with-resources パターン
+
+```java
+try (InputStream input = new FileInputStream("input.csv");
+     OutputStream output = new FileOutputStream("output.txt")) {
+
+    StreamConverter converter = StreamConverter.create(pipeline);
+    List<CommandResult> results = converter.run(input, output);
+
+    // 結果を確認
+    boolean allSuccessful = results.stream().allMatch(CommandResult::isSuccessful);
+    if (!allSuccessful) {
+        throw new RuntimeException("Pipeline execution failed");
+    }
+
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+## 関連ドキュメント
+
+- [Basic Usage](../quickstart/basic-usage.md) - 初心者向けチュートリアル
+- [ARCHITECTURE.md](../ARCHITECTURE.md) - アーキテクチャ詳細
+- [VALIDATION.md](../features/VALIDATION.md) - バリデーション機能の詳細
+- [AUTO_LOGGING.md](../AUTO_LOGGING.md) - ロギング機能
+- [COMMAND_REFERENCE.md](COMMAND_REFERENCE.md) - Gradle コマンドリファレンス

--- a/docs/reference/COMMAND_EXAMPLES.md
+++ b/docs/reference/COMMAND_EXAMPLES.md
@@ -7,10 +7,19 @@ StreamConverter で使用できるコマンドの基本的な使用例を示し�
 ### CsvNavigateCommand - CSV列抽出
 
 ```java
-import com.streamConverter.command.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.CommandResult;
+import java.util.List;
 
 // 特定の列を抽出
-IStreamCommand csvCommand = new CsvNavigateCommand("productName");
+IStreamCommand csvCommand = new CsvNavigateCommand(
+    new CSVPath("productName"),
+    new PassThroughRule()
+);
 
 StreamConverter converter = StreamConverter.create(new IStreamCommand[]{csvCommand});
 List<CommandResult> results = converter.run(inputStream, outputStream);
@@ -19,22 +28,29 @@ List<CommandResult> results = converter.run(inputStream, outputStream);
 ### CsvFilterCommand - CSV行フィルタ
 
 ```java
-import com.streamConverter.command.csv.CsvFilterCommand;
+import com.streamconverter.command.impl.csv.CsvFilterCommand;
+import com.streamconverter.path.CSVPath;
 
-// 条件に一致する行のみ抽出
-IStreamCommand filterCommand = new CsvFilterCommand("price", value -> {
-    return Integer.parseInt(value) > 1000;
-});
+// 特定の列のみ抽出（ヘッダーありと仮定）
+IStreamCommand filterCommand = CsvFilterCommand.create(new CSVPath("price"));
+
+// ヘッダーの有無を明示的に指定
+IStreamCommand filterCommand2 = new CsvFilterCommand(new CSVPath("name"), true);
 ```
 
 ### CsvValidateCommand - CSV検証
 
 ```java
-import com.streamConverter.command.csv.CsvValidateCommand;
+import com.streamconverter.command.impl.csv.CsvValidateCommand;
 
-// CSVファイルの構造を検証
-IStreamCommand validateCommand = new CsvValidateCommand(
-    Arrays.asList("id", "name", "price")  // 期待される列
+// CSVファイルの構造を検証（必須カラムを指定）
+IStreamCommand validateCommand = new CsvValidateCommand("id", "name", "price");
+
+// 詳細設定を指定
+IStreamCommand validateCommand2 = new CsvValidateCommand(
+    true,  // hasHeader
+    10,    // maxErrorsToReport
+    "id", "name", "price"  // requiredColumns
 );
 ```
 
@@ -43,10 +59,15 @@ IStreamCommand validateCommand = new CsvValidateCommand(
 ### JsonNavigateCommand - JSON要素抽出
 
 ```java
-import com.streamConverter.command.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.path.TreePath;
+import com.streamconverter.command.rule.PassThroughRule;
 
 // JSONPathで要素を抽出
-IStreamCommand jsonCommand = new JsonNavigateCommand("$.user.name");
+IStreamCommand jsonCommand = new JsonNavigateCommand(
+    new TreePath("user", "name"),
+    new PassThroughRule()
+);
 
 StreamConverter converter = StreamConverter.create(new IStreamCommand[]{jsonCommand});
 ```
@@ -54,21 +75,22 @@ StreamConverter converter = StreamConverter.create(new IStreamCommand[]{jsonComm
 ### JsonFilterCommand - JSON要素フィルタ
 
 ```java
-import com.streamConverter.command.json.JsonFilterCommand;
+import com.streamconverter.command.impl.json.JsonFilterCommand;
+import com.streamconverter.path.TreePath;
 
-// 条件に一致するJSON要素のみ抽出
-IStreamCommand filterCommand = new JsonFilterCommand("$.items[*]", item -> {
-    return item.get("price").asInt() > 1000;
-});
+// TreePathを使用してJSON要素を抽出
+IStreamCommand filterCommand = new JsonFilterCommand(
+    new TreePath("items", "0", "price")
+);
 ```
 
 ### JsonValidateCommand - JSON Schema検証
 
 ```java
-import com.streamConverter.command.json.JsonValidateCommand;
+import com.streamconverter.command.impl.json.JsonValidateCommand;
 
-// JSONスキーマで検証
-IStreamCommand validateCommand = new JsonValidateCommand(schemaInputStream);
+// JSONスキーマで検証（静的ファクトリメソッドを使用）
+IStreamCommand validateCommand = JsonValidateCommand.create("schemas/user-schema.json");
 ```
 
 ## XML Commands
@@ -76,30 +98,36 @@ IStreamCommand validateCommand = new JsonValidateCommand(schemaInputStream);
 ### XmlNavigateCommand - XML要素抽出
 
 ```java
-import com.streamConverter.command.xml.XmlNavigateCommand;
+import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.path.TreePath;
+import com.streamconverter.command.rule.PassThroughRule;
 
-// XPathで要素を抽出
-IStreamCommand xmlCommand = new XmlNavigateCommand("/root/user/name");
+// TreePathでXML要素を抽出
+IStreamCommand xmlCommand = new XmlNavigateCommand(
+    new TreePath("root", "user", "name"),
+    new PassThroughRule()
+);
 ```
 
 ### XmlFilterCommand - XML要素フィルタ
 
 ```java
-import com.streamConverter.command.xml.XmlFilterCommand;
+import com.streamconverter.command.impl.xml.XmlFilterCommand;
+import com.streamconverter.path.TreePath;
 
-// 条件に一致するXML要素のみ抽出
-IStreamCommand filterCommand = new XmlFilterCommand("/root/item", element -> {
-    return Integer.parseInt(element.getAttribute("price")) > 1000;
-});
+// TreePathを使用してXML要素を抽出
+IStreamCommand filterCommand = new XmlFilterCommand(
+    new TreePath("root", "item")
+);
 ```
 
 ### ValidateCommand - XML検証
 
 ```java
-import com.streamConverter.command.xml.ValidateCommand;
+import com.streamconverter.command.impl.xml.ValidateCommand;
 
-// XMLスキーマで検証
-IStreamCommand validateCommand = new ValidateCommand(xsdInputStream);
+// XMLスキーマで検証（スキーマパスを指定）
+IStreamCommand validateCommand = new ValidateCommand("schemas/document.xsd");
 ```
 
 ## HTTP Communication
@@ -107,16 +135,21 @@ IStreamCommand validateCommand = new ValidateCommand(xsdInputStream);
 ### SendHttpCommand - HTTP リクエスト送信
 
 ```java
-import com.streamConverter.command.communication.SendHttpCommand;
+import com.streamconverter.command.impl.SendHttpCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
+import com.streamconverter.command.rule.PassThroughRule;
 
 // HTTP POSTリクエストを送信
 IStreamCommand httpCommand = new SendHttpCommand("https://api.example.com/process");
 
 // パイプライン例: CSV → HTTP API → JSON
 IStreamCommand[] pipeline = {
-    new CsvNavigateCommand("productName"),
+    new CsvNavigateCommand(new CSVPath("productName"), new PassThroughRule()),
     new SendHttpCommand("https://api.example.com/lookup"),
-    new JsonNavigateCommand("$.result")
+    new JsonNavigateCommand(new TreePath("result"), new PassThroughRule())
 };
 ```
 
@@ -125,22 +158,26 @@ IStreamCommand[] pipeline = {
 ### CharacterConvertCommand - 文字コード変換
 
 ```java
-import com.streamConverter.command.CharacterConvertCommand;
+import com.streamconverter.command.impl.charcode.CharacterConvertCommand;
 
-// Shift_JIS から UTF-8 に変換
-IStreamCommand convertCommand = new CharacterConvertCommand(
-    Charset.forName("Shift_JIS"),
-    Charset.forName("UTF-8")
-);
+// Shift_JIS から UTF-8 に変換（String パラメータを使用）
+IStreamCommand convertCommand = new CharacterConvertCommand("Shift_JIS", "UTF-8");
 ```
 
 ### LineEndingNormalizeCommand - 改行コード正規化
 
 ```java
-import com.streamConverter.command.LineEndingNormalizeCommand;
+import com.streamconverter.command.impl.LineEndingNormalizeCommand;
+import com.streamconverter.command.impl.LineEndingNormalizeCommand.LineEndingType;
 
-// 改行コードをLFに統一
-IStreamCommand normalizeCommand = new LineEndingNormalizeCommand("\n");
+// 改行コードをLFに統一（列挙型を使用）
+IStreamCommand normalizeCommand = new LineEndingNormalizeCommand(LineEndingType.UNIX);
+
+// Windowsスタイル (CRLF)
+IStreamCommand windowsCommand = new LineEndingNormalizeCommand(LineEndingType.WINDOWS);
+
+// システムデフォルト
+IStreamCommand systemCommand = new LineEndingNormalizeCommand(LineEndingType.SYSTEM_DEFAULT);
 ```
 
 ## Pipeline Patterns
@@ -148,10 +185,21 @@ IStreamCommand normalizeCommand = new LineEndingNormalizeCommand("\n");
 ### 単純なパイプライン
 
 ```java
+import com.streamconverter.StreamConverter;
+import com.streamconverter.CommandResult;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.charcode.CharacterConvertCommand;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.command.rule.PassThroughRule;
+import java.util.List;
+import java.io.InputStream;
+import java.io.OutputStream;
+
 // CSV → 変換 → 出力
 IStreamCommand[] pipeline = {
-    new CsvNavigateCommand("name"),
-    new CharacterConvertCommand(Charset.forName("Shift_JIS"), StandardCharsets.UTF_8)
+    new CsvNavigateCommand(new CSVPath("name"), new PassThroughRule()),
+    new CharacterConvertCommand("Shift_JIS", "UTF-8")
 };
 
 StreamConverter converter = StreamConverter.create(pipeline);
@@ -163,6 +211,11 @@ List<CommandResult> results = converter.run(inputStream, outputStream);
 ExecutionContext の詳細な使用方法は [Basic Usage - Context and Metrics](../quickstart/basic-usage.md#3-context-and-metrics) を参照してください。
 
 ```java
+import com.streamconverter.ExecutionContext;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.CommandResult;
+import java.util.List;
+
 // コンテキスト作成
 ExecutionContext context = ExecutionContext.builder()
     .globalContext("requestId", "REQ-12345")
@@ -177,12 +230,24 @@ List<CommandResult> results = converter.run(inputStream, outputStream);
 ### 複雑なパイプライン例
 
 ```java
+import com.streamconverter.ExecutionContext;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.SendHttpCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.json.JsonValidateCommand;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
+import com.streamconverter.command.rule.PassThroughRule;
+import java.util.UUID;
+
 // CSV → HTTP API → JSON → 検証 → 出力
 IStreamCommand[] complexPipeline = {
-    new CsvNavigateCommand("productId"),
+    new CsvNavigateCommand(new CSVPath("productId"), new PassThroughRule()),
     new SendHttpCommand("https://api.example.com/products"),
-    new JsonNavigateCommand("$.product.details"),
-    new JsonValidateCommand(schemaInputStream)
+    new JsonNavigateCommand(new TreePath("product", "details"), new PassThroughRule()),
+    JsonValidateCommand.create("schemas/product-schema.json")
 };
 
 ExecutionContext context = ExecutionContext.builder()
@@ -197,6 +262,9 @@ StreamConverter converter = StreamConverter.createWithContext(context, complexPi
 ### CommandResult を使用した結果確認
 
 ```java
+import com.streamconverter.CommandResult;
+import java.util.List;
+
 List<CommandResult> results = converter.run(inputStream, outputStream);
 
 for (CommandResult result : results) {
@@ -213,6 +281,16 @@ for (CommandResult result : results) {
 ### try-with-resources パターン
 
 ```java
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+import com.streamconverter.StreamConverter;
+import com.streamconverter.CommandResult;
+import com.streamconverter.command.IStreamCommand;
+import java.util.List;
+
 try (InputStream input = new FileInputStream("input.csv");
      OutputStream output = new FileOutputStream("output.txt")) {
 

--- a/docs/reference/COMMAND_EXAMPLES.md
+++ b/docs/reference/COMMAND_EXAMPLES.md
@@ -4,7 +4,7 @@ StreamConverter で使用できるコマンドの基本的な使用例を示し�
 
 ## CSV Commands
 
-### CsvNavigateCommand - CSV列抽出
+### CsvNavigateCommand - CSV列変換
 
 ```java
 import com.streamconverter.command.impl.csv.CsvNavigateCommand;
@@ -15,7 +15,7 @@ import com.streamconverter.StreamConverter;
 import com.streamconverter.CommandResult;
 import java.util.List;
 
-// 特定の列を抽出
+// 特定の列に変換ルールを適用（CSV構造全体を保持）
 IStreamCommand csvCommand = new CsvNavigateCommand(
     new CSVPath("productName"),
     new PassThroughRule()
@@ -25,13 +25,13 @@ StreamConverter converter = StreamConverter.create(new IStreamCommand[]{csvComma
 List<CommandResult> results = converter.run(inputStream, outputStream);
 ```
 
-### CsvFilterCommand - CSV行フィルタ
+### CsvFilterCommand - CSV列抽出
 
 ```java
 import com.streamconverter.command.impl.csv.CsvFilterCommand;
 import com.streamconverter.path.CSVPath;
 
-// 特定の列のみ抽出（ヘッダーありと仮定）
+// 特定の列のみ抽出（指定した列だけを出力、ヘッダーありと仮定）
 IStreamCommand filterCommand = CsvFilterCommand.create(new CSVPath("price"));
 
 // ヘッダーの有無を明示的に指定
@@ -56,14 +56,14 @@ IStreamCommand validateCommand2 = new CsvValidateCommand(
 
 ## JSON Commands
 
-### JsonNavigateCommand - JSON要素抽出
+### JsonNavigateCommand - JSON要素変換
 
 ```java
 import com.streamconverter.command.impl.json.JsonNavigateCommand;
 import com.streamconverter.path.TreePath;
 import com.streamconverter.command.rule.PassThroughRule;
 
-// JSONPathで要素を抽出
+// 特定の要素に変換ルールを適用（JSON構造全体を保持）
 IStreamCommand jsonCommand = new JsonNavigateCommand(
     new TreePath("user", "name"),
     new PassThroughRule()
@@ -72,13 +72,13 @@ IStreamCommand jsonCommand = new JsonNavigateCommand(
 StreamConverter converter = StreamConverter.create(new IStreamCommand[]{jsonCommand});
 ```
 
-### JsonFilterCommand - JSON要素フィルタ
+### JsonFilterCommand - JSON要素抽出
 
 ```java
 import com.streamconverter.command.impl.json.JsonFilterCommand;
 import com.streamconverter.path.TreePath;
 
-// TreePathを使用してJSON要素を抽出
+// TreePathを使用してJSON要素を抽出（指定した要素のみを出力）
 IStreamCommand filterCommand = new JsonFilterCommand(
     new TreePath("items", "0", "price")
 );
@@ -95,27 +95,27 @@ IStreamCommand validateCommand = JsonValidateCommand.create("schemas/user-schema
 
 ## XML Commands
 
-### XmlNavigateCommand - XML要素抽出
+### XmlNavigateCommand - XML要素変換
 
 ```java
 import com.streamconverter.command.impl.xml.XmlNavigateCommand;
 import com.streamconverter.path.TreePath;
 import com.streamconverter.command.rule.PassThroughRule;
 
-// TreePathでXML要素を抽出
+// 特定の要素に変換ルールを適用（XML構造全体を保持）
 IStreamCommand xmlCommand = new XmlNavigateCommand(
     new TreePath("root", "user", "name"),
     new PassThroughRule()
 );
 ```
 
-### XmlFilterCommand - XML要素フィルタ
+### XmlFilterCommand - XML要素抽出
 
 ```java
 import com.streamconverter.command.impl.xml.XmlFilterCommand;
 import com.streamconverter.path.TreePath;
 
-// TreePathを使用してXML要素を抽出
+// TreePathを使用してXML要素を抽出（指定した要素のみを出力）
 IStreamCommand filterCommand = new XmlFilterCommand(
     new TreePath("root", "item")
 );


### PR DESCRIPTION
## Summary

基本的なコマンドインスタンス化例が7箇所以上のドキュメントで重複していたため、`docs/reference/COMMAND_EXAMPLES.md` を作成して一元管理しました。

## Problem

同じコマンド例が複数のドキュメントに重複：
- ARCHITECTURE.md (3箇所)
- quickstart/basic-usage.md
- AUTO_LOGGING.md
- development/INTEGRATION_EXAMPLES.md (2箇所)
- features/RULES_CATALOG.md (2箇所)

コマンドAPIが変更された際に、すべての箇所を更新する必要がありました。

## Changes

### 新規ファイル: docs/reference/COMMAND_EXAMPLES.md

包括的なコマンド使用例リファレンスを作成：

**CSV Commands**
- CsvNavigateCommand - 列抽出
- CsvFilterCommand - 行フィルタ
- CsvValidateCommand - 検証

**JSON Commands**
- JsonNavigateCommand - 要素抽出
- JsonFilterCommand - 要素フィルタ
- JsonValidateCommand - Schema検証

**XML Commands**
- XmlNavigateCommand - 要素抽出
- XmlFilterCommand - 要素フィルタ
- ValidateCommand - 検証

**HTTP & Transformation**
- SendHttpCommand - HTTPリクエスト
- CharacterConvertCommand - 文字コード変換
- LineEndingNormalizeCommand - 改行コード正規化

**Pipeline Patterns**
- Simple Pipeline
- With ExecutionContext
- Complex Pipeline
- Error Handling

### docs/ARCHITECTURE.md

**Before** (重複したコマンド例):
```java
IStreamCommand csvCommand = new CsvNavigateCommand(new CSVPath("name"), new PassThroughRule());
IStreamCommand jsonCommand = new JsonNavigateCommand(new JSONPath("user.name"), new PassThroughRule());
IStreamCommand xmlCommand = new XmlNavigateCommand(new XPath("//user/name"), new PassThroughRule());
```

**After** (参照に置き換え):
```markdown
Commands are created directly with explicit parameters. For detailed examples, see [Command Examples](reference/COMMAND_EXAMPLES.md).

```java
// Example: CSV command
IStreamCommand csvCommand = new CsvNavigateCommand("name");
```
```

### docs/INDEX.md

新しいセクションに COMMAND_EXAMPLES.md を追加。

## Benefits

✅ **Single Source of Truth**: コマンド例の唯一の情報源  
✅ **DRY 原則**: 重複を大幅に削減  
✅ **メンテナンス性**: 更新箇所が1つに  
✅ **網羅性**: すべてのコマンドタイプを網羅  
✅ **発見性**: 一箇所で全例を確認可能

## Future Work

このPRは初期バージョンです。今後のPRで以下のドキュメントも更新予定：
- AUTO_LOGGING.md
- development/INTEGRATION_EXAMPLES.md  
- features/RULES_CATALOG.md

## Related Issues

Closes #389

Part of #388 (DRY 原則によるドキュメント整合性向上)

🤖 Generated with [Claude Code](https://claude.com/claude-code)