### PR TITLE
docs: remove Web API endpoint duplication (#397)

### DIFF
--- a/docs/development/INTEGRATION_EXAMPLES.md
+++ b/docs/development/INTEGRATION_EXAMPLES.md
@@ -65,16 +65,9 @@ logging:
 
 **実装**: `StreamProcessingController.java:1`
 
-#### エンドポイント一覧
+利用可能なエンドポイントの詳細は [WEB_API.md](../WEB_API.md#-api-エンドポイント) を参照してください。
 
-| エンドポイント | メソッド | 説明 | 実装行 |
-|---------------|---------|------|-------|
-| `/api/v1/stream/health` | GET | ヘルスチェック | `112-115` |
-| `/api/v1/stream/csv/extract` | POST | CSV列抽出 | `41-56` |
-| `/api/v1/stream/json/extract` | POST | JSONパス抽出 | `65-80` |
-| `/api/v1/stream/process` | POST | パイプライン処理 | `89-105` |
-
-#### CSV列抽出エンドポイント
+#### CSV列抽出エンドポイント実装例
 
 ```java
 @PostMapping(


### PR DESCRIPTION
## Summary

Remove duplicate Web API endpoint list from INTEGRATION_EXAMPLES.md and replace with reference to WEB_API.md as single source of truth.

## Changes

- ✅ Remove endpoint table (4 endpoints) from INTEGRATION_EXAMPLES.md
- ✅ Add reference link to WEB_API.md API エンドポイント section  
- ✅ Update section title to clarify focus on implementation examples
- ✅ Verified handbook/web-api.md already references WEB_API.md correctly

## Before/After

**Before**: Endpoint list duplicated in 3 locations:
- WEB_API.md (detailed, canonical)
- handbook/web-api.md (already referencing WEB_API.md ✅)
- development/INTEGRATION_EXAMPLES.md (duplicate ❌)

**After**: Single source of truth in WEB_API.md with all files referencing it

## Impact

- Reduces maintenance burden (updates only needed in one place)
- Prevents information drift between documents
- Aligns with DRY principle (#388)

## Related

Closes #397