### PR TITLE
feat: add @FunctionalInterface annotations to core interfaces

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/IStreamCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/IStreamCommand.java
@@ -25,7 +25,10 @@ import java.io.OutputStream;
  * <p>Usage examples:
  *
  * <pre>{@code
+ * // Simple copy operation (IOException is propagated from execute method signature)
  * IStreamCommand copyCommand = (in, out) -> in.transferTo(out);
+ *
+ * // Buffered stream processing with custom logic
  * IStreamCommand bufferCommand = (in, out) -> {
  *     byte[] buffer = new byte[8192];
  *     int len;
@@ -33,6 +36,10 @@ import java.io.OutputStream;
  *         out.write(buffer, 0, len);
  *     }
  * };
+ *
+ * // Using in StreamConverter pipeline
+ * StreamConverter converter = StreamConverter.create(copyCommand);
+ * converter.run(inputStream, outputStream);
  * }</pre>
  */
 @FunctionalInterface

--- a/streamconverter-core/src/main/java/com/streamconverter/command/IStreamCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/IStreamCommand.java
@@ -18,7 +18,24 @@ import java.io.OutputStream;
  *   <li>Basic commands: Implement only the 2-parameter execute method
  *   <li>Context-aware commands: Override the 3-parameter execute method for enhanced functionality
  * </ul>
+ *
+ * <p>This is a functional interface and can be implemented using lambda expressions or method
+ * references for simple stream processing operations.
+ *
+ * <p>Usage examples:
+ *
+ * <pre>{@code
+ * IStreamCommand copyCommand = (in, out) -> in.transferTo(out);
+ * IStreamCommand bufferCommand = (in, out) -> {
+ *     byte[] buffer = new byte[8192];
+ *     int len;
+ *     while ((len = in.read(buffer)) != -1) {
+ *         out.write(buffer, 0, len);
+ *     }
+ * };
+ * }</pre>
  */
+@FunctionalInterface
 public interface IStreamCommand {
 
   /**

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/IRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/IRule.java
@@ -11,8 +11,19 @@ package com.streamconverter.command.rule;
  * <p>使用例:
  *
  * <pre>{@code
+ * // 単純な変換ルール
  * IRule upperCaseRule = input -> input.toUpperCase();
  * IRule trimRule = String::trim;
+ *
+ * // 複合ルール（トリムして大文字に変換）
+ * IRule trimAndUpperCase = input -> input.trim().toUpperCase();
+ *
+ * // StreamConverterコマンドでの使用例
+ * IRule dataCleaningRule = input -> input.trim().replaceAll("\\s+", " ");
+ * JsonNavigateCommand command = JsonNavigateCommand.create(
+ *     TreePath.fromJson("$.user.name"),
+ *     dataCleaningRule
+ * );
  * }</pre>
  */
 @FunctionalInterface

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/IRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/IRule.java
@@ -5,7 +5,17 @@ package com.streamconverter.command.rule;
  *
  * <p>このインターフェースは、ストリーム変換のルールを定義するためのものです。 具体的なルールはこのインターフェースを実装するクラスで定義されます。
  * ルールは、ストリーム変換の際に適用される条件や処理を定義します。
+ *
+ * <p>このインターフェースは関数型インターフェースです。ラムダ式やメソッド参照で実装できます。
+ *
+ * <p>使用例:
+ *
+ * <pre>{@code
+ * IRule upperCaseRule = input -> input.toUpperCase();
+ * IRule trimRule = String::trim;
+ * }</pre>
  */
+@FunctionalInterface
 public interface IRule {
 
   /**

--- a/streamconverter-core/src/main/java/com/streamconverter/path/IPath.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/path/IPath.java
@@ -7,8 +7,18 @@ package com.streamconverter.path;
  *
  * <p>Don't Ask, Tell原則に従い、パス一致判定のみに特化した設計です。
  *
+ * <p>このインターフェースは関数型インターフェースです。ラムダ式やメソッド参照で実装できます。
+ *
+ * <p>使用例:
+ *
+ * <pre>{@code
+ * IPath<JsonNode> rootPath = node -> node.isRoot();
+ * IPath<Integer> evenColumnPath = col -> col % 2 == 0;
+ * }</pre>
+ *
  * @param <T> コンテキスト型（TreePath=JsonNode, TreePath=List&lt;String&gt;, CSVPath=Integer）
  */
+@FunctionalInterface
 public interface IPath<T> {
 
   /**


### PR DESCRIPTION
## Summary
Add `@FunctionalInterface` annotations to three core interfaces to enable lambda expressions and method references for simpler implementations.

## Changes

### IRule (#431)
- Added `@FunctionalInterface` annotation
- Added lambda usage examples in Javadoc
- Examples: `input -> input.toUpperCase()`, `String::trim`

### IPath<T> (#432)
- Added `@FunctionalInterface` annotation  
- Added lambda usage examples in Javadoc
- Examples: `node -> node.isRoot()`, `col -> col % 2 == 0`

### IStreamCommand (#433)
- Added `@FunctionalInterface` annotation
- Added lambda usage examples in Javadoc
- Examples: `(in, out) -> in.transferTo(out)`, buffered stream processing

## Benefits
✅ **Lambda expressions** - Concise implementation for simple use cases  
✅ **Method references** - Even more concise when applicable  
✅ **Compile-time validation** - Ensures interface remains functional  
✅ **Better documentation** - Usage examples in Javadoc  
✅ **Backward compatible** - Existing implementations continue to work

## Usage Examples

### Before (verbose)
```java
IRule upperCaseRule = new IRule() {
    @Override
    public String apply(String input) {
        return input.toUpperCase();
    }
};
```

### After (concise)
```java
IRule upperCaseRule = input -> input.toUpperCase();
IRule trimRule = String::trim;
```

## Test Results
✅ All builds successful  
✅ All tests passing (242 tests)  
✅ Pre-commit hooks passing

## Closes
Closes #431  
Closes #432  
Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)