### PR TITLE
docs: remove version number from README to follow DRY principle (#398)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # StreamConverter
 
-**Version**: 0.0.0（開発中） &nbsp;|&nbsp; Java 21 &nbsp;|&nbsp; [📚 完全なドキュメント一覧](docs/INDEX.md) &nbsp;|&nbsp; [📖 クイックスタート](docs/README.md) &nbsp;|&nbsp; [🔗 API Javadoc](https://3211133.github.io/StreamConverter/)
-
-> 💡 **Version Info**: Authoritative version is defined in [build.gradle.kts](build.gradle.kts) (search for `version = "`). The version displayed above is for visibility and requires manual update when releasing. See [VERSION_MANAGEMENT.md](docs/reference/VERSION_MANAGEMENT.md) for version history and policy.
+Java 21 &nbsp;|&nbsp; [📚 完全なドキュメント一覧](docs/INDEX.md) &nbsp;|&nbsp; [📖 クイックスタート](docs/README.md) &nbsp;|&nbsp; [🔗 API Javadoc](https://3211133.github.io/StreamConverter/)
 
 大容量ファイルをストリームで処理するための Java ライブラリ/ツールキットです。パイプライン化された `IStreamCommand` を組み合わせて、
 文字コード変換・CSV/JSON/XML ナビゲーション・HTTP 連携・バリデーションなどをメモリ効率良く実行できます。
+
+> 💡 **Version**: See [build.gradle.kts](build.gradle.kts) or [VERSION_MANAGEMENT.md](docs/reference/VERSION_MANAGEMENT.md) for current version.
 
 ---
 


### PR DESCRIPTION
## Summary

README.mdからバージョン番号を削除し、真のDRY原則に従うようにしました。

## Changes

README.mdヘッダーからハードコードされたバージョン番号を削除しました。

### Before
```markdown
**Version**: 0.0.0（開発中） &nbsp;|&nbsp; Java 21 &nbsp;|&nbsp; ...

> 💡 **Version Info**: Authoritative version is defined in [build.gradle.kts]...
```
- バージョン番号がREADME.mdに表示
- バージョン変更時に手動更新が必要
- 複数箇所に存在（README.md, build.gradle.kts, VERSION_MANAGEMENT.md）

### After
```markdown
Java 21 &nbsp;|&nbsp; [📚 完全なドキュメント一覧](docs/INDEX.md) &nbsp;|&nbsp; ...

> 💡 **Version**: See [build.gradle.kts] or [VERSION_MANAGEMENT.md] for current version.
```
- README.mdヘッダーからバージョン番号を削除
- 単一の情報源：build.gradle.kts
- 必要な読者のためのシンプルな参照リンク

## Rationale

Issue #398の議論で指摘された通り：
- **バージョン情報はREADME読者にとって必須ではない**
- 複数箇所にバージョンを持つことはDRY原則違反
- バージョン同期のための自動化（sed、CI/CD）自体がDRY違反
- 真のDRYとは、情報を正確に1箇所だけに持つこと

バージョン情報は以下で引き続き利用可能：
- build.gradle.kts（権威ある情報源）
- docs/reference/VERSION_MANAGEMENT.md（バージョン履歴とポリシー）

## Test Plan

- ✅ README.md renders correctly on GitHub
- ✅ Version links work correctly
- ✅ All builds pass
- ✅ No broken references

## Resolves

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)