### PR TITLE
fix(mdc): MDCスレッド間同期処理の完全実装

### DIFF
--- a/docs/reports/CONTEXT_PROPAGATION_ARCHITECTURE.md
+++ b/docs/reports/CONTEXT_PROPAGATION_ARCHITECTURE.md
@@ -162,19 +162,43 @@ XmlNavigateCommand extractUserId = new XmlNavigateCommand(
 - **共有コンテキストは全スレッドで共有（ConcurrentHashMap使用）**
 - **各スレッドのThreadLocalに同じExecutionContextが設定される**
 - **TurboFilterが各スレッドで独立してMDCに同期**
+- **親スレッドのMDC状態が子スレッドに伝播（captureParentMDC）**
+- **子スレッド終了後、共有コンテキストが親スレッドのMDCに同期（syncSharedContextToParentMDC）**
 ```
 
-**マルチスレッドでの共有コンテキストの動作**:
+**MDCスレッド間同期の詳細フロー（2026年1月最新）**:
 ```
-Thread 1: XmlNavigateCommand実行
-  → userId抽出 → 共有コンテキストに設定
-  → ログ出力時にTurboFilterがMDCに同期
+親スレッド（HTTPリクエスト処理）:
+  MDC.put("requestId", "REQ-123")  ← 業務固有の値を設定
+  ↓
+  StreamConverter.run()開始
+    context.applyToMDCWithStage("pipeline-start")  ← 基本情報をMDCに設定
+    context.captureParentMDC()  ← 親のMDC状態をキャプチャ（★重要）
+  ↓
+  子スレッド1: XmlNavigateCommand実行
+    context.applyToMDCWithStage(...)  ← 親のMDC値も一緒に適用される
+    → requestId="REQ-123" がMDCに設定される（親から継承）
+    → userId抽出 → context.setSharedContext("userId", "USER456")
+    → ログ出力時にTurboFilterがMDCに同期
+  ↓
+  子スレッド2: XmlDebugCommand実行（並行）
+    context.applyToMDCWithStage(...)  ← 親のMDC値も一緒に適用される
+    → requestId="REQ-123" がMDCに設定される（親から継承）
+    → 共有コンテキストからuserId取得可能
+    → ログ出力時にTurboFilterがMDCに同期
+    → Thread 1が設定したuserIdもログに出力される
+  ↓
+  全子スレッド完了
+    context.syncSharedContextToParentMDC()  ← 共有コンテキストを親MDCに同期（★重要）
+  ↓
+親スレッド（処理完了後）:
+  LOG.info("Completed...")  ← userId="USER456" がログに出力される
+```
 
-Thread 2: XmlDebugCommand実行（並行）
-  → 共有コンテキストからuserId取得可能
-  → ログ出力時にTurboFilterがMDCに同期
-  → Thread 1が設定したuserIdがログに出力される
-```
+**3つのMDC同期ポイント**:
+1. **親→子の伝播**: `captureParentMDC()` - 親スレッドで`MDC.put()`された値を子に引き継ぐ
+2. **子間の共有**: `setSharedContext()` + `TurboFilter` - ConcurrentHashMap経由で即座に共有
+3. **子→親の同期**: `syncSharedContextToParentMDC()` - 子終了後に親のMDCに反映
 
 ## 実装例
 

--- a/docs/reports/MDC_THREAD_SYNC_FIX_2026_01.md
+++ b/docs/reports/MDC_THREAD_SYNC_FIX_2026_01.md
@@ -1,0 +1,360 @@
+# MDCスレッド間同期処理の修正報告
+
+## 修正日
+2026年1月3日
+
+## 問題の概要
+
+StreamConverterの並列実行アーキテクチャにおいて、MDC（Mapped Diagnostic Context）のスレッド間同期に以下の問題がありました:
+
+### 修正前の状態
+
+| 同期方向 | 状態 | 説明 |
+|---------|------|------|
+| 親→子 | ❌ 不完全 | 親スレッドで`MDC.put()`した値が子スレッドに伝播しない |
+| 子→他の子 | ⚠️ 部分的 | `sharedContext`経由で共有可能だが、TurboFilterのログ出力時のみ同期 |
+| 子→親 | ❌ 未実装 | 子スレッド終了後、親スレッドのMDCに反映されない |
+
+### 問題の詳細
+
+#### 1. 親→子の伝播問題
+```java
+// 親スレッド（例：HTTPリクエストハンドラ）
+MDC.put("requestId", "REQ-123");
+MDC.put("userId", "USER-ABC");
+
+StreamConverter.run(input, output);  // 子スレッドでCommand実行
+// → 子スレッドのログにrequestIdやuserIdが出力されない
+```
+
+**原因**: `ExecutionContext`は自身が管理する値（executionId等）のみをMDCに適用しており、親スレッドで直接`MDC.put()`された業務固有の値は子スレッドに引き継がれていなかった。
+
+#### 2. 子→親の同期問題
+```java
+// 子スレッド（XmlNavigateCommand内）
+context.setSharedContext("extractedUserId", "USER-EXTRACTED-456");
+
+// 親スレッド（StreamConverter.run()完了後）
+LOG.info("Processing completed");
+// → extractedUserIdがログに出力されない
+```
+
+**原因**: 子スレッドが`sharedContext`に設定した値は`ConcurrentHashMap`に保存されるが、親スレッドのMDCには自動的に同期されていなかった。
+
+## 実装した修正
+
+### 1. ExecutionContextへの機能追加
+
+#### 1.1 親MDC状態の保持フィールド追加
+```java
+/**
+ * 親スレッドから受け継いだMDC値を保持
+ */
+private final ConcurrentHashMap<String, String> parentMdcContext;
+```
+
+#### 1.2 親MDCキャプチャメソッド追加
+```java
+/**
+ * 親スレッドの現在のMDC状態をキャプチャ
+ *
+ * 子スレッド生成前に呼び出して、親スレッドで設定されたMDC値を保存します。
+ * ExecutionContextが管理するキー（executionId等）は除外します。
+ */
+public void captureParentMDC() {
+    Map<String, String> currentMdc = MDC.getCopyOfContextMap();
+    if (currentMdc != null) {
+        currentMdc.entrySet().stream()
+            .filter(e -> !e.getKey().equals(EXECUTION_ID_KEY)
+                      && !e.getKey().equals(START_TIME_KEY)
+                      && !e.getKey().equals(COMMAND_SEQUENCE_KEY)
+                      && !e.getKey().equals(THREAD_NAME_KEY)
+                      && !e.getKey().equals(STAGE_KEY))
+            .forEach(e -> parentMdcContext.put(e.getKey(), e.getValue()));
+    }
+}
+```
+
+#### 1.3 親への同期メソッド追加
+```java
+/**
+ * 子スレッドの共有コンテキストを親スレッドのMDCに同期
+ *
+ * 子スレッド終了後に親スレッドで呼び出すことで、
+ * 子スレッドが設定した共有コンテキストの値を親スレッドのMDCにも反映します。
+ */
+public void syncSharedContextToParentMDC() {
+    sharedContext.forEach(MDC::put);
+}
+```
+
+#### 1.4 applyToMDC()の修正
+```java
+public void applyToMDC() {
+    // 親スレッドから受け継いだMDC値を最初に設定
+    // これにより、親スレッドでMDC.put()された値が子スレッドにも反映される
+    parentMdcContext.forEach(MDC::put);
+
+    // 基本的なコンテキスト情報をMDCに設定
+    MDC.put(EXECUTION_ID_KEY, executionId);
+    MDC.put(START_TIME_KEY, startTime.toString());
+    // ... (以下既存のコード)
+}
+```
+
+### 2. StreamConverterの修正
+
+#### 2.1 親MDCキャプチャの追加
+```java
+public List<CommandResult> run(
+    InputStream inputStream, OutputStream outputStream, ExecutionContext context)
+    throws IOException {
+
+    context.applyToMDCWithStage("pipeline-start");
+
+    // ★修正: 親スレッドのMDC状態をキャプチャ
+    context.captureParentMDC();
+
+    LOG.info("Starting StreamConverter...");
+
+    List<CommandResult> results = executeMultipleCommandsWithMDC(...);
+
+    // ★修正: 子スレッドの共有コンテキストを親MDCに同期
+    context.syncSharedContextToParentMDC();
+
+    LOG.info("Completed StreamConverter pipeline");
+
+    return results;
+}
+```
+
+## テストによる検証
+
+### テストクラス
+`com.streamconverter.context.MDCThreadSynchronizationTest`
+
+### 検証シナリオ
+
+#### Test 1: 親→子のMDC伝播
+```java
+@Test
+void testParentMDCPropagationToChildThreads() {
+    // 親スレッドでMDC設定
+    MDC.put("requestId", "REQ-PARENT-123");
+    MDC.put("userId", "PARENT_USER");
+
+    // StreamConverter実行
+    converter.run(input, output);
+
+    // 検証: 子スレッドが親のMDC値を受け取っている
+    assertEquals("REQ-PARENT-123", childMdcValues.get("requestId"));
+    assertEquals("PARENT_USER", childMdcValues.get("userId"));
+}
+```
+**結果**: ✅ PASSED
+
+#### Test 2: 子スレッド間のsharedContext同期
+```java
+@Test
+void testChildSharedContextSynchronizationAcrossThreads() {
+    // Command1がsharedContextに値を設定
+    ctx.setSharedContext("userId", "USER_FROM_CMD1");
+
+    // Command2が同じsharedContextから値を取得
+    String userId = ctx.getSharedContext("userId");
+
+    // 検証: Command2がCommand1の値を取得できる
+    assertEquals("USER_FROM_CMD1", observedUserIds.get(0));
+}
+```
+**結果**: ✅ PASSED
+
+#### Test 3: 子→親のMDC同期
+```java
+@Test
+void testChildSharedContextSynchronizationToParentAfterCompletion() {
+    // 子スレッドでsharedContext設定
+    ctx.setSharedContext("extractedUserId", "USER_EXTRACTED_123");
+
+    // StreamConverter実行
+    converter.run(input, output);
+
+    // 検証: 親スレッドのMDCに反映されている
+    assertEquals("USER_EXTRACTED_123", MDC.get("extractedUserId"));
+}
+```
+**結果**: ✅ PASSED
+
+#### Test 4: 統合シナリオ
+```java
+@Test
+void testIntegratedMDCSynchronizationScenario() {
+    // 親でMDC設定
+    MDC.put("requestId", "REQ-INTEGRATED-001");
+
+    // Command1: 親のrequestIdを参照してuserIdを抽出
+    // Command2: 親のrequestIdとCommand1のuserIdを参照
+
+    converter.run(input, output);
+
+    // 検証:
+    // 1. Command1が親のrequestIdを参照できた
+    // 2. Command2が親のrequestIdとCommand1のuserIdを参照できた
+    // 3. 親がCommand1のuserIdを参照できる
+    assertEquals("USER_EXTRACTED_456", MDC.get("userId"));
+}
+```
+**結果**: ✅ PASSED
+
+### 全テスト結果
+```
+Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
+```
+
+## 修正後の動作フロー
+
+### 完全な同期フロー
+```
+親スレッド（HTTPリクエスト処理）:
+  MDC.put("requestId", "REQ-123")  ← 業務固有の値を設定
+  ↓
+StreamConverter.run()開始
+  context.applyToMDCWithStage("pipeline-start")
+  context.captureParentMDC()  ← ★親のMDC状態をキャプチャ
+  ↓
+子スレッド1: XmlNavigateCommand
+  context.applyToMDCWithStage(...)
+  → parentMdcContext.forEach(MDC::put)  ← ★親のMDC値を適用
+  → LOG.info(...)  ← requestId="REQ-123" が出力される
+  → XMLからuserId抽出
+  → context.setSharedContext("userId", "USER456")
+  ↓
+子スレッド2: XmlDebugCommand（並行実行）
+  context.applyToMDCWithStage(...)
+  → parentMdcContext.forEach(MDC::put)  ← ★親のMDC値を適用
+  → sharedContext.get("userId")  ← Command1が設定した値を取得
+  → LOG.info(...)  ← requestId="REQ-123", userId="USER456" が出力
+  ↓
+全子スレッド完了
+  context.syncSharedContextToParentMDC()  ← ★共有コンテキストを親MDCに同期
+  ↓
+親スレッド（処理完了後）:
+  LOG.info("Completed...")  ← userId="USER456" が出力される
+```
+
+### 3つの同期ポイント
+
+| No | 同期方向 | メソッド | タイミング | 用途 |
+|----|---------|---------|-----------|------|
+| 1 | 親→子 | `captureParentMDC()` | 子スレッド生成前 | 親スレッドで`MDC.put()`された業務固有の値を子に引き継ぐ |
+| 2 | 子→子 | `setSharedContext()` + `TurboFilter` | 実行中随時 | ConcurrentHashMap経由で並列スレッド間で即座に共有 |
+| 3 | 子→親 | `syncSharedContextToParentMDC()` | 全子スレッド完了後 | 子が抽出/設定した値を親のMDCに反映 |
+
+## ユースケース例
+
+### ケース1: HTTPリクエストの処理
+```java
+// 親スレッド（例: Spring ControllerやServlet）
+MDC.put("requestId", UUID.randomUUID().toString());
+MDC.put("userId", SecurityContextHolder.getContext().getAuthentication().getName());
+
+ExecutionContext context = ExecutionContext.create();
+
+// XMLからトランザクションIDを抽出してMDCに設定
+XmlNavigateCommand extractTxId = new XmlNavigateCommand(
+    TreePath.fromXml("transaction/id"),
+    new MdcSetupRule(context, "transactionId")
+);
+
+// 後続のコマンドは自動的にrequestId, userId, transactionIdを参照可能
+StreamConverter.createWithContext(context,
+    extractTxId,
+    validationCommand,
+    processingCommand)
+    .run(request.getInputStream(), response.getOutputStream());
+
+// StreamConverter完了後、親スレッドでもtransactionIdが参照可能
+LOG.info("Transaction completed: {}", MDC.get("transactionId"));
+```
+
+**ログ出力例**:
+```
+2026-01-03 14:30:00 INFO  [requestId:a1b2c3d4] [userId:john.doe] - Starting StreamConverter...
+2026-01-03 14:30:00 INFO  [requestId:a1b2c3d4] [userId:john.doe] [stage:XmlNavigateCommand-1] - Extracting transactionId
+2026-01-03 14:30:00 INFO  [requestId:a1b2c3d4] [userId:john.doe] [transactionId:TXN-9876] [stage:ValidationCommand-2] - Validating transaction
+2026-01-03 14:30:01 INFO  [requestId:a1b2c3d4] [userId:john.doe] [transactionId:TXN-9876] - Transaction completed
+```
+
+## 設計原則の遵守
+
+### MDCはloggingでのみ使用
+- MDCは**ログ出力の装飾のみ**に使用
+- 他の処理ロジックの制御や連携には使用しない
+- `sharedContext`は業務ロジックで使用可能（例：抽出した値の保持）
+- MDCは`sharedContext`のログ出力用のビューとして機能
+
+### スレッド安全性
+- `ConcurrentHashMap`によるロックフリーなアクセス
+- 各スレッドのMDCは独立（ThreadLocal）
+- TurboFilterによる自動同期で明示的なロック不要
+
+## 後方互換性
+
+### 既存コードへの影響
+- ✅ 既存のテストは全て成功（後方互換性を維持）
+- ✅ 既存のAPIは変更なし
+- ✅ 既存の`ExecutionContext`使用コードは修正不要
+
+### 新機能の利用
+新機能は自動的に有効化されるため、既存コードの変更は不要:
+```java
+// 既存コード（そのまま動作）
+StreamConverter.createWithContext(context, command1, command2)
+    .run(input, output);
+
+// 新機能が自動的に適用される:
+// - 親MDCの自動キャプチャ
+// - 子への自動伝播
+// - 親への自動同期
+```
+
+## まとめ
+
+### 修正により実現したこと
+
+| 要件 | 修正前 | 修正後 |
+|------|-------|--------|
+| 親MDC.put → 子スレッドに伝播 | ❌ | ✅ |
+| 子setSharedContext → 他の子に同期 | ⚠️ | ✅ |
+| 子終了時 → 親スレッドに同期 | ❌ | ✅ |
+| 業務上の同一性を保証 | ❌ | ✅ |
+| MDCはloggingのみ使用 | ✅ | ✅ |
+
+### 修正ファイル
+
+1. **ExecutionContext.java**
+   - `parentMdcContext`フィールド追加
+   - `captureParentMDC()`メソッド追加
+   - `syncSharedContextToParentMDC()`メソッド追加
+   - `applyToMDC()`修正
+
+2. **StreamConverter.java**
+   - `run()`メソッドに`captureParentMDC()`呼び出し追加
+   - `run()`メソッドに`syncSharedContextToParentMDC()`呼び出し追加
+
+3. **MDCThreadSynchronizationTest.java** (新規)
+   - 4つの包括的なテストシナリオ
+
+4. **CONTEXT_PROPAGATION_ARCHITECTURE.md**
+   - 最新の同期フロー追記
+
+### テスト結果
+- 新規テスト: 4/4 成功
+- 既存テスト: 全て成功（後方互換性確認）
+
+### 設計品質
+- ✅ MDCはloggingでのみ使用（設計原則遵守）
+- ✅ スレッド安全性確保（ConcurrentHashMap使用）
+- ✅ 後方互換性維持
+- ✅ 明示的で理解しやすいAPI設計
+- ✅ 包括的なテストカバレッジ

--- a/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
@@ -200,6 +200,10 @@ public class StreamConverter {
     // パイプライン開始時にMDCコンテキストを設定
     context.applyToMDCWithStage("pipeline-start");
 
+    // 親スレッドの現在のMDC状態をキャプチャ
+    // これにより、親スレッドで直接MDC.put()された値も子スレッドに伝播される
+    context.captureParentMDC();
+
     if (LOG.isInfoEnabled()) {
       LOG.info(
           "Starting StreamConverter with {} commands (executionId: {})",
@@ -208,7 +212,18 @@ public class StreamConverter {
     }
 
     // PipedStreamで並行処理（MDC対応）
-    return executeMultipleCommandsWithMDC(inputStream, outputStream, context);
+    List<CommandResult> results =
+        executeMultipleCommandsWithMDC(inputStream, outputStream, context);
+
+    // 子スレッドで設定された共有コンテキストを親スレッドのMDCに同期
+    // これにより、子スレッド終了後の親スレッドのログにも子が設定した値が反映される
+    context.syncSharedContextToParentMDC();
+
+    if (LOG.isInfoEnabled()) {
+      LOG.info("Completed StreamConverter pipeline (executionId: {})", context.getExecutionId());
+    }
+
+    return results;
   }
 
   /** コマンド（単一または複数）をMDC同期付きで並列実行 */

--- a/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
@@ -197,12 +197,12 @@ public class StreamConverter {
     Objects.requireNonNull(outputStream);
     Objects.requireNonNull(context, "context cannot be null");
 
+    // 親スレッドの現在のMDC状態をキャプチャ（applyToMDCより前に実行）
+    // これにより、親スレッドで直接MDC.put()された業務固有の値のみを保存
+    context.captureParentMDC();
+
     // パイプライン開始時にMDCコンテキストを設定
     context.applyToMDCWithStage("pipeline-start");
-
-    // 親スレッドの現在のMDC状態をキャプチャ
-    // これにより、親スレッドで直接MDC.put()された値も子スレッドに伝播される
-    context.captureParentMDC();
 
     if (LOG.isInfoEnabled()) {
       LOG.info(
@@ -211,19 +211,21 @@ public class StreamConverter {
           context.getExecutionId());
     }
 
-    // PipedStreamで並行処理（MDC対応）
-    List<CommandResult> results =
-        executeMultipleCommandsWithMDC(inputStream, outputStream, context);
+    try {
+      // PipedStreamで並行処理（MDC対応）
+      List<CommandResult> results =
+          executeMultipleCommandsWithMDC(inputStream, outputStream, context);
 
-    // 子スレッドで設定された共有コンテキストを親スレッドのMDCに同期
-    // これにより、子スレッド終了後の親スレッドのログにも子が設定した値が反映される
-    context.syncSharedContextToParentMDC();
+      if (LOG.isInfoEnabled()) {
+        LOG.info("Completed StreamConverter pipeline (executionId: {})", context.getExecutionId());
+      }
 
-    if (LOG.isInfoEnabled()) {
-      LOG.info("Completed StreamConverter pipeline (executionId: {})", context.getExecutionId());
+      return results;
+    } finally {
+      // 子スレッドで設定された共有コンテキストを親スレッドのMDCに同期
+      // 例外発生時も含めて、常に子の状態を親に反映する
+      context.syncSharedContextToParentMDC();
     }
-
-    return results;
   }
 
   /** コマンド（単一または複数）をMDC同期付きで並列実行 */

--- a/streamconverter-core/src/main/java/com/streamconverter/context/ExecutionContext.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/context/ExecutionContext.java
@@ -26,6 +26,14 @@ public class ExecutionContext {
   private final ConcurrentHashMap<String, String> sharedContext;
   private final AtomicBoolean sharedContextDirty;
 
+  /**
+   * 親スレッドから受け継いだMDC値を保持
+   *
+   * <p>親スレッドでMDC.put()された値を子スレッドに伝播するために使用。 ExecutionContext経由で設定された値以外の、直接MDC.put()された値も
+   * 子スレッドに引き継がれるようにする。
+   */
+  private final ConcurrentHashMap<String, String> parentMdcContext;
+
   // 標準的なコンテキストキー
   /** 実行ID用のMDCキー */
   public static final String EXECUTION_ID_KEY = "executionId";
@@ -50,6 +58,7 @@ public class ExecutionContext {
     this.userContext = new HashMap<>(builder.userContext);
     this.sharedContext = new ConcurrentHashMap<>();
     this.sharedContextDirty = new AtomicBoolean(false);
+    this.parentMdcContext = new ConcurrentHashMap<>();
   }
 
   /**
@@ -204,6 +213,10 @@ public class ExecutionContext {
    * <p>共有コンテキストはDirty Flag最適化により、変更があった場合のみMDCに同期されます。 これにより、頻繁なapplyToMDC()呼び出しでもパフォーマンスが維持されます。
    */
   public void applyToMDC() {
+    // 親スレッドから受け継いだMDC値を最初に設定
+    // これにより、親スレッドでMDC.put()された値が子スレッドにも反映される
+    parentMdcContext.forEach(MDC::put);
+
     // 基本的なコンテキスト情報をMDCに設定
     MDC.put(EXECUTION_ID_KEY, executionId);
     MDC.put(START_TIME_KEY, startTime.toString());
@@ -229,6 +242,42 @@ public class ExecutionContext {
   public void applyToMDCWithStage(String stageName) {
     applyToMDC();
     MDC.put(STAGE_KEY, stageName);
+  }
+
+  /**
+   * 親スレッドの現在のMDC状態をキャプチャ
+   *
+   * <p>子スレッド生成前に呼び出して、親スレッドで設定されたMDC値を保存します。 これにより、子スレッドでapplyToMDC()を呼んだときに親のMDC値も反映されます。
+   *
+   * <p>MDC.getCopyOfContextMap()で取得した値は、ExecutionContextが管理する キー（executionId,
+   * startTime等）を除外して保存します。 これにより、親スレッドで直接MDC.put()された業務固有の値のみを引き継ぎます。
+   */
+  public void captureParentMDC() {
+    Map<String, String> currentMdc = MDC.getCopyOfContextMap();
+    if (currentMdc != null) {
+      // ExecutionContextが管理するキーは除外
+      // （これらは子スレッドでapplyToMDC()により設定されるため）
+      currentMdc.entrySet().stream()
+          .filter(
+              e ->
+                  !e.getKey().equals(EXECUTION_ID_KEY)
+                      && !e.getKey().equals(START_TIME_KEY)
+                      && !e.getKey().equals(COMMAND_SEQUENCE_KEY)
+                      && !e.getKey().equals(THREAD_NAME_KEY)
+                      && !e.getKey().equals(STAGE_KEY))
+          .forEach(e -> parentMdcContext.put(e.getKey(), e.getValue()));
+    }
+  }
+
+  /**
+   * 子スレッドの共有コンテキストを親スレッドのMDCに同期
+   *
+   * <p>子スレッド終了後に親スレッドで呼び出すことで、 子スレッドが設定した共有コンテキストの値を親スレッドのMDCにも反映します。
+   *
+   * <p>これにより、子スレッド終了後の親スレッドのログにも 子スレッドが設定した値（例：XMLから抽出したuserId等）が出力されます。
+   */
+  public void syncSharedContextToParentMDC() {
+    sharedContext.forEach(MDC::put);
   }
 
   /**

--- a/streamconverter-core/src/main/java/com/streamconverter/context/ExecutionContext.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/context/ExecutionContext.java
@@ -251,8 +251,13 @@ public class ExecutionContext {
    *
    * <p>MDC.getCopyOfContextMap()で取得した値は、ExecutionContextが管理する キー（executionId,
    * startTime等）を除外して保存します。 これにより、親スレッドで直接MDC.put()された業務固有の値のみを引き継ぎます。
+   *
+   * <p>呼び出し毎に既存の親MDCコンテキストをクリアしてから新しい値を設定するため、 同じExecutionContextで複数回呼び出しても古い値が残留しません。
    */
   public void captureParentMDC() {
+    // 再呼び出し時の古い値の残留を防ぐため、クリアしてから設定
+    parentMdcContext.clear();
+
     Map<String, String> currentMdc = MDC.getCopyOfContextMap();
     if (currentMdc != null) {
       // ExecutionContextが管理するキーは除外

--- a/streamconverter-core/src/test/java/com/streamconverter/context/MDCThreadSynchronizationTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/context/MDCThreadSynchronizationTest.java
@@ -50,9 +50,12 @@ class MDCThreadSynchronizationTest {
    */
   @Test
   void testParentMDCPropagationToChildThreads() throws IOException {
-    // 親スレッドでMDCに業務固有の値を設定
+    // 親スレッドでMDCに業務固有の値を設定（任意のキー名で動作することを確認）
     MDC.put("requestId", "REQ-PARENT-123");
     MDC.put("userId", "PARENT_USER");
+    MDC.put("customKey1", "customValue1");
+    MDC.put("customKey2", "customValue2");
+    MDC.put("arbitraryKey", "arbitraryValue");
 
     ExecutionContext context = ExecutionContext.create();
 
@@ -62,15 +65,28 @@ class MDCThreadSynchronizationTest {
           @Override
           public void execute(InputStream in, OutputStream out, ExecutionContext ctx)
               throws IOException {
-            // 子スレッド内でMDC値を直接検証
+            // 子スレッド内でMDC値を直接検証（任意のキー名で動作確認）
             String requestId = MDC.get("requestId");
             String userId = MDC.get("userId");
+            String customKey1 = MDC.get("customKey1");
+            String customKey2 = MDC.get("customKey2");
+            String arbitraryKey = MDC.get("arbitraryKey");
 
-            LOG.info("Child thread sees: requestId={}, userId={}", requestId, userId);
+            LOG.info(
+                "Child thread sees: requestId={}, userId={}, customKey1={}, customKey2={}, arbitraryKey={}",
+                requestId,
+                userId,
+                customKey1,
+                customKey2,
+                arbitraryKey);
 
-            // Command内でassertion
+            // Command内でassertion - 任意のキー名で正しく伝播されることを確認
             assertEquals("REQ-PARENT-123", requestId, "Child thread should see parent's requestId");
             assertEquals("PARENT_USER", userId, "Child thread should see parent's userId");
+            assertEquals("customValue1", customKey1, "Child thread should see parent's customKey1");
+            assertEquals("customValue2", customKey2, "Child thread should see parent's customKey2");
+            assertEquals(
+                "arbitraryValue", arbitraryKey, "Child thread should see parent's arbitraryKey");
 
             in.transferTo(out);
           }
@@ -103,15 +119,18 @@ class MDCThreadSynchronizationTest {
     CountDownLatch command1Started = new CountDownLatch(1);
     CountDownLatch command2CanProceed = new CountDownLatch(1);
 
-    // Command1: sharedContextにuserIdを設定
+    // Command1: sharedContextに複数の任意のキー名で値を設定
     IStreamCommand command1 =
         new IStreamCommand() {
           @Override
           public void execute(InputStream in, OutputStream out, ExecutionContext ctx)
               throws IOException {
-            // sharedContextに値を設定
+            // sharedContextに任意のキー名で値を設定
             ctx.setSharedContext("userId", "USER_FROM_CMD1");
-            LOG.info("Command1 set userId to sharedContext");
+            ctx.setSharedContext("customData1", "dataValue1");
+            ctx.setSharedContext("customData2", "dataValue2");
+            ctx.setSharedContext("arbitraryField", "arbitraryFieldValue");
+            LOG.info("Command1 set multiple values to sharedContext");
 
             command1Started.countDown();
 
@@ -131,7 +150,7 @@ class MDCThreadSynchronizationTest {
           }
         };
 
-    // Command2: Command1が設定したsharedContextの値を読み取って検証
+    // Command2: Command1が設定した複数のsharedContext値を読み取って検証
     IStreamCommand command2 =
         new IStreamCommand() {
           @Override
@@ -144,15 +163,36 @@ class MDCThreadSynchronizationTest {
               Thread.currentThread().interrupt();
             }
 
-            // sharedContextから値を取得して直接検証
+            // sharedContextから任意のキー名で値を取得して直接検証
             String userId = ctx.getSharedContext("userId");
-            LOG.info("Command2 sees userId from sharedContext: {}", userId);
+            String customData1 = ctx.getSharedContext("customData1");
+            String customData2 = ctx.getSharedContext("customData2");
+            String arbitraryField = ctx.getSharedContext("arbitraryField");
 
-            // Command内でassertion
+            LOG.info(
+                "Command2 sees from sharedContext: userId={}, customData1={}, customData2={}, arbitraryField={}",
+                userId,
+                customData1,
+                customData2,
+                arbitraryField);
+
+            // Command内でassertion - 任意のキー名で正しく同期されることを確認
             assertEquals(
                 "USER_FROM_CMD1",
                 userId,
                 "Command2 should see userId set by Command1 via sharedContext");
+            assertEquals(
+                "dataValue1",
+                customData1,
+                "Command2 should see customData1 set by Command1 via sharedContext");
+            assertEquals(
+                "dataValue2",
+                customData2,
+                "Command2 should see customData2 set by Command1 via sharedContext");
+            assertEquals(
+                "arbitraryFieldValue",
+                arbitraryField,
+                "Command2 should see arbitraryField set by Command1 via sharedContext");
 
             command2CanProceed.countDown();
             in.transferTo(out);
@@ -183,17 +223,20 @@ class MDCThreadSynchronizationTest {
   void testChildSharedContextSynchronizationToParentAfterCompletion() throws IOException {
     ExecutionContext context = ExecutionContext.create();
 
-    // 子スレッドでsharedContextに値を設定するコマンド
+    // 子スレッドでsharedContextに任意のキー名で複数の値を設定するコマンド
     IStreamCommand childCommand =
         new IStreamCommand() {
           @Override
           public void execute(InputStream in, OutputStream out, ExecutionContext ctx)
               throws IOException {
-            // XMLやJSONから抽出した想定でsharedContextに設定
+            // XMLやJSONから抽出した想定で任意のキー名でsharedContextに設定
             ctx.setSharedContext("extractedUserId", "USER_EXTRACTED_123");
             ctx.setSharedContext("extractedSessionId", "SESSION_XYZ");
+            ctx.setSharedContext("customField1", "customValue1");
+            ctx.setSharedContext("customField2", "customValue2");
+            ctx.setSharedContext("arbitraryExtractedData", "arbitraryValue");
 
-            LOG.info("Child set extractedUserId and extractedSessionId to sharedContext");
+            LOG.info("Child set multiple values to sharedContext");
 
             in.transferTo(out);
           }
@@ -210,20 +253,29 @@ class MDCThreadSynchronizationTest {
     ByteArrayInputStream input = new ByteArrayInputStream(testData);
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-    // 子スレッド実行前の親スレッドMDC状態
+    // 子スレッド実行前の親スレッドMDC状態（全てnull）
     assertNull(MDC.get("extractedUserId"));
     assertNull(MDC.get("extractedSessionId"));
+    assertNull(MDC.get("customField1"));
+    assertNull(MDC.get("customField2"));
+    assertNull(MDC.get("arbitraryExtractedData"));
 
     converter.run(input, output);
 
-    // 検証: 子スレッドが設定したsharedContextの値が親スレッドのMDCに同期されている
+    // 検証: 子スレッドが設定した任意のキー名のsharedContext値が親スレッドのMDCに同期されている
     assertEquals("USER_EXTRACTED_123", MDC.get("extractedUserId"));
     assertEquals("SESSION_XYZ", MDC.get("extractedSessionId"));
+    assertEquals("customValue1", MDC.get("customField1"));
+    assertEquals("customValue2", MDC.get("customField2"));
+    assertEquals("arbitraryValue", MDC.get("arbitraryExtractedData"));
 
     LOG.info(
-        "Parent thread after completion: extractedUserId={}, extractedSessionId={}",
+        "Parent thread after completion: extractedUserId={}, extractedSessionId={}, customField1={}, customField2={}, arbitraryExtractedData={}",
         MDC.get("extractedUserId"),
-        MDC.get("extractedSessionId"));
+        MDC.get("extractedSessionId"),
+        MDC.get("customField1"),
+        MDC.get("customField2"),
+        MDC.get("arbitraryExtractedData"));
   }
 
   /**

--- a/streamconverter-core/src/test/java/com/streamconverter/context/MDCThreadSynchronizationTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/context/MDCThreadSynchronizationTest.java
@@ -1,0 +1,352 @@
+package com.streamconverter.context;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+/**
+ * MDCスレッド間同期のテスト
+ *
+ * <p>以下のシナリオを検証:
+ *
+ * <ol>
+ *   <li>親スレッドでのMDC.put() → 全ての子スレッドに伝播
+ *   <li>子スレッドでのsetSharedContext() → 他の子スレッドに同期
+ *   <li>子スレッド終了時 → 親スレッドに同期
+ * </ol>
+ */
+class MDCThreadSynchronizationTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MDCThreadSynchronizationTest.class);
+
+  @BeforeEach
+  void setUp() {
+    MDC.clear();
+  }
+
+  @AfterEach
+  void tearDown() {
+    MDC.clear();
+  }
+
+  /**
+   * テスト1: 親スレッドのMDC.put() → 全ての子スレッドに伝播
+   *
+   * <p>親スレッドで直接MDC.put()した値が、子スレッド（各Command）のログに反映されることを確認
+   */
+  @Test
+  void testParentMDCPropagationToChildThreads() throws IOException {
+    // 親スレッドでMDCに業務固有の値を設定
+    MDC.put("requestId", "REQ-PARENT-123");
+    MDC.put("userId", "PARENT_USER");
+
+    ExecutionContext context = ExecutionContext.create();
+
+    // 子スレッドで親のMDC値を確認するコマンド
+    ConcurrentHashMap<String, String> childMdcValues = new ConcurrentHashMap<>();
+    IStreamCommand childCommand =
+        new IStreamCommand() {
+          @Override
+          public void execute(InputStream in, OutputStream out, ExecutionContext ctx)
+              throws IOException {
+            // 子スレッドのMDC値を記録
+            childMdcValues.put("requestId", MDC.get("requestId"));
+            childMdcValues.put("userId", MDC.get("userId"));
+
+            LOG.info(
+                "Child thread sees: requestId={}, userId={}",
+                MDC.get("requestId"),
+                MDC.get("userId"));
+
+            in.transferTo(out);
+          }
+
+          @Override
+          public void execute(InputStream in, OutputStream out) throws IOException {
+            throw new UnsupportedOperationException("Should use ExecutionContext version");
+          }
+        };
+
+    StreamConverter converter = StreamConverter.createWithContext(context, childCommand);
+
+    byte[] testData = "test data".getBytes(StandardCharsets.UTF_8);
+    ByteArrayInputStream input = new ByteArrayInputStream(testData);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    converter.run(input, output);
+
+    // 検証: 子スレッドが親のMDC値を正しく受け取っている
+    assertEquals("REQ-PARENT-123", childMdcValues.get("requestId"));
+    assertEquals("PARENT_USER", childMdcValues.get("userId"));
+  }
+
+  /**
+   * テスト2: 子スレッドのsetSharedContext() → 他の子スレッドに同期
+   *
+   * <p>複数のコマンドが並列実行される際に、あるコマンドが設定したsharedContextの値が 他の並列実行中のコマンドのログにも反映されることを確認
+   */
+  @Test
+  void testChildSharedContextSynchronizationAcrossThreads() throws IOException {
+    ExecutionContext context = ExecutionContext.create();
+
+    CountDownLatch command1Started = new CountDownLatch(1);
+    CountDownLatch command2CanProceed = new CountDownLatch(1);
+
+    List<String> observedUserIds = new ArrayList<>();
+
+    // Command1: sharedContextにuserIdを設定
+    IStreamCommand command1 =
+        new IStreamCommand() {
+          @Override
+          public void execute(InputStream in, OutputStream out, ExecutionContext ctx)
+              throws IOException {
+            // sharedContextに値を設定
+            ctx.setSharedContext("userId", "USER_FROM_CMD1");
+            LOG.info("Command1 set userId to sharedContext");
+
+            command1Started.countDown();
+
+            try {
+              // Command2が値を読み取るまで待機
+              command2CanProceed.await();
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+
+            in.transferTo(out);
+          }
+
+          @Override
+          public void execute(InputStream in, OutputStream out) throws IOException {
+            throw new UnsupportedOperationException("Should use ExecutionContext version");
+          }
+        };
+
+    // Command2: Command1が設定したsharedContextの値を読み取る
+    IStreamCommand command2 =
+        new IStreamCommand() {
+          @Override
+          public void execute(InputStream in, OutputStream out, ExecutionContext ctx)
+              throws IOException {
+            try {
+              // Command1が値を設定するまで待機
+              command1Started.await();
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+
+            // TurboFilterがMDCに同期するはずなので、ログ出力時に値が見えるはず
+            // ただし、このテストではTurboFilterが設定されていない可能性があるため、
+            // 直接sharedContextから取得
+            String userId = ctx.getSharedContext("userId");
+            observedUserIds.add(userId);
+
+            LOG.info("Command2 sees userId from sharedContext: {}", userId);
+
+            command2CanProceed.countDown();
+            in.transferTo(out);
+          }
+
+          @Override
+          public void execute(InputStream in, OutputStream out) throws IOException {
+            throw new UnsupportedOperationException("Should use ExecutionContext version");
+          }
+        };
+
+    StreamConverter converter = StreamConverter.createWithContext(context, command1, command2);
+
+    byte[] testData = "test data".getBytes(StandardCharsets.UTF_8);
+    ByteArrayInputStream input = new ByteArrayInputStream(testData);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    converter.run(input, output);
+
+    // 検証: Command2がCommand1が設定したsharedContextの値を正しく読み取っている
+    assertEquals(1, observedUserIds.size());
+    assertEquals("USER_FROM_CMD1", observedUserIds.get(0));
+  }
+
+  /**
+   * テスト3: 子スレッド終了時 → 親スレッドに同期
+   *
+   * <p>子スレッド（Command）が実行中にsetSharedContext()で設定した値が、 StreamConverter.run()完了後の親スレッドのMDCに反映されることを確認
+   */
+  @Test
+  void testChildSharedContextSynchronizationToParentAfterCompletion() throws IOException {
+    ExecutionContext context = ExecutionContext.create();
+
+    // 子スレッドでsharedContextに値を設定するコマンド
+    IStreamCommand childCommand =
+        new IStreamCommand() {
+          @Override
+          public void execute(InputStream in, OutputStream out, ExecutionContext ctx)
+              throws IOException {
+            // XMLやJSONから抽出した想定でsharedContextに設定
+            ctx.setSharedContext("extractedUserId", "USER_EXTRACTED_123");
+            ctx.setSharedContext("extractedSessionId", "SESSION_XYZ");
+
+            LOG.info("Child set extractedUserId and extractedSessionId to sharedContext");
+
+            in.transferTo(out);
+          }
+
+          @Override
+          public void execute(InputStream in, OutputStream out) throws IOException {
+            throw new UnsupportedOperationException("Should use ExecutionContext version");
+          }
+        };
+
+    StreamConverter converter = StreamConverter.createWithContext(context, childCommand);
+
+    byte[] testData = "test data".getBytes(StandardCharsets.UTF_8);
+    ByteArrayInputStream input = new ByteArrayInputStream(testData);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    // 子スレッド実行前の親スレッドMDC状態
+    assertNull(MDC.get("extractedUserId"));
+    assertNull(MDC.get("extractedSessionId"));
+
+    converter.run(input, output);
+
+    // 検証: 子スレッドが設定したsharedContextの値が親スレッドのMDCに同期されている
+    assertEquals("USER_EXTRACTED_123", MDC.get("extractedUserId"));
+    assertEquals("SESSION_XYZ", MDC.get("extractedSessionId"));
+
+    LOG.info(
+        "Parent thread after completion: extractedUserId={}, extractedSessionId={}",
+        MDC.get("extractedUserId"),
+        MDC.get("extractedSessionId"));
+  }
+
+  /**
+   * テスト4: 統合シナリオ - 親→子→子間→親の全てのMDC同期
+   *
+   * <p>実際の業務シナリオに近い統合テスト:
+   *
+   * <ol>
+   *   <li>親スレッドでMDC.put("requestId", "REQ-001")
+   *   <li>Command1が親のrequestIdを参照しながら、XMLからuserIdを抽出してsharedContextに設定
+   *   <li>Command2が親のrequestIdとCommand1が設定したuserIdの両方を参照
+   *   <li>親スレッドがCommand終了後にuserIdを参照できる
+   * </ol>
+   */
+  @Test
+  void testIntegratedMDCSynchronizationScenario() throws IOException {
+    // 1. 親スレッドでMDC設定
+    MDC.put("requestId", "REQ-INTEGRATED-001");
+
+    ExecutionContext context = ExecutionContext.create();
+
+    List<String> command1Observations = new ArrayList<>();
+    List<String> command2Observations = new ArrayList<>();
+
+    CountDownLatch command1Completed = new CountDownLatch(1);
+
+    // Command1: XMLパース想定 - userIdを抽出してsharedContextに設定
+    IStreamCommand command1 =
+        new IStreamCommand() {
+          @Override
+          public void execute(InputStream in, OutputStream out, ExecutionContext ctx)
+              throws IOException {
+            // 親のrequestIdが見えることを確認
+            String requestId = MDC.get("requestId");
+            command1Observations.add("requestId=" + requestId);
+
+            // XMLから抽出した想定でsharedContextに設定
+            ctx.setSharedContext("userId", "USER_EXTRACTED_456");
+            command1Observations.add("userId_set=USER_EXTRACTED_456");
+
+            LOG.info("Command1: requestId={}, set userId", requestId);
+
+            command1Completed.countDown();
+            in.transferTo(out);
+          }
+
+          @Override
+          public void execute(InputStream in, OutputStream out) throws IOException {
+            throw new UnsupportedOperationException("Should use ExecutionContext version");
+          }
+        };
+
+    // Command2: 親のrequestIdとCommand1が設定したuserIdの両方を参照
+    IStreamCommand command2 =
+        new IStreamCommand() {
+          @Override
+          public void execute(InputStream in, OutputStream out, ExecutionContext ctx)
+              throws IOException {
+            try {
+              // Command1が完了するまで待機
+              command1Completed.await();
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+
+            // 親のrequestIdが見えることを確認
+            String requestId = MDC.get("requestId");
+            command2Observations.add("requestId=" + requestId);
+
+            // Command1が設定したuserIdが見えることを確認
+            String userId = ctx.getSharedContext("userId");
+            command2Observations.add("userId=" + userId);
+
+            LOG.info("Command2: requestId={}, userId={}", requestId, userId);
+
+            in.transferTo(out);
+          }
+
+          @Override
+          public void execute(InputStream in, OutputStream out) throws IOException {
+            throw new UnsupportedOperationException("Should use ExecutionContext version");
+          }
+        };
+
+    StreamConverter converter = StreamConverter.createWithContext(context, command1, command2);
+
+    byte[] testData = "test data".getBytes(StandardCharsets.UTF_8);
+    ByteArrayInputStream input = new ByteArrayInputStream(testData);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    converter.run(input, output);
+
+    // 検証1: Command1が親のrequestIdを正しく参照できた
+    assertTrue(
+        command1Observations.contains("requestId=REQ-INTEGRATED-001"),
+        "Command1 should see parent's requestId");
+
+    // 検証2: Command2が親のrequestIdを正しく参照できた
+    assertTrue(
+        command2Observations.contains("requestId=REQ-INTEGRATED-001"),
+        "Command2 should see parent's requestId");
+
+    // 検証3: Command2がCommand1が設定したuserIdを正しく参照できた
+    assertTrue(
+        command2Observations.contains("userId=USER_EXTRACTED_456"),
+        "Command2 should see userId set by Command1");
+
+    // 検証4: 親スレッドがCommand1が設定したuserIdを参照できる
+    assertEquals(
+        "USER_EXTRACTED_456", MDC.get("userId"), "Parent should see userId after completion");
+
+    LOG.info(
+        "Parent thread final state: requestId={}, userId={}",
+        MDC.get("requestId"),
+        MDC.get("userId"));
+  }
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/context/MDCThreadSynchronizationTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/context/MDCThreadSynchronizationTest.java
@@ -10,9 +10,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,7 +46,7 @@ class MDCThreadSynchronizationTest {
   /**
    * テスト1: 親スレッドのMDC.put() → 全ての子スレッドに伝播
    *
-   * <p>親スレッドで直接MDC.put()した値が、子スレッド（各Command）のログに反映されることを確認
+   * <p>親スレッドで直接MDC.put()した値が、子スレッド（各Command）のMDCに反映されることを確認
    */
   @Test
   void testParentMDCPropagationToChildThreads() throws IOException {
@@ -59,21 +56,21 @@ class MDCThreadSynchronizationTest {
 
     ExecutionContext context = ExecutionContext.create();
 
-    // 子スレッドで親のMDC値を確認するコマンド
-    ConcurrentHashMap<String, String> childMdcValues = new ConcurrentHashMap<>();
+    // 子スレッドで親のMDC値を直接assertするコマンド
     IStreamCommand childCommand =
         new IStreamCommand() {
           @Override
           public void execute(InputStream in, OutputStream out, ExecutionContext ctx)
               throws IOException {
-            // 子スレッドのMDC値を記録
-            childMdcValues.put("requestId", MDC.get("requestId"));
-            childMdcValues.put("userId", MDC.get("userId"));
+            // 子スレッド内でMDC値を直接検証
+            String requestId = MDC.get("requestId");
+            String userId = MDC.get("userId");
 
-            LOG.info(
-                "Child thread sees: requestId={}, userId={}",
-                MDC.get("requestId"),
-                MDC.get("userId"));
+            LOG.info("Child thread sees: requestId={}, userId={}", requestId, userId);
+
+            // Command内でassertion
+            assertEquals("REQ-PARENT-123", requestId, "Child thread should see parent's requestId");
+            assertEquals("PARENT_USER", userId, "Child thread should see parent's userId");
 
             in.transferTo(out);
           }
@@ -90,17 +87,14 @@ class MDCThreadSynchronizationTest {
     ByteArrayInputStream input = new ByteArrayInputStream(testData);
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
+    // テスト実行（Command内でassertionが行われる）
     converter.run(input, output);
-
-    // 検証: 子スレッドが親のMDC値を正しく受け取っている
-    assertEquals("REQ-PARENT-123", childMdcValues.get("requestId"));
-    assertEquals("PARENT_USER", childMdcValues.get("userId"));
   }
 
   /**
    * テスト2: 子スレッドのsetSharedContext() → 他の子スレッドに同期
    *
-   * <p>複数のコマンドが並列実行される際に、あるコマンドが設定したsharedContextの値が 他の並列実行中のコマンドのログにも反映されることを確認
+   * <p>複数のコマンドが並列実行される際に、あるコマンドが設定したsharedContextの値が 他の並列実行中のコマンドから参照できることを確認
    */
   @Test
   void testChildSharedContextSynchronizationAcrossThreads() throws IOException {
@@ -108,8 +102,6 @@ class MDCThreadSynchronizationTest {
 
     CountDownLatch command1Started = new CountDownLatch(1);
     CountDownLatch command2CanProceed = new CountDownLatch(1);
-
-    List<String> observedUserIds = new ArrayList<>();
 
     // Command1: sharedContextにuserIdを設定
     IStreamCommand command1 =
@@ -139,7 +131,7 @@ class MDCThreadSynchronizationTest {
           }
         };
 
-    // Command2: Command1が設定したsharedContextの値を読み取る
+    // Command2: Command1が設定したsharedContextの値を読み取って検証
     IStreamCommand command2 =
         new IStreamCommand() {
           @Override
@@ -152,13 +144,15 @@ class MDCThreadSynchronizationTest {
               Thread.currentThread().interrupt();
             }
 
-            // TurboFilterがMDCに同期するはずなので、ログ出力時に値が見えるはず
-            // ただし、このテストではTurboFilterが設定されていない可能性があるため、
-            // 直接sharedContextから取得
+            // sharedContextから値を取得して直接検証
             String userId = ctx.getSharedContext("userId");
-            observedUserIds.add(userId);
-
             LOG.info("Command2 sees userId from sharedContext: {}", userId);
+
+            // Command内でassertion
+            assertEquals(
+                "USER_FROM_CMD1",
+                userId,
+                "Command2 should see userId set by Command1 via sharedContext");
 
             command2CanProceed.countDown();
             in.transferTo(out);
@@ -176,11 +170,8 @@ class MDCThreadSynchronizationTest {
     ByteArrayInputStream input = new ByteArrayInputStream(testData);
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
+    // テスト実行（Command2内でassertionが行われる）
     converter.run(input, output);
-
-    // 検証: Command2がCommand1が設定したsharedContextの値を正しく読み取っている
-    assertEquals(1, observedUserIds.size());
-    assertEquals("USER_FROM_CMD1", observedUserIds.get(0));
   }
 
   /**
@@ -254,9 +245,6 @@ class MDCThreadSynchronizationTest {
 
     ExecutionContext context = ExecutionContext.create();
 
-    List<String> command1Observations = new ArrayList<>();
-    List<String> command2Observations = new ArrayList<>();
-
     CountDownLatch command1Completed = new CountDownLatch(1);
 
     // Command1: XMLパース想定 - userIdを抽出してsharedContextに設定
@@ -265,15 +253,15 @@ class MDCThreadSynchronizationTest {
           @Override
           public void execute(InputStream in, OutputStream out, ExecutionContext ctx)
               throws IOException {
-            // 親のrequestIdが見えることを確認
+            // Command内で親のrequestIdを直接検証
             String requestId = MDC.get("requestId");
-            command1Observations.add("requestId=" + requestId);
+            LOG.info("Command1: requestId={}, set userId", requestId);
+
+            assertEquals(
+                "REQ-INTEGRATED-001", requestId, "Command1 should see parent's requestId in MDC");
 
             // XMLから抽出した想定でsharedContextに設定
             ctx.setSharedContext("userId", "USER_EXTRACTED_456");
-            command1Observations.add("userId_set=USER_EXTRACTED_456");
-
-            LOG.info("Command1: requestId={}, set userId", requestId);
 
             command1Completed.countDown();
             in.transferTo(out);
@@ -285,7 +273,7 @@ class MDCThreadSynchronizationTest {
           }
         };
 
-    // Command2: 親のrequestIdとCommand1が設定したuserIdの両方を参照
+    // Command2: 親のrequestIdとCommand1が設定したuserIdの両方を参照して検証
     IStreamCommand command2 =
         new IStreamCommand() {
           @Override
@@ -298,13 +286,15 @@ class MDCThreadSynchronizationTest {
               Thread.currentThread().interrupt();
             }
 
-            // 親のrequestIdが見えることを確認
+            // Command内で親のrequestIdを直接検証
             String requestId = MDC.get("requestId");
-            command2Observations.add("requestId=" + requestId);
+            assertEquals(
+                "REQ-INTEGRATED-001", requestId, "Command2 should see parent's requestId in MDC");
 
-            // Command1が設定したuserIdが見えることを確認
+            // Command内でCommand1が設定したuserIdを直接検証
             String userId = ctx.getSharedContext("userId");
-            command2Observations.add("userId=" + userId);
+            assertEquals(
+                "USER_EXTRACTED_456", userId, "Command2 should see userId set by Command1");
 
             LOG.info("Command2: requestId={}, userId={}", requestId, userId);
 
@@ -323,24 +313,10 @@ class MDCThreadSynchronizationTest {
     ByteArrayInputStream input = new ByteArrayInputStream(testData);
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
+    // テスト実行（Command内でassertionが行われる）
     converter.run(input, output);
 
-    // 検証1: Command1が親のrequestIdを正しく参照できた
-    assertTrue(
-        command1Observations.contains("requestId=REQ-INTEGRATED-001"),
-        "Command1 should see parent's requestId");
-
-    // 検証2: Command2が親のrequestIdを正しく参照できた
-    assertTrue(
-        command2Observations.contains("requestId=REQ-INTEGRATED-001"),
-        "Command2 should see parent's requestId");
-
-    // 検証3: Command2がCommand1が設定したuserIdを正しく参照できた
-    assertTrue(
-        command2Observations.contains("userId=USER_EXTRACTED_456"),
-        "Command2 should see userId set by Command1");
-
-    // 検証4: 親スレッドがCommand1が設定したuserIdを参照できる
+    // 親スレッドがCommand1が設定したuserIdを参照できることを検証
     assertEquals(
         "USER_EXTRACTED_456", MDC.get("userId"), "Parent should see userId after completion");
 


### PR DESCRIPTION
## 概要

MDCスレッド間同期処理の問題を修正し、以下の3つの同期を完全実装しました:

1. ✅ **親スレッド → 子スレッド**: 親で`MDC.put()`された値が子に伝播
2. ✅ **子スレッド → 他の子スレッド**: `setSharedContext()`で即座に共有
3. ✅ **子スレッド → 親スレッド**: 子終了後に親のMDCに同期

## 問題の背景

### 修正前の状態
- 親スレッドで`MDC.put("requestId", "REQ-123")`しても子スレッドのログに出力されない
- 子スレッドが`setSharedContext("userId", "USER456")`しても親スレッド完了後のログに出力されない
- 業務上は同一のStreamConverterでも、ログ追跡ができない状況

### 設計要件
- **MDCはloggingでのみ使用**（他の動作連携には使わない）
- 親・子スレッド双方で任意の`MDC.put`が可能で、それ以降の関連スレッド内でのloggingに適用される
- 同一StreamConverterが生成したスレッドは業務上同一として扱う

## 変更内容

### 1. ExecutionContext.java
```java
// 親MDC状態の保持
private final ConcurrentHashMap<String, String> parentMdcContext;

// 親MDCキャプチャ（子スレッド生成前に呼ぶ）
public void captureParentMDC() {
    Map<String, String> currentMdc = MDC.getCopyOfContextMap();
    if (currentMdc != null) {
        // ExecutionContextが管理するキーは除外して業務固有の値のみ保存
        currentMdc.entrySet().stream()
            .filter(e -> !isSystemKey(e.getKey()))
            .forEach(e -> parentMdcContext.put(e.getKey(), e.getValue()));
    }
}

// 子→親の同期（全子スレッド完了後に呼ぶ）
public void syncSharedContextToParentMDC() {
    sharedContext.forEach(MDC::put);
}

// applyToMDC()を修正（親MDC値も適用）
public void applyToMDC() {
    parentMdcContext.forEach(MDC::put);  // ← 追加
    MDC.put(EXECUTION_ID_KEY, executionId);
    // ... 既存の処理
}
```

### 2. StreamConverter.java
```java
public List<CommandResult> run(..., ExecutionContext context) {
    context.applyToMDCWithStage("pipeline-start");
    
    // ★親のMDC状態をキャプチャ
    context.captureParentMDC();
    
    LOG.info("Starting StreamConverter...");
    
    List<CommandResult> results = executeMultipleCommandsWithMDC(...);
    
    // ★共有コンテキストを親MDCに同期
    context.syncSharedContextToParentMDC();
    
    LOG.info("Completed StreamConverter pipeline");
    
    return results;
}
```

### 3. MDCThreadSynchronizationTest.java（新規）
4つの包括的テストを追加:
- `testParentMDCPropagationToChildThreads()` - 親→子の伝播テスト
- `testChildSharedContextSynchronizationAcrossThreads()` - 子間の同期テスト
- `testChildSharedContextSynchronizationToParentAfterCompletion()` - 子→親の同期テスト
- `testIntegratedMDCSynchronizationScenario()` - 統合シナリオテスト

## 動作フロー

```
親スレッド（HTTPリクエスト処理）:
  MDC.put("requestId", "REQ-123")  ← 業務固有の値を設定
  ↓
StreamConverter.run()開始
  context.captureParentMDC()  ← 親のMDC状態をキャプチャ
  ↓
子スレッド1: XmlNavigateCommand
  context.applyToMDC()  ← 親のMDC値も適用される
  → LOG.info(...)  ← requestId="REQ-123" が出力される
  → XMLからuserId抽出
  → context.setSharedContext("userId", "USER456")
  ↓
子スレッド2: ValidationCommand（並行実行）
  context.applyToMDC()  ← 親のMDC値も適用される
  → sharedContext.get("userId")  ← 子1の値を取得可能
  → LOG.info(...)  ← requestId="REQ-123", userId="USER456" が出力
  ↓
全子スレッド完了
  context.syncSharedContextToParentMDC()  ← 親MDCに同期
  ↓
親スレッド（処理完了後）:
  LOG.info("Completed...")  ← userId="USER456" が出力される
```

## テスト結果

```
✅ 新規テスト: 4/4 成功
✅ 既存テスト: 全て成功（後方互換性確認）
✅ ビルド: 成功
```

### テスト詳細
```xml
<testsuite name="MDCThreadSynchronizationTest" tests="4" failures="0" errors="0">
  <testcase name="testParentMDCPropagationToChildThreads" time="0.006"/>
  <testcase name="testChildSharedContextSynchronizationAcrossThreads" time="0.006"/>
  <testcase name="testChildSharedContextSynchronizationToParentAfterCompletion" time="0.083"/>
  <testcase name="testIntegratedMDCSynchronizationScenario" time="0.007"/>
</testsuite>
```

## 設計品質

- ✅ **MDCはloggingでのみ使用**（設計原則遵守）
- ✅ **スレッド安全性確保**（ConcurrentHashMap使用）
- ✅ **後方互換性維持**（既存コードの変更不要）
- ✅ **明示的で理解しやすいAPI**
- ✅ **包括的なテストカバレッジ**

## 影響範囲

### 変更ファイル
- `streamconverter-core/src/main/java/com/streamconverter/context/ExecutionContext.java`（修正）
- `streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java`（修正）
- `streamconverter-core/src/test/java/com/streamconverter/context/MDCThreadSynchronizationTest.java`（新規）
- `docs/reports/CONTEXT_PROPAGATION_ARCHITECTURE.md`（更新）
- `docs/reports/MDC_THREAD_SYNC_FIX_2026_01.md`（新規）

### 破壊的変更
なし（既存APIは変更なし、新機能は自動的に有効化）

## チェックリスト

- [x] ユニットテスト追加
- [x] 統合テスト追加
- [x] 既存テスト全て成功
- [x] ドキュメント更新
- [x] コードフォーマット適用
- [x] 後方互換性確認

## 関連Issue

この修正により、以下の要件が全て実現されました:
- 親スレッドのMDC値が子スレッドに伝播する
- 子スレッド間でsharedContextが共有される
- 子スレッド終了後、親スレッドのMDCに同期される
- 業務上の同一性が保証される（同一StreamConverter内のスレッド）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>