### PR TITLE
fix(security): apply XXE protection to XmlNavigateCommand and XmlFilterCommand

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/ConvertCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/ConvertCommand.java
@@ -4,6 +4,7 @@ import com.streamconverter.StreamProcessingException;
 import com.streamconverter.command.AbstractStreamCommand;
 import com.streamconverter.command.rule.IRule;
 import com.streamconverter.path.TreePath;
+import com.streamconverter.security.SecureXmlConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -60,7 +61,7 @@ public class ConvertCommand extends AbstractStreamCommand {
     // StaXを使用したXML変換処理を実装する
     // ここでは、IRuleを使用して変換処理を行うことを想定しています。
     // 例: XMLを読み込み、IRuleを適用して変換し、出力ストリームに書き込む処理を実装する
-    XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+    XMLInputFactory xmlInputFactory = SecureXmlConfiguration.createSecureXMLInputFactory();
     XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
 
     try {

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
@@ -2,6 +2,7 @@ package com.streamconverter.command.impl.xml;
 
 import com.streamconverter.command.AbstractStreamCommand;
 import com.streamconverter.path.IPath;
+import com.streamconverter.security.SecureXmlConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -59,9 +60,7 @@ public class XmlFilterCommand extends AbstractStreamCommand {
       throws IOException {
     try (Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
 
-      XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-      inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-      inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+      XMLInputFactory inputFactory = SecureXmlConfiguration.createSecureXMLInputFactory();
 
       List<String> extractedElements = new ArrayList<>();
 

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
@@ -3,6 +3,7 @@ package com.streamconverter.command.impl.xml;
 import com.streamconverter.command.AbstractStreamCommand;
 import com.streamconverter.command.rule.IRule;
 import com.streamconverter.path.TreePath;
+import com.streamconverter.security.SecureXmlConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -149,7 +150,7 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
 
   // Common factory methods and utilities
   private XMLEventReader createXMLEventReader(InputStream inputStream) throws XMLStreamException {
-    XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+    XMLInputFactory inputFactory = SecureXmlConfiguration.createSecureXMLInputFactory();
     XMLEventReader reader = inputFactory.createXMLEventReader(inputStream);
     if (!reader.hasNext()) {
       throw new XMLStreamException("Empty XML input");


### PR DESCRIPTION
## Summary

- XmlNavigateCommand: Use `SecureXmlConfiguration.createSecureXMLInputFactory()` instead of `XMLInputFactory.newInstance()`
- XmlFilterCommand: Replace manual XXE settings with `SecureXmlConfiguration`

## Changes

| File | Before | After |
|------|--------|-------|
| XmlNavigateCommand | `XMLInputFactory.newInstance()` (no XXE protection) | `SecureXmlConfiguration.createSecureXMLInputFactory()` |
| XmlFilterCommand | Manual 2-property setting | `SecureXmlConfiguration.createSecureXMLInputFactory()` |

## Security

`SecureXmlConfiguration.createSecureXMLInputFactory()` provides:
- `IS_SUPPORTING_EXTERNAL_ENTITIES = false`
- `SUPPORT_DTD = false`
- `IS_REPLACING_ENTITY_REFERENCES = false`
- `IS_VALIDATING = false`

This ensures consistent XXE protection across all XML commands.

## Test plan

- [x] `./gradlew :streamconverter-core:test` passes
- [x] XmlNavigateCommand tests pass
- [x] XmlFilterCommand tests pass

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)