### PR TITLE
docs: establish build.gradle.kts as single source of truth for version (#398)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Version**: 0.0.0（開発中） &nbsp;|&nbsp; Java 21 &nbsp;|&nbsp; [📚 完全なドキュメント一覧](docs/INDEX.md) &nbsp;|&nbsp; [📖 クイックスタート](docs/README.md) &nbsp;|&nbsp; [🔗 API Javadoc](https://3211133.github.io/StreamConverter/)
 
-> 💡 **Version Info**: Defined in [build.gradle.kts](build.gradle.kts). See [VERSION_MANAGEMENT.md](docs/reference/VERSION_MANAGEMENT.md) for version history and policy.
+> 💡 **Version Info**: Authoritative version is defined in [build.gradle.kts](build.gradle.kts) (search for `version = "`). The version displayed above is for visibility and requires manual update when releasing. See [VERSION_MANAGEMENT.md](docs/reference/VERSION_MANAGEMENT.md) for version history and policy.
 
 大容量ファイルをストリームで処理するための Java ライブラリ/ツールキットです。パイプライン化された `IStreamCommand` を組み合わせて、
 文字コード変換・CSV/JSON/XML ナビゲーション・HTTP 連携・バリデーションなどをメモリ効率良く実行できます。

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Version**: 0.0.0（開発中） &nbsp;|&nbsp; Java 21 &nbsp;|&nbsp; [📚 完全なドキュメント一覧](docs/INDEX.md) &nbsp;|&nbsp; [📖 クイックスタート](docs/README.md) &nbsp;|&nbsp; [🔗 API Javadoc](https://3211133.github.io/StreamConverter/)
 
+> 💡 **Version Info**: Defined in [build.gradle.kts](build.gradle.kts). See [VERSION_MANAGEMENT.md](docs/reference/VERSION_MANAGEMENT.md) for version history and policy.
+
 大容量ファイルをストリームで処理するための Java ライブラリ/ツールキットです。パイプライン化された `IStreamCommand` を組み合わせて、
 文字コード変換・CSV/JSON/XML ナビゲーション・HTTP 連携・バリデーションなどをメモリ効率良く実行できます。
 

--- a/docs/reference/VERSION_MANAGEMENT.md
+++ b/docs/reference/VERSION_MANAGEMENT.md
@@ -1,10 +1,14 @@
 # Version Management
 
 ## Current Version
-- **Version**: 0.0.0 (in development)
+
+For the current version, see [build.gradle.kts](../../build.gradle.kts) (search for `version = "`).
+
 - **Status**: Pre-release Development
 - **Java**: 21+
 - **Gradle**: 8.13
+
+> 💡 **Note**: The authoritative version number is defined in `build.gradle.kts`. Documentation references this file to avoid version inconsistencies.
 
 ## Supported Versions
 


### PR DESCRIPTION
## Summary

Establish `build.gradle.kts` as the single source of truth for version information, reducing duplication and preventing version inconsistencies.

## Changes

### ✅ VERSION_MANAGEMENT.md
- **Before**: Hardcoded "Version: 0.0.0"
- **After**: References `build.gradle.kts` with clear note about authoritative source
- Added guidance: "search for \`version = \"\`"

### ✅ README.md
- **Before**: Version displayed but no reference to source
- **After**: Added note linking to `build.gradle.kts` and `VERSION_MANAGEMENT.md`
- Keeps version display for visibility (manual update still needed)

### ✅ CLAUDE.md
- Already cleaned in PR #401 (no version info)

## Version Management Before/After

### Before (Duplicated in 3+ places)
```
build.gradle.kts  →  version = "0.0.0"
README.md         →  Version: 0.0.0
VERSION_MANAGEMENT.md → Version: 0.0.0
CLAUDE.md         →  Version: 1.2.0 (incorrect!)
```
**Problem**: Manual updates required in multiple files, risk of drift

### After (Single Source of Truth)
```
build.gradle.kts  →  version = "0.0.0" (AUTHORITATIVE)
README.md         →  Version: 0.0.0 + link to build.gradle.kts
VERSION_MANAGEMENT.md → References build.gradle.kts
CLAUDE.md         →  No version info
```
**Benefit**: Clear authority, fewer update points

## Future Version Update Workflow

When releasing a new version:

1. **Update `build.gradle.kts`**: Change `version = "x.y.z"`
2. **Update `README.md`**: Update display version (for visibility)
3. **Update `VERSION_MANAGEMENT.md`**: Add version history entry

Manual updates reduced from 3+ files to 2 files.

## Benefits

✅ **Prevents inconsistencies**: Clear authoritative source  
✅ **Reduces maintenance**: Fewer places to update  
✅ **Aligns with DRY**: Don't Repeat Yourself principle  
✅ **Foundation for automation**: Future GitHub Actions can auto-update README.md

## Phase 1 Complete

This PR implements **Phase 1** of issue #398. Future work:
- **Phase 2**: Add GitHub Actions to auto-update README.md when build.gradle.kts changes
- **Phase 3**: Add version badge to README.md
- **Phase 4**: Auto-create PR when version changes

## Related

Addresses #398  
Part of #388 (DRY principle meta-issue)