### PR TITLE
docs: add base documentation references to implementation-based docs (#393)

### DIFF
--- a/docs/AUTO_LOGGING.md
+++ b/docs/AUTO_LOGGING.md
@@ -1,5 +1,10 @@
 # Auto-Logging Infrastructure
 
+## このドキュメントの基礎資料
+このドキュメントは以下の実装を基に作成されています：
+- [AbstractStreamCommand.java](../streamconverter-core/src/main/java/com/streamconverter/command/AbstractStreamCommand.java) - 基本的な実行ログ機能の実装
+- [LoggingDecorator.java](../streamconverter-core/src/main/java/com/streamconverter/command/LoggingDecorator.java) - デコレーターパターンによるログ追加機能の実装
+
 > 💡 **クイック概要**: まず [Logging Handbook](handbook/logging.md) で What/Why/How を理解することをお勧めします。
 
 StreamConverterは包括的な自動ログ出力機能を提供し、大容量ファイル処理時のトラブルシューティングとモニタリングを支援します。

--- a/docs/WEB_API.md
+++ b/docs/WEB_API.md
@@ -1,5 +1,9 @@
 # StreamConverter Web API
 
+## このドキュメントの基礎資料
+このドキュメントは以下の実装を基に作成されています：
+- [StreamProcessingController.java](../streamconverter-web/src/main/java/com/streamconverter/web/StreamProcessingController.java) - REST APIエンドポイントの実装
+
 > 💡 **クイック概要**: まず [Web API Handbook](handbook/web-api.md) で What/Why/How を理解することをお勧めします。
 
 StreamConverterの既存機能をWebAPIとして提供するRESTfulサービスです。

--- a/docs/development/INTEGRATION_EXAMPLES.md
+++ b/docs/development/INTEGRATION_EXAMPLES.md
@@ -1,5 +1,12 @@
 # StreamConverter 統合パターンと実装例
 
+## このドキュメントの基礎資料
+このドキュメントは以下の資料および実装を基に作成されています：
+- [ARCHITECTURE.md](../ARCHITECTURE.md) - アーキテクチャ設計と設計原則
+- [handbook/web-api.md](../handbook/web-api.md) - Web API概要
+- [StreamProcessingController.java](../../streamconverter-web/src/main/java/com/streamconverter/web/StreamProcessingController.java) - Spring Boot統合の実装
+- Spring Boot / Quarkus / Vert.x の公式ドキュメント
+
 > 意図と実行タイミングについて
 >
 > - 目的: ここに掲載する例は、コマンド/ルールの組み合わせや入出力の流れを理解するための学習・動作確認用です。性能比較や厳密な仕様検証は目的にしていません。

--- a/docs/features/RULES_CATALOG.md
+++ b/docs/features/RULES_CATALOG.md
@@ -1,5 +1,10 @@
 # Rules Catalog and Usage Examples
 
+## このドキュメントの基礎資料
+このドキュメントは以下の実装を基に作成されています：
+- [com.streamconverter.command.rule.impl](../../streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/) - 変換ルールの実装
+- [IRule.java](../../streamconverter-core/src/main/java/com/streamconverter/command/rule/IRule.java) - ルールインターフェース
+
 This catalog lists currently implemented transformation rules in StreamConverter core and shows concise usage examples. It focuses on rules that are already available so teams can apply them consistently.
 
 ## Implemented Rules


### PR DESCRIPTION
## Summary

Add 'このドキュメントの基礎資料' sections to implementation-based reference documents, establishing implementation code as the primary source of truth.

## Changes

Added base documentation sections to 4 files:

### ✅ AUTO_LOGGING.md
- Links to AbstractStreamCommand.java (基本的な実行ログ機能)
- Links to LoggingDecorator.java (デコレーターパターンによるログ追加)

### ✅ WEB_API.md  
- Links to StreamProcessingController.java (REST APIエンドポイント実装)

### ✅ features/RULES_CATALOG.md
- Links to com.streamconverter.command.rule.impl package (変換ルール実装)
- Links to IRule.java (ルールインターフェース)

### ✅ development/INTEGRATION_EXAMPLES.md
- Links to ARCHITECTURE.md (アーキテクチャ設計)
- Links to handbook/web-api.md (Web API概要)
- Links to StreamProcessingController.java (実装)
- References Spring Boot/Quarkus/Vert.x official docs

## Document Classification Policy

Following user guidance, this PR treats implementation-based reference documents as secondary sources derived from implementation code:

- **Design documents** → Link to conceptual/design docs
- **Reference documents** → Link to implementation code (primary source)

## Pattern Consistency

This extends the pattern established in PR #387 (8 files) to cover implementation-based documentation (4 additional files).

**Before**: 8/33 documents had base documentation sections (24%)  
**After**: 12/33 documents have base documentation sections (36%)

## Benefits

- Clear traceability from documentation to implementation
- Users can verify examples against actual code
- Easier to maintain when implementation changes
- Aligns with DRY principle (#388)

## Related

Closes #393  
Part of #388 (DRY principle meta-issue)