### PR TITLE
fix(core): SpotBugs CT_CONSTRUCTOR_THROW / DLS / RV 警告を解消 (#521)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/charcode/CharacterConvertCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/charcode/CharacterConvertCommand.java
@@ -27,17 +27,29 @@ public class CharacterConvertCommand extends AbstractStreamCommand {
    * @param to The target character encoding.
    * @throws IllegalArgumentException if the specified character encodings are not supported.
    */
-  public CharacterConvertCommand(String from, String to) {
-    Objects.requireNonNull(from);
-    Objects.requireNonNull(to);
-    if (Charset.isSupported(from) == false) {
-      throw new IllegalArgumentException("変換元文字コードがサポートされていません");
-    }
-    if (Charset.isSupported(to) == false) {
-      throw new IllegalArgumentException("変換先文字コードがサポートされていません");
-    }
+  private CharacterConvertCommand(String from, String to) {
     this.from = from;
     this.to = to;
+  }
+
+  /**
+   * Factory method to create a CharacterConvertCommand.
+   *
+   * @param from The source character encoding.
+   * @param to The target character encoding.
+   * @return a new CharacterConvertCommand instance
+   * @throws IllegalArgumentException if the specified character encodings are not supported.
+   */
+  public static CharacterConvertCommand create(String from, String to) {
+    Objects.requireNonNull(from);
+    Objects.requireNonNull(to);
+    if (!Charset.isSupported(from)) {
+      throw new IllegalArgumentException("変換元文字コードがサポートされていません");
+    }
+    if (!Charset.isSupported(to)) {
+      throw new IllegalArgumentException("変換先文字コードがサポートされていません");
+    }
+    return new CharacterConvertCommand(from, to);
   }
 
   /**

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvFilterCommand.java
@@ -11,7 +11,6 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -37,13 +36,8 @@ public class CsvFilterCommand extends AbstractStreamCommand {
    * @param hasHeader whether the CSV has a header row
    * @throws IllegalArgumentException if columnSelector is null
    */
-  public CsvFilterCommand(CSVPath columnSelector, boolean hasHeader) {
-    if (columnSelector == null) {
-      throw new IllegalArgumentException("Column selector cannot be null");
-    }
+  private CsvFilterCommand(CSVPath columnSelector, boolean hasHeader) {
     this.combinedSelector = columnSelector;
-    Arrays.asList(columnSelector);
-    Arrays.asList(columnSelector.toString());
     this.hasHeader = hasHeader;
   }
 
@@ -52,6 +46,7 @@ public class CsvFilterCommand extends AbstractStreamCommand {
    *
    * @param columnSelector the typed CSVPath to extract
    * @return a CsvFilterCommand instance
+   * @throws IllegalArgumentException if columnSelector is null
    */
   public static CsvFilterCommand create(CSVPath columnSelector) {
     return create(columnSelector, true);
@@ -63,8 +58,12 @@ public class CsvFilterCommand extends AbstractStreamCommand {
    * @param columnSelector the typed CSVPath to extract
    * @param hasHeader whether the CSV has a header row
    * @return a CsvFilterCommand instance
+   * @throws IllegalArgumentException if columnSelector is null
    */
   public static CsvFilterCommand create(CSVPath columnSelector, boolean hasHeader) {
+    if (columnSelector == null) {
+      throw new IllegalArgumentException("Column selector cannot be null");
+    }
     return new CsvFilterCommand(columnSelector, hasHeader);
   }
 
@@ -74,7 +73,7 @@ public class CsvFilterCommand extends AbstractStreamCommand {
             new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
         Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
 
-      List<Integer> columnIndices = new ArrayList<>();
+      List<Integer> columnIndices;
       String[] headers = null;
 
       // Read first line

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvNavigateCommand.java
@@ -35,14 +35,8 @@ public class CsvNavigateCommand extends AbstractStreamCommand {
    * @deprecated Use {@link #CsvNavigateCommand(CSVPath, IRule)} instead
    */
   @Deprecated
-  public CsvNavigateCommand(String columnSelector, IRule rule) {
-    if (columnSelector == null) {
-      throw new IllegalArgumentException("Column selector cannot be null");
-    }
-    if (rule == null) {
-      throw new IllegalArgumentException("Rule cannot be null");
-    }
-    this.columnSelector = new CSVPath(columnSelector);
+  private CsvNavigateCommand(String columnSelector, IRule rule) {
+    this.columnSelector = CSVPath.of(columnSelector);
     this.rule = rule;
   }
 
@@ -53,15 +47,8 @@ public class CsvNavigateCommand extends AbstractStreamCommand {
    * @param rule the transformation rule to apply to selected column
    * @throws IllegalArgumentException if columnSelector or rule is null
    */
-  public CsvNavigateCommand(CSVPath columnSelector, IRule rule) {
-    if (columnSelector == null) {
-      throw new IllegalArgumentException("Column selector cannot be null");
-    }
-    if (rule == null) {
-      throw new IllegalArgumentException("Rule cannot be null");
-    }
+  private CsvNavigateCommand(CSVPath columnSelector, IRule rule) {
     this.columnSelector = columnSelector;
-    columnSelector.toString();
     this.rule = rule;
   }
 
@@ -72,16 +59,8 @@ public class CsvNavigateCommand extends AbstractStreamCommand {
    * @param rule the transformation rule to apply to selected column
    * @throws IllegalArgumentException if treePath or rule is null
    */
-  public CsvNavigateCommand(TreePath treePath, IRule rule) {
-    if (treePath == null) {
-      throw new IllegalArgumentException("TreePath cannot be null");
-    }
-    if (rule == null) {
-      throw new IllegalArgumentException("Rule cannot be null");
-    }
-    // Convert TreePath to CSVPath - assume simple column name
-    String columnName = treePath.toString();
-    this.columnSelector = new CSVPath(columnName);
+  private CsvNavigateCommand(TreePath treePath, IRule rule) {
+    this.columnSelector = CSVPath.of(treePath.toString());
     this.rule = rule;
   }
 
@@ -98,6 +77,12 @@ public class CsvNavigateCommand extends AbstractStreamCommand {
    */
   @Deprecated
   public static CsvNavigateCommand create(String columnSelector, IRule rule) {
+    if (columnSelector == null) {
+      throw new IllegalArgumentException("Column selector cannot be null");
+    }
+    if (rule == null) {
+      throw new IllegalArgumentException("Rule cannot be null");
+    }
     return new CsvNavigateCommand(columnSelector, rule);
   }
 
@@ -107,10 +92,34 @@ public class CsvNavigateCommand extends AbstractStreamCommand {
    * @param columnSelector the typed CSVPath to select column
    * @param rule the transformation rule to apply to selected column data
    * @return a CsvNavigateCommand that extracts the specified column with the given rule
-   * @throws IllegalArgumentException if rule is null
+   * @throws IllegalArgumentException if columnSelector or rule is null
    */
   public static CsvNavigateCommand create(CSVPath columnSelector, IRule rule) {
+    if (columnSelector == null) {
+      throw new IllegalArgumentException("Column selector cannot be null");
+    }
+    if (rule == null) {
+      throw new IllegalArgumentException("Rule cannot be null");
+    }
     return new CsvNavigateCommand(columnSelector, rule);
+  }
+
+  /**
+   * Factory method for creating a CSV navigation command with TreePath compatibility.
+   *
+   * @param treePath the TreePath representing column selector
+   * @param rule the transformation rule to apply to selected column data
+   * @return a CsvNavigateCommand that extracts the specified column with the given rule
+   * @throws IllegalArgumentException if treePath or rule is null
+   */
+  public static CsvNavigateCommand create(TreePath treePath, IRule rule) {
+    if (treePath == null) {
+      throw new IllegalArgumentException("TreePath cannot be null");
+    }
+    if (rule == null) {
+      throw new IllegalArgumentException("Rule cannot be null");
+    }
+    return new CsvNavigateCommand(treePath, rule);
   }
 
   @Override

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  *
  * <pre>
  * String[] requiredColumns = {"id", "name", "email"};
- * CsvValidateCommand validator = new CsvValidateCommand(requiredColumns);
+ * CsvValidateCommand validator = CsvValidateCommand.create(requiredColumns);
  * validator.consume(csvInputStream);
  * </pre>
  */
@@ -49,7 +49,7 @@ public class CsvValidateCommand extends ConsumerCommand {
    * @param requiredColumns 必須カラム名の配列
    * @throws IllegalArgumentException 必須カラムがnullの場合
    */
-  public CsvValidateCommand(final String... requiredColumns) {
+  private CsvValidateCommand(final String... requiredColumns) {
     this(true, 10, requiredColumns);
   }
 
@@ -59,15 +59,10 @@ public class CsvValidateCommand extends ConsumerCommand {
    * @param hasHeader ヘッダー行の存在フラグ
    * @param maxErrorsToReport 報告する最大エラー数
    * @param requiredColumns 必須カラム名の配列
-   * @throws IllegalArgumentException requiredColumnsがnullの場合
    */
-  public CsvValidateCommand(
+  private CsvValidateCommand(
       final boolean hasHeader, final int maxErrorsToReport, final String... requiredColumns) {
     super();
-    if (requiredColumns == null) {
-      throw new IllegalArgumentException("Required columns cannot be null");
-    }
-
     this.hasHeader = hasHeader;
     this.maxErrorsToReport = Math.max(1, maxErrorsToReport);
 
@@ -83,6 +78,37 @@ public class CsvValidateCommand extends ConsumerCommand {
     } else {
       LOGGER.info("Required columns: {}", this.requiredColumns);
     }
+  }
+
+  /**
+   * 必須カラムを指定してCsvValidateCommandを作成（ヘッダー行ありと仮定）
+   *
+   * @param requiredColumns 必須カラム名の配列
+   * @return a CsvValidateCommand instance
+   * @throws IllegalArgumentException 必須カラムがnullの場合
+   */
+  public static CsvValidateCommand create(final String... requiredColumns) {
+    if (requiredColumns == null) {
+      throw new IllegalArgumentException("Required columns cannot be null");
+    }
+    return new CsvValidateCommand(requiredColumns);
+  }
+
+  /**
+   * 詳細設定を指定してCsvValidateCommandを作成
+   *
+   * @param hasHeader ヘッダー行の存在フラグ
+   * @param maxErrorsToReport 報告する最大エラー数
+   * @param requiredColumns 必須カラム名の配列
+   * @return a CsvValidateCommand instance
+   * @throws IllegalArgumentException requiredColumnsがnullの場合
+   */
+  public static CsvValidateCommand create(
+      final boolean hasHeader, final int maxErrorsToReport, final String... requiredColumns) {
+    if (requiredColumns == null) {
+      throw new IllegalArgumentException("Required columns cannot be null");
+    }
+    return new CsvValidateCommand(hasHeader, maxErrorsToReport, requiredColumns);
   }
 
   /**

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonFilterCommand.java
@@ -40,13 +40,23 @@ public class JsonFilterCommand extends AbstractStreamCommand {
    * @param jsonPath the typed TreePath to extract data
    * @throws IllegalArgumentException if jsonPath is null
    */
-  public JsonFilterCommand(IPath<List<String>> jsonPath) {
+  private JsonFilterCommand(IPath<List<String>> jsonPath) {
+    this.jsonPath = jsonPath;
+    this.objectMapper = new ObjectMapper();
+  }
+
+  /**
+   * Factory method for JSON filtering with typed path selector.
+   *
+   * @param jsonPath the typed path to extract data
+   * @return a JsonFilterCommand instance
+   * @throws IllegalArgumentException if jsonPath is null
+   */
+  public static JsonFilterCommand create(IPath<List<String>> jsonPath) {
     if (jsonPath == null) {
       throw new IllegalArgumentException("TreePath cannot be null");
     }
-    this.jsonPath = jsonPath;
-    jsonPath.toString();
-    this.objectMapper = new ObjectMapper();
+    return new JsonFilterCommand(jsonPath);
   }
 
   @Override

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonNavigateCommand.java
@@ -39,13 +39,7 @@ public class JsonNavigateCommand extends AbstractStreamCommand {
    * @param rule the transformation rule to apply to selected elements
    * @throws IllegalArgumentException if treePath or rule is null
    */
-  public JsonNavigateCommand(TreePath treePath, IRule rule) {
-    if (treePath == null) {
-      throw new IllegalArgumentException("TreePath cannot be null");
-    }
-    if (rule == null) {
-      throw new IllegalArgumentException("Rule cannot be null");
-    }
+  private JsonNavigateCommand(TreePath treePath, IRule rule) {
     this.treePath = treePath;
     this.rule = rule;
     this.objectMapper = new ObjectMapper();
@@ -57,9 +51,15 @@ public class JsonNavigateCommand extends AbstractStreamCommand {
    * @param treePath the TreePath to select data
    * @param rule the transformation rule to apply to selected elements
    * @return a JsonNavigateCommand that transforms the specified path with the given rule
-   * @throws IllegalArgumentException if rule is null
+   * @throws IllegalArgumentException if treePath or rule is null
    */
   public static JsonNavigateCommand create(TreePath treePath, IRule rule) {
+    if (treePath == null) {
+      throw new IllegalArgumentException("TreePath cannot be null");
+    }
+    if (rule == null) {
+      throw new IllegalArgumentException("Rule cannot be null");
+    }
     return new JsonNavigateCommand(treePath, rule);
   }
 

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/ValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/ValidateCommand.java
@@ -45,15 +45,28 @@ public class ValidateCommand extends ConsumerCommand {
    * @param schemaPath クラスパスリソース識別子（例: "schemas/test.xsd", "test-schema.xsd"）
    * @throws StreamProcessingException スキーマファイルの読み込みに失敗した場合
    */
-  public ValidateCommand(String schemaPath) {
+  private ValidateCommand(String schemaPath, Schema schema) {
+    this.schemaPath = schemaPath;
+    this.schema = schema;
+  }
+
+  /**
+   * Factory method for creating a ValidateCommand.
+   *
+   * @param schemaPath クラスパスリソース識別子（例: "schemas/test.xsd", "test-schema.xsd"）
+   * @return a ValidateCommand instance
+   * @throws NullPointerException スキーマパスがnullの場合
+   * @throws IllegalArgumentException スキーマパスが空の場合
+   * @throws StreamProcessingException スキーマファイルの読み込みに失敗した場合
+   */
+  public static ValidateCommand create(String schemaPath) {
     Objects.requireNonNull(schemaPath, "Schema path cannot be null");
     if (schemaPath.trim().isEmpty()) {
       throw new IllegalArgumentException("Schema path cannot be empty");
     }
-
-    // クラスパスリソース識別子として扱う（セキュリティはClasspathResourceValidatorが担保）
-    this.schemaPath = normalizeClasspathPath(schemaPath);
-    this.schema = loadSchemaFromClasspath(this.schemaPath);
+    String normalizedPath = normalizeClasspathPath(schemaPath);
+    Schema schema = loadSchemaFromClasspath(normalizedPath);
+    return new ValidateCommand(normalizedPath, schema);
   }
 
   /**
@@ -64,7 +77,7 @@ public class ValidateCommand extends ConsumerCommand {
    * @param inputPath 入力されたクラスパス識別子
    * @return 正規化されたクラスパス識別子
    */
-  private String normalizeClasspathPath(String inputPath) {
+  private static String normalizeClasspathPath(String inputPath) {
     String trimmed = inputPath.trim();
     // Remove leading slash for ClassLoader compatibility
     if (trimmed.startsWith("/")) {
@@ -80,7 +93,7 @@ public class ValidateCommand extends ConsumerCommand {
    * @return ロードされたSchemaオブジェクト
    * @throws StreamProcessingException スキーマロードに失敗した場合
    */
-  private Schema loadSchemaFromClasspath(String validatedPath) {
+  private static Schema loadSchemaFromClasspath(String validatedPath) {
     try {
       // セキュアなSchemaFactoryの作成（新しいセキュリティインフラを使用）
       SchemaFactory factory = SecureXmlConfiguration.createSecureSchemaFactory();

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
@@ -42,12 +42,22 @@ public class XmlFilterCommand extends AbstractStreamCommand {
    * @param xpath the typed TreePath to extract elements
    * @throws IllegalArgumentException if xpath is null
    */
-  public XmlFilterCommand(IPath<List<String>> xpath) {
+  private XmlFilterCommand(IPath<List<String>> xpath) {
+    this.xpath = xpath;
+  }
+
+  /**
+   * Factory method for XML filtering with typed path selector.
+   *
+   * @param xpath the typed path to extract elements
+   * @return an XmlFilterCommand instance
+   * @throws IllegalArgumentException if xpath is null
+   */
+  public static XmlFilterCommand create(IPath<List<String>> xpath) {
     if (xpath == null) {
       throw new IllegalArgumentException("TreePath cannot be null");
     }
-    this.xpath = xpath;
-    xpath.toString();
+    return new XmlFilterCommand(xpath);
   }
 
   @Override

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
@@ -42,13 +42,7 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
    * @param rule the transformation rule to apply to selected elements
    * @throws IllegalArgumentException if treePath or rule is null
    */
-  public XmlNavigateCommand(TreePath treePath, IRule rule) {
-    if (treePath == null) {
-      throw new IllegalArgumentException("TreePath cannot be null");
-    }
-    if (rule == null) {
-      throw new IllegalArgumentException("Rule cannot be null");
-    }
+  private XmlNavigateCommand(TreePath treePath, IRule rule) {
     this.treePath = treePath;
     this.rule = rule;
   }
@@ -60,9 +54,15 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
    * @param rule the transformation rule to apply to selected elements
    * @return an XmlNavigateCommand that transforms the specified TreePath elements with the given
    *     rule
-   * @throws IllegalArgumentException if rule is null
+   * @throws IllegalArgumentException if treePath or rule is null
    */
   public static XmlNavigateCommand create(TreePath treePath, IRule rule) {
+    if (treePath == null) {
+      throw new IllegalArgumentException("TreePath cannot be null");
+    }
+    if (rule == null) {
+      throw new IllegalArgumentException("Rule cannot be null");
+    }
     return new XmlNavigateCommand(treePath, rule);
   }
 

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/composite/ChainRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/composite/ChainRule.java
@@ -41,9 +41,6 @@ public class ChainRule implements IRule {
 
   /** Private constructor for builder pattern */
   private ChainRule(List<IRule> rules) {
-    if (rules == null || rules.isEmpty()) {
-      throw new IllegalArgumentException("Chain must contain at least one rule");
-    }
     this.rules = Collections.unmodifiableList(new ArrayList<>(rules));
   }
 
@@ -199,6 +196,9 @@ public class ChainRule implements IRule {
      * @throws IllegalArgumentException if no rules have been added
      */
     public ChainRule build() {
+      if (rules.isEmpty()) {
+        throw new IllegalArgumentException("Chain must contain at least one rule");
+      }
       return new ChainRule(rules);
     }
   }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/string/LowerCaseRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/string/LowerCaseRule.java
@@ -43,11 +43,22 @@ public class LowerCaseRule implements IRule {
    * @param locale the locale to use for case conversion
    * @throws IllegalArgumentException if locale is null
    */
-  public LowerCaseRule(Locale locale) {
+  private LowerCaseRule(Locale locale) {
+    this.locale = locale;
+  }
+
+  /**
+   * Creates a LowerCaseRule using the specified locale.
+   *
+   * @param locale the locale to use for case conversion
+   * @return a LowerCaseRule instance
+   * @throws IllegalArgumentException if locale is null
+   */
+  public static LowerCaseRule create(Locale locale) {
     if (locale == null) {
       throw new IllegalArgumentException("Locale cannot be null");
     }
-    this.locale = locale;
+    return new LowerCaseRule(locale);
   }
 
   @Override

--- a/streamconverter-core/src/main/java/com/streamconverter/path/CSVPath.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/path/CSVPath.java
@@ -21,7 +21,7 @@ public class CSVPath extends AbstractPath<Integer> {
    * @param selector 列選択子（列名または数値インデックス）
    * @throws IllegalArgumentException セレクターが不正な場合
    */
-  public CSVPath(String selector) {
+  private CSVPath(String selector) {
     super(selector);
     this.selectors = Collections.singletonList(selector.trim());
   }
@@ -32,11 +32,8 @@ public class CSVPath extends AbstractPath<Integer> {
    * @param selectorList 列選択子のリスト
    * @throws IllegalArgumentException セレクターが不正な場合
    */
-  public CSVPath(List<String> selectorList) {
+  private CSVPath(List<String> selectorList) {
     super(String.join(",", selectorList));
-    if (selectorList == null || selectorList.isEmpty()) {
-      throw new IllegalArgumentException("Selector list cannot be null or empty");
-    }
     List<String> temp = new ArrayList<>();
     for (String sel : selectorList) {
       temp.add(sel.trim());
@@ -44,11 +41,37 @@ public class CSVPath extends AbstractPath<Integer> {
     this.selectors = Collections.unmodifiableList(temp);
   }
 
-  @Override
-  protected void validateAndNormalize(String rawSelector) {
-    if (isNullOrEmpty(rawSelector)) {
+  /**
+   * 単一セレクターでCSVPathを作成
+   *
+   * @param selector 列選択子（列名または数値インデックス）
+   * @return CSVPath instance
+   * @throws IllegalArgumentException セレクターが不正な場合
+   */
+  public static CSVPath of(String selector) {
+    if (selector == null || selector.trim().isEmpty()) {
       throw new IllegalArgumentException("CSV column selector cannot be null or empty");
     }
+    return new CSVPath(selector);
+  }
+
+  /**
+   * 複数セレクターでCSVPathを作成（OR条件）
+   *
+   * @param selectorList 列選択子のリスト
+   * @return CSVPath instance
+   * @throws IllegalArgumentException セレクターが不正な場合
+   */
+  public static CSVPath of(List<String> selectorList) {
+    if (selectorList == null || selectorList.isEmpty()) {
+      throw new IllegalArgumentException("Selector list cannot be null or empty");
+    }
+    return new CSVPath(selectorList);
+  }
+
+  @Override
+  protected void validateAndNormalize(String rawSelector) {
+    // Validation is performed in factory methods (of/create) to avoid CT_CONSTRUCTOR_THROW
   }
 
   @Override

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/FilterCommandBasicTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/FilterCommandBasicTest.java
@@ -31,7 +31,7 @@ class FilterCommandBasicTest {
     String jsonInput = "{\"name\":\"田中太郎\",\"age\":30,\"city\":\"東京\"}";
 
     // Create command to extract "name" property
-    JsonFilterCommand command = new JsonFilterCommand(TreePath.fromJson("$.name"));
+    JsonFilterCommand command = JsonFilterCommand.create(TreePath.fromJson("$.name"));
 
     // Execute
     ByteArrayInputStream input =
@@ -50,7 +50,7 @@ class FilterCommandBasicTest {
     String jsonInput = "{\"userId\":\"1001\",\"amount\":120000}";
 
     // Create command to extract entire JSON (root path)
-    JsonFilterCommand command = new JsonFilterCommand(TreePath.fromJson("$"));
+    JsonFilterCommand command = JsonFilterCommand.create(TreePath.fromJson("$"));
 
     // Execute
     ByteArrayInputStream input =
@@ -69,7 +69,7 @@ class FilterCommandBasicTest {
     String csvInput = createTestData("name,age,city", "田中太郎,30,東京", "佐藤花子,25,大阪");
 
     // Create command to extract "name" column
-    CsvFilterCommand command = CsvFilterCommand.create(new CSVPath("name"));
+    CsvFilterCommand command = CsvFilterCommand.create(CSVPath.of("name"));
 
     // Execute
     ByteArrayInputStream input =
@@ -90,7 +90,7 @@ class FilterCommandBasicTest {
 
     // Create command to extract "name" and "city" columns
     CsvFilterCommand command =
-        CsvFilterCommand.create(new CSVPath(Arrays.asList("name", "city")), true);
+        CsvFilterCommand.create(CSVPath.of(Arrays.asList("name", "city")), true);
 
     // Execute
     ByteArrayInputStream input =
@@ -111,7 +111,7 @@ class FilterCommandBasicTest {
         "<?xml version=\"1.0\"?><users><user><name>田中太郎</name><age>30</age></user></users>";
 
     // Create command to extract "name" elements
-    XmlFilterCommand command = new XmlFilterCommand(TreePath.fromXml("users/user/name"));
+    XmlFilterCommand command = XmlFilterCommand.create(TreePath.fromXml("users/user/name"));
 
     // Execute
     ByteArrayInputStream input =
@@ -131,7 +131,7 @@ class FilterCommandBasicTest {
     String jsonInput = "{\"name\":\"田中太郎\",\"age\":30}";
 
     // Create command to extract non-existent property
-    JsonFilterCommand command = new JsonFilterCommand(TreePath.fromJson("$.nonexistent"));
+    JsonFilterCommand command = JsonFilterCommand.create(TreePath.fromJson("$.nonexistent"));
 
     // Execute
     ByteArrayInputStream input =
@@ -150,7 +150,7 @@ class FilterCommandBasicTest {
     String csvInput = createTestData("田中太郎,30,東京", "佐藤花子,25,大阪");
 
     // Create command to extract first column (index 0) without header
-    CsvFilterCommand command = CsvFilterCommand.create(new CSVPath("0"), false);
+    CsvFilterCommand command = CsvFilterCommand.create(CSVPath.of("0"), false);
 
     // Execute
     ByteArrayInputStream input =
@@ -181,7 +181,7 @@ class FilterCommandBasicTest {
 
     String jsonData = jsonBuilder.toString();
 
-    JsonFilterCommand command = new JsonFilterCommand(TreePath.fromJson("$[*].name"));
+    JsonFilterCommand command = JsonFilterCommand.create(TreePath.fromJson("$[*].name"));
 
     TrackingInputStream trackingInputStream =
         new TrackingInputStream(jsonData.getBytes(StandardCharsets.UTF_8));
@@ -222,7 +222,7 @@ class FilterCommandBasicTest {
     String csvData = csvBuilder.toString();
 
     CsvFilterCommand command =
-        CsvFilterCommand.create(new CSVPath(Arrays.asList("name", "department")), true);
+        CsvFilterCommand.create(CSVPath.of(Arrays.asList("name", "department")), true);
 
     TrackingInputStream trackingInputStream =
         new TrackingInputStream(csvData.getBytes(StandardCharsets.UTF_8));
@@ -272,7 +272,7 @@ class FilterCommandBasicTest {
 
     String xmlData = xmlBuilder.toString();
 
-    XmlFilterCommand command = new XmlFilterCommand(TreePath.fromXml("records/record/name"));
+    XmlFilterCommand command = XmlFilterCommand.create(TreePath.fromXml("records/record/name"));
 
     TrackingInputStream trackingInputStream =
         new TrackingInputStream(xmlData.getBytes(StandardCharsets.UTF_8));
@@ -318,7 +318,7 @@ class FilterCommandBasicTest {
     String jsonData = jsonBuilder.toString();
 
     JsonFilterCommand command =
-        new JsonFilterCommand(TreePath.fromJson("$.users[*].profile.department"));
+        JsonFilterCommand.create(TreePath.fromJson("$.users[*].profile.department"));
 
     TrackingInputStream trackingInputStream =
         new TrackingInputStream(jsonData.getBytes(StandardCharsets.UTF_8));

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/charcode/ConvertTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/charcode/ConvertTest.java
@@ -24,7 +24,7 @@ class ConvertTest {
   @DisplayName("Constructor Test")
   void testConstructor() {
     // コンストラクタのテスト
-    CharacterConvertCommand command = new CharacterConvertCommand("UTF-8", "UTF-16");
+    CharacterConvertCommand command = CharacterConvertCommand.create("UTF-8", "UTF-16");
     assertNotNull(command);
   }
 
@@ -33,7 +33,7 @@ class ConvertTest {
   @DisplayName("Execute Normal Case: Character Code Conversion")
   void testExecuteWithValidCharsets(String fromCharset, String toCharset) throws IOException {
     // 正常系のexecuteメソッドテスト
-    CharacterConvertCommand command = new CharacterConvertCommand(fromCharset, toCharset);
+    CharacterConvertCommand command = CharacterConvertCommand.create(fromCharset, toCharset);
 
     // 入力文字列をfromCharsetでエンコード
     byte[] inputBytes = TEST_STRING.getBytes(Charset.forName(fromCharset));
@@ -53,7 +53,7 @@ class ConvertTest {
   @DisplayName("Execute Error Case: Null Input Stream")
   void testExecuteWithNullInputStream() {
     // null入力ストリームでのexecuteメソッドテスト
-    CharacterConvertCommand command = new CharacterConvertCommand("UTF-8", "UTF-16");
+    CharacterConvertCommand command = CharacterConvertCommand.create("UTF-8", "UTF-16");
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
     assertThrows(
@@ -67,7 +67,7 @@ class ConvertTest {
   @DisplayName("Execute Error Case: Null Output Stream")
   void testExecuteWithNullOutputStream() {
     // null出力ストリームでのexecuteメソッドテスト
-    CharacterConvertCommand command = new CharacterConvertCommand("UTF-8", "UTF-16");
+    CharacterConvertCommand command = CharacterConvertCommand.create("UTF-8", "UTF-16");
     InputStream inputStream =
         new ByteArrayInputStream(TEST_STRING.getBytes(StandardCharsets.UTF_8));
 
@@ -86,7 +86,7 @@ class ConvertTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          new CharacterConvertCommand("INVALID-CHARSET", "UTF-8");
+          CharacterConvertCommand.create("INVALID-CHARSET", "UTF-8");
         });
   }
 
@@ -98,7 +98,7 @@ class ConvertTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          new CharacterConvertCommand("UTF-8", "INVALID-CHARSET");
+          CharacterConvertCommand.create("UTF-8", "INVALID-CHARSET");
         });
   }
 
@@ -106,7 +106,7 @@ class ConvertTest {
   @DisplayName("Execute: Empty Input Stream")
   void testExecuteWithEmptyInputStream() throws IOException {
     // 空の入力ストリームでのexecuteメソッドテスト
-    CharacterConvertCommand command = new CharacterConvertCommand("UTF-8", "UTF-16");
+    CharacterConvertCommand command = CharacterConvertCommand.create("UTF-8", "UTF-16");
 
     try (InputStream inputStream = new ByteArrayInputStream(new byte[0]);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
@@ -123,7 +123,7 @@ class ConvertTest {
   void testJapaneseCharacterConversion() throws IOException {
     // 日本語文字の変換テスト
     String japaneseText = "日本語のテスト文字列です。漢字、ひらがな、カタカナを含みます。";
-    CharacterConvertCommand command = new CharacterConvertCommand("UTF-8", "UTF-16");
+    CharacterConvertCommand command = CharacterConvertCommand.create("UTF-8", "UTF-16");
 
     try (InputStream inputStream =
             new ByteArrayInputStream(japaneseText.getBytes(StandardCharsets.UTF_8));
@@ -140,7 +140,7 @@ class ConvertTest {
   @Test
   @DisplayName("Streaming character conversion behavior verification")
   void testStreamingCharacterConversionBehavior() throws IOException {
-    CharacterConvertCommand command = new CharacterConvertCommand("UTF-8", "UTF-16");
+    CharacterConvertCommand command = CharacterConvertCommand.create("UTF-8", "UTF-16");
 
     // Create moderate-sized multilingual text to observe streaming behavior
     StringBuilder textBuilder = new StringBuilder();
@@ -183,7 +183,7 @@ class ConvertTest {
   @Test
   @DisplayName("Incremental character conversion processing verification")
   void testIncrementalCharacterConversionProcessing() throws IOException {
-    CharacterConvertCommand command = new CharacterConvertCommand("UTF-8", "UTF-16");
+    CharacterConvertCommand command = CharacterConvertCommand.create("UTF-8", "UTF-16");
 
     // Create complex multilingual content to force incremental processing
     StringBuilder contentBuilder = new StringBuilder();

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvNavigateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvNavigateCommandTest.java
@@ -26,7 +26,7 @@ class CsvNavigateCommandTest {
   @BeforeEach
   void setUp() {
     // Use a specific column selector instead of createForAll
-    command = CsvNavigateCommand.create(new CSVPath("name"), new PassThroughRule());
+    command = CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule());
   }
 
   @Test
@@ -95,7 +95,7 @@ class CsvNavigateCommandTest {
 
     // Create command for the specific column that exists in this test's data
     CsvNavigateCommand testCommand =
-        CsvNavigateCommand.create(new CSVPath("id"), new PassThroughRule());
+        CsvNavigateCommand.create(CSVPath.of("id"), new PassThroughRule());
 
     TrackingInputStream trackingInputStream =
         new TrackingInputStream(csvData.getBytes(StandardCharsets.UTF_8));
@@ -138,7 +138,7 @@ class CsvNavigateCommandTest {
 
     // Create command for the specific column that exists in this test's data
     CsvNavigateCommand testCommand =
-        CsvNavigateCommand.create(new CSVPath("employee_id"), new PassThroughRule());
+        CsvNavigateCommand.create(CSVPath.of("employee_id"), new PassThroughRule());
 
     TrackingInputStream trackingInputStream =
         new TrackingInputStream(csvData.getBytes(StandardCharsets.UTF_8));

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -21,7 +21,7 @@ public class CsvValidateCommandTest {
 
     assertDoesNotThrow(
         () -> {
-          CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+          CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
           assertNotNull(command);
         });
   }
@@ -30,7 +30,8 @@ public class CsvValidateCommandTest {
   @DisplayName("Constructor with null required columns throws exception")
   void testConstructorWithNullRequiredColumns() {
     IllegalArgumentException exception =
-        assertThrows(IllegalArgumentException.class, () -> new CsvValidateCommand((String[]) null));
+        assertThrows(
+            IllegalArgumentException.class, () -> CsvValidateCommand.create((String[]) null));
     assertEquals("Required columns cannot be null", exception.getMessage());
   }
 
@@ -41,7 +42,7 @@ public class CsvValidateCommandTest {
 
     assertDoesNotThrow(
         () -> {
-          CsvValidateCommand command = new CsvValidateCommand(emptyColumns);
+          CsvValidateCommand command = CsvValidateCommand.create(emptyColumns);
           assertNotNull(command);
         });
   }
@@ -53,13 +54,13 @@ public class CsvValidateCommandTest {
 
     assertDoesNotThrow(
         () -> {
-          CsvValidateCommand command = new CsvValidateCommand(true, 10, requiredColumns);
+          CsvValidateCommand command = CsvValidateCommand.create(true, 10, requiredColumns);
           assertNotNull(command);
         });
 
     assertDoesNotThrow(
         () -> {
-          CsvValidateCommand command = new CsvValidateCommand(false, 10, requiredColumns);
+          CsvValidateCommand command = CsvValidateCommand.create(false, 10, requiredColumns);
           assertNotNull(command);
         });
   }
@@ -68,7 +69,7 @@ public class CsvValidateCommandTest {
   @DisplayName("Valid CSV with required columns validation succeeds")
   void testValidCsvWithRequiredColumnsSuccess() throws IOException {
     String[] requiredColumns = {"id", "name", "email"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     String validCsv =
         """
@@ -89,7 +90,7 @@ public class CsvValidateCommandTest {
   @DisplayName("CSV missing required columns validation fails")
   void testCsvMissingRequiredColumnsFailure() throws IOException {
     String[] requiredColumns = {"id", "name", "email", "phone"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     String csvMissingColumns =
         """
@@ -112,7 +113,7 @@ public class CsvValidateCommandTest {
   @DisplayName("CSV with duplicate headers validation fails")
   void testCsvWithDuplicateHeadersFailure() throws IOException {
     String[] requiredColumns = {"id", "name"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     String csvWithDuplicates =
         """
@@ -135,7 +136,7 @@ public class CsvValidateCommandTest {
   @DisplayName("CSV with inconsistent row length validation fails")
   void testCsvWithInconsistentRowLengthFailure() throws IOException {
     String[] requiredColumns = {"id", "name", "email"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     String csvInconsistentRows =
         """
@@ -159,7 +160,7 @@ public class CsvValidateCommandTest {
   @DisplayName("Empty CSV input validation fails")
   void testEmptyCsvInputFailure() throws IOException {
     String[] requiredColumns = {"id", "name", "email"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     ByteArrayInputStream inputStream =
         new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8));
@@ -175,7 +176,7 @@ public class CsvValidateCommandTest {
   @DisplayName("CSV with only header validation fails")
   void testCsvWithOnlyHeaderFailure() throws IOException {
     String[] requiredColumns = {"id", "name", "email"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     String csvOnlyHeader = "id,name,email,department\n";
 
@@ -193,7 +194,7 @@ public class CsvValidateCommandTest {
   @DisplayName("CSV without header validation with hasHeader=false")
   void testCsvWithoutHeaderValidation() throws IOException {
     String[] requiredColumns = {}; // ヘッダーなしの場合は必須カラムなし
-    CsvValidateCommand command = new CsvValidateCommand(false, 10, requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(false, 10, requiredColumns);
 
     String csvWithoutHeader =
         """
@@ -213,7 +214,7 @@ public class CsvValidateCommandTest {
   @DisplayName("Large CSV validation")
   void testLargeCsvValidation() throws IOException {
     String[] requiredColumns = {"id", "name", "email"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     // 大きなCSVデータを作成
     StringBuilder largeCsv = new StringBuilder();
@@ -235,7 +236,7 @@ public class CsvValidateCommandTest {
   @DisplayName("CSV with special characters validation")
   void testCsvWithSpecialCharactersValidation() throws IOException {
     String[] requiredColumns = {"id", "name", "email"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     String csvWithSpecialChars =
         """
@@ -256,7 +257,7 @@ public class CsvValidateCommandTest {
   @DisplayName("Null input stream throws exception")
   void testNullInputStream() throws IOException {
     String[] requiredColumns = {"id", "name", "email"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     NullPointerException exception =
         assertThrows(NullPointerException.class, () -> command.consume(null));
@@ -268,7 +269,7 @@ public class CsvValidateCommandTest {
   @DisplayName("CSV with quoted fields containing newlines")
   void testCsvWithQuotedFieldsContainingNewlines() throws IOException {
     String[] requiredColumns = {"id", "name", "description"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     String csvWithNewlines =
         """
@@ -289,7 +290,7 @@ public class CsvValidateCommandTest {
   @DisplayName("CSV with empty fields validation")
   void testCsvWithEmptyFieldsValidation() throws IOException {
     String[] requiredColumns = {"id", "name", "email"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     String csvWithEmptyFields =
         """
@@ -311,7 +312,7 @@ public class CsvValidateCommandTest {
   @DisplayName("Malformed CSV with unclosed quotes validation fails")
   void testMalformedCsvWithUnclosedQuotes() throws IOException {
     String[] requiredColumns = {"id", "name", "email"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     String malformedCsv =
         """
@@ -333,7 +334,7 @@ public class CsvValidateCommandTest {
   @DisplayName("CSV validation with no required columns succeeds")
   void testCsvValidationWithNoRequiredColumns() throws IOException {
     String[] requiredColumns = {}; // 必須カラムなし
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     String csvAnyStructure =
         """
@@ -354,7 +355,7 @@ public class CsvValidateCommandTest {
       "Verify streaming behavior: validation completes before input stream is fully consumed")
   void testStreamingValidationBehavior() throws IOException {
     String[] requiredColumns = {"id", "name", "email"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     // Create a larger CSV to ensure streaming behavior is observable
     StringBuilder csvBuilder = new StringBuilder();
@@ -389,7 +390,7 @@ public class CsvValidateCommandTest {
   @DisplayName("Verify incremental CSV processing with streaming validation")
   void testIncrementalCsvValidation() throws IOException {
     String[] requiredColumns = {"id", "name"};
-    CsvValidateCommand command = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand command = CsvValidateCommand.create(requiredColumns);
 
     // Create CSV data that requires incremental processing
     StringBuilder csvBuilder = new StringBuilder();

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ValidateTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ValidateTest.java
@@ -38,7 +38,7 @@ class ValidateTest {
   @DisplayName("コンストラクタのテスト")
   void testConstructor() {
     // コンストラクタのテスト
-    ValidateCommand command = new ValidateCommand(schemaPath);
+    ValidateCommand command = ValidateCommand.create(schemaPath);
     assertNotNull(command);
   }
 
@@ -46,7 +46,7 @@ class ValidateTest {
   @DisplayName("execute正常系：有効なXML")
   void testExecuteWithValidXml() throws IOException {
     // 正常系のexecuteメソッドテスト
-    ValidateCommand command = new ValidateCommand(schemaPath);
+    ValidateCommand command = ValidateCommand.create(schemaPath);
 
     try (InputStream inputStream =
             getClass().getClassLoader().getResourceAsStream("valid-test.xml");
@@ -68,7 +68,7 @@ class ValidateTest {
   @DisplayName("execute異常系：無効なXML")
   void testExecuteWithInvalidXml() throws IOException {
     // 無効なXMLでのexecuteメソッドテスト
-    ValidateCommand command = new ValidateCommand(schemaPath);
+    ValidateCommand command = ValidateCommand.create(schemaPath);
 
     try (InputStream inputStream =
             getClass().getClassLoader().getResourceAsStream("invalid-test.xml");
@@ -87,7 +87,7 @@ class ValidateTest {
   @DisplayName("execute異常系：null入力ストリーム")
   void testExecuteWithNullInputStream() {
     // null入力ストリームでのexecuteメソッドテスト
-    ValidateCommand command = new ValidateCommand(schemaPath);
+    ValidateCommand command = ValidateCommand.create(schemaPath);
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
     assertThrows(
@@ -101,7 +101,7 @@ class ValidateTest {
   @DisplayName("execute異常系：null出力ストリーム")
   void testExecuteWithNullOutputStream() throws IOException {
     // null出力ストリームでのexecuteメソッドテスト
-    ValidateCommand command = new ValidateCommand(schemaPath);
+    ValidateCommand command = ValidateCommand.create(schemaPath);
 
     try (InputStream inputStream =
         getClass().getClassLoader().getResourceAsStream("valid-test.xml")) {
@@ -121,7 +121,7 @@ class ValidateTest {
     assertThrows(
         com.streamconverter.StreamProcessingException.class,
         () -> {
-          new ValidateCommand("non-existent-schema.xsd");
+          ValidateCommand.create("non-existent-schema.xsd");
         });
   }
 
@@ -134,14 +134,14 @@ class ValidateTest {
     assertThrows(
         com.streamconverter.StreamProcessingException.class,
         () -> {
-          new ValidateCommand("../secret-schema.xsd");
+          ValidateCommand.create("../secret-schema.xsd");
         },
         "Path with .. should be treated as non-existent resource");
 
     assertThrows(
         com.streamconverter.StreamProcessingException.class,
         () -> {
-          new ValidateCommand("schemas/../../etc/passwd");
+          ValidateCommand.create("schemas/../../etc/passwd");
         },
         "Path with .. should be treated as non-existent resource");
   }
@@ -150,7 +150,7 @@ class ValidateTest {
   @DisplayName("execute：空の入力ストリーム")
   void testExecuteWithEmptyInputStream() throws IOException {
     // 空の入力ストリームでのexecuteメソッドテスト
-    ValidateCommand command = new ValidateCommand(schemaPath);
+    ValidateCommand command = ValidateCommand.create(schemaPath);
 
     try (InputStream inputStream = new ByteArrayInputStream(new byte[0]);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
@@ -167,7 +167,7 @@ class ValidateTest {
   @Test
   @DisplayName("Streaming XML validation behavior verification")
   void testStreamingXmlValidationBehavior() throws IOException {
-    ValidateCommand command = new ValidateCommand(schemaPath);
+    ValidateCommand command = ValidateCommand.create(schemaPath);
 
     // Create multiple valid XML documents to observe streaming behavior
     StringBuilder xmlBuilder = new StringBuilder();
@@ -211,7 +211,7 @@ class ValidateTest {
   @Test
   @DisplayName("Incremental XML validation processing verification")
   void testIncrementalXmlValidationProcessing() throws IOException {
-    ValidateCommand command = new ValidateCommand(schemaPath);
+    ValidateCommand command = ValidateCommand.create(schemaPath);
 
     // Create complex XML with nested structures to force incremental processing
     StringBuilder xmlBuilder = new StringBuilder();

--- a/streamconverter-db/src/test/java/com/streamconverter/integration/DatabaseRuleIntegrationTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/integration/DatabaseRuleIntegrationTest.java
@@ -109,7 +109,7 @@ class DatabaseRuleIntegrationTest {
     DatabaseFetchRule dbRule = new DatabaseFetchRule(DB_URL, "SELECT name FROM users WHERE id = ?");
 
     // JsonNavigateCommandの作成
-    JsonNavigateCommand command = new JsonNavigateCommand(TreePath.fromJson("$.userId"), dbRule);
+    JsonNavigateCommand command = JsonNavigateCommand.create(TreePath.fromJson("$.userId"), dbRule);
 
     // テスト用JSON
     String inputJson =
@@ -146,7 +146,7 @@ class DatabaseRuleIntegrationTest {
         new DatabaseFetchRule(DB_URL, "SELECT name FROM products WHERE code = ?");
 
     // CsvNavigateCommandの作成
-    CsvNavigateCommand command = new CsvNavigateCommand(new CSVPath("product_code"), dbRule);
+    CsvNavigateCommand command = CsvNavigateCommand.create(CSVPath.of("product_code"), dbRule);
 
     // テスト用CSV
     String inputCsv =
@@ -181,7 +181,7 @@ class DatabaseRuleIntegrationTest {
     DatabaseFetchRule dbRule = new DatabaseFetchRule(DB_URL, "SELECT name FROM users WHERE id = ?");
 
     // JsonNavigateCommandの作成
-    JsonNavigateCommand command = new JsonNavigateCommand(TreePath.fromJson("$.userId"), dbRule);
+    JsonNavigateCommand command = JsonNavigateCommand.create(TreePath.fromJson("$.userId"), dbRule);
 
     // 存在しないユーザーIDを含むJSON
     String inputJson =
@@ -215,7 +215,7 @@ class DatabaseRuleIntegrationTest {
         new DatabaseFetchRule(DB_URL, "SELECT department FROM users WHERE id = ?");
 
     // JsonNavigateCommandの作成
-    JsonNavigateCommand command = new JsonNavigateCommand(TreePath.fromJson("$.userId"), dbRule);
+    JsonNavigateCommand command = JsonNavigateCommand.create(TreePath.fromJson("$.userId"), dbRule);
 
     // 複数のユーザーIDを含むJSON配列
     String inputJson =
@@ -253,7 +253,7 @@ class DatabaseRuleIntegrationTest {
 
     // JsonNavigateCommandの作成
     JsonNavigateCommand command =
-        new JsonNavigateCommand(TreePath.fromJson("$.productCode"), dbRule);
+        JsonNavigateCommand.create(TreePath.fromJson("$.productCode"), dbRule);
 
     // テスト用JSON
     String inputJson =

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/ComplexPipelineExample.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/ComplexPipelineExample.java
@@ -97,7 +97,7 @@ public class ComplexPipelineExample {
     String[] requiredColumns = {"id", "name", "email", "department"};
 
     // CsvValidateCommandを使用して入力検証
-    return new CsvValidateCommand(requiredColumns);
+    return CsvValidateCommand.create(requiredColumns);
   }
 
   /** DB変換コマンドを作成 */

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/DatabaseRuleDemo.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/DatabaseRuleDemo.java
@@ -171,7 +171,7 @@ public class DatabaseRuleDemo {
 
     // JsonNavigateCommandの作成
     JsonNavigateCommand command =
-        new JsonNavigateCommand(TreePath.fromJson("$.customerId"), customerRule);
+        JsonNavigateCommand.create(TreePath.fromJson("$.customerId"), customerRule);
 
     // 変換前のJSON
     String inputJson =
@@ -210,7 +210,7 @@ public class DatabaseRuleDemo {
         new DatabaseFetchRule(DB_URL, "SELECT name FROM products WHERE code = ?");
 
     // CsvNavigateCommandの作成
-    CsvNavigateCommand command = new CsvNavigateCommand(new CSVPath("product_code"), productRule);
+    CsvNavigateCommand command = CsvNavigateCommand.create(CSVPath.of("product_code"), productRule);
 
     // 変換前のCSV
     String inputCsv =
@@ -245,7 +245,7 @@ public class DatabaseRuleDemo {
 
     // JsonNavigateCommandの作成
     JsonNavigateCommand command =
-        new JsonNavigateCommand(TreePath.fromJson("$.customerId"), customerRule);
+        JsonNavigateCommand.create(TreePath.fromJson("$.customerId"), customerRule);
 
     // 複数の注文を含むJSON
     String inputJson =
@@ -297,9 +297,9 @@ public class DatabaseRuleDemo {
 
     // 複数段階の変換を組み合わせる
     JsonNavigateCommand customerCommand =
-        new JsonNavigateCommand(TreePath.fromJson("$.customerId"), customerRule);
+        JsonNavigateCommand.create(TreePath.fromJson("$.customerId"), customerRule);
     JsonNavigateCommand deptCommand =
-        new JsonNavigateCommand(TreePath.fromJson("$.deptCode"), deptRule);
+        JsonNavigateCommand.create(TreePath.fromJson("$.deptCode"), deptRule);
 
     // StreamConverterで複数のコマンドを組み合わせ
     StreamConverter converter =
@@ -341,7 +341,7 @@ public class DatabaseRuleDemo {
 
     // JsonNavigateCommandの作成
     JsonNavigateCommand command =
-        new JsonNavigateCommand(TreePath.fromJson("$.customerId"), customerRule);
+        JsonNavigateCommand.create(TreePath.fromJson("$.customerId"), customerRule);
 
     // 存在しない顧客IDを含むJSON
     String inputJson =

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/PerformanceOptimizationExamples.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/PerformanceOptimizationExamples.java
@@ -75,7 +75,7 @@ public class PerformanceOptimizationExamples {
     logger.info("🔄 Processing 10,000 records...");
     processDataWithTiming(
         largeDataset.toString(),
-        CsvNavigateCommand.create(new CSVPath("name"), new PassThroughRule()));
+        CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule()));
 
     long endTime = System.currentTimeMillis();
     logger.info(String.format("⏱️ Processing completed in %d ms", endTime - startTime));
@@ -139,8 +139,7 @@ public class PerformanceOptimizationExamples {
 
     logger.info("🔄 Processing 50,000 records with 100-char data each...");
     processDataWithTiming(
-        hugeDataset.toString(),
-        CsvNavigateCommand.create(new CSVPath("id"), new PassThroughRule()));
+        hugeDataset.toString(), CsvNavigateCommand.create(CSVPath.of("id"), new PassThroughRule()));
 
     long afterMemory = getUsedMemory();
     long memoryIncrease = afterMemory - beforeMemory;
@@ -164,13 +163,13 @@ public class PerformanceOptimizationExamples {
     // Strategy 1: Direct processing
     long start = System.nanoTime();
     processDataWithTiming(
-        testData, CsvNavigateCommand.create(new CSVPath("name"), new PassThroughRule()));
+        testData, CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule()));
     long directTime = System.nanoTime() - start;
 
     // Strategy 2: Pipeline processing
     start = System.nanoTime();
     IStreamCommand[] pipeline = {
-      CsvNavigateCommand.create(new CSVPath("name"), new PassThroughRule()),
+      CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule()),
       (IStreamCommand) (in, out) -> in.transferTo(out)
     };
     processDataWithTiming(testData, pipeline);
@@ -179,7 +178,7 @@ public class PerformanceOptimizationExamples {
     // Strategy 3: Multi-stage processing
     start = System.nanoTime();
     IStreamCommand[] multiStage = {
-      CsvNavigateCommand.create(new CSVPath("name"), new PassThroughRule()),
+      CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule()),
       (IStreamCommand) (in, out) -> in.transferTo(out),
       (IStreamCommand) (in, out) -> in.transferTo(out),
       (IStreamCommand) (in, out) -> in.transferTo(out)

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/QuickStart.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/QuickStart.java
@@ -64,7 +64,7 @@ public class QuickStart {
     // Note: The lambda pass-through is a placeholder for demonstration.
     // In real applications, replace with actual processing commands.
     IStreamCommand[] pipeline = {
-      CsvNavigateCommand.create(new CSVPath("name"), new PassThroughRule()),
+      CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule()),
       (IStreamCommand) (in, out) -> in.transferTo(out)
     };
     String result = processData(csvData, pipeline);
@@ -139,7 +139,7 @@ public class QuickStart {
 
     // Create processing pipeline
     IStreamCommand[] pipeline = {
-      CsvNavigateCommand.create(new CSVPath("name"), new PassThroughRule()), // Extract names
+      CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule()), // Extract names
       (IStreamCommand) (in, out) -> in.transferTo(out) // Process names
     };
 

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/StreamConverterMDCDemo.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/StreamConverterMDCDemo.java
@@ -121,7 +121,7 @@ public class StreamConverterMDCDemo {
       // 複数のコマンドでパイプライン構築
       IStreamCommand validator = (in, out) -> in.transferTo(out);
       CsvNavigateCommand extractor =
-          CsvNavigateCommand.create(new CSVPath("product"), new PassThroughRule());
+          CsvNavigateCommand.create(CSVPath.of("product"), new PassThroughRule());
       IStreamCommand formatter = (in, out) -> in.transferTo(out);
 
       StreamConverter converter = StreamConverter.create(validator, extractor, formatter);

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/ValidationExample.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/ValidationExample.java
@@ -140,7 +140,7 @@ public class ValidationExample {
     String[] requiredColumns = {"id", "name", "email"};
 
     // CsvValidateCommandを直接使用してバリデーション実行
-    CsvValidateCommand csvValidator = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand csvValidator = CsvValidateCommand.create(requiredColumns);
     IStreamCommand dataProcessor = (in, out) -> in.transferTo(out);
 
     ByteArrayInputStream inputStream =
@@ -175,7 +175,7 @@ public class ValidationExample {
       String data, String[] requiredColumns, String description) throws IOException {
     logger.debug("Processing {}: {}", description, data.substring(0, Math.min(50, data.length())));
 
-    CsvValidateCommand csvValidator = new CsvValidateCommand(requiredColumns);
+    CsvValidateCommand csvValidator = CsvValidateCommand.create(requiredColumns);
     IStreamCommand processor = (in, out) -> in.transferTo(out);
 
     ByteArrayInputStream inputStream =

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/docs/BasicUsageExamples.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/docs/BasicUsageExamples.java
@@ -44,7 +44,7 @@ public class BasicUsageExamples {
 
     // Create pipeline: navigate CSV + process
     IStreamCommand[] pipeline = {
-      new CsvNavigateCommand(new CSVPath("productName"), new PassThroughRule()),
+      CsvNavigateCommand.create(CSVPath.of("productName"), new PassThroughRule()),
       (IStreamCommand) (in, out) -> in.transferTo(out)
     };
 
@@ -66,8 +66,7 @@ public class BasicUsageExamples {
 
     // Create pipeline: filter CSV + process
     IStreamCommand[] pipeline = {
-      CsvFilterCommand.create(new CSVPath("price")),
-      (IStreamCommand) (in, out) -> in.transferTo(out)
+      CsvFilterCommand.create(CSVPath.of("price")), (IStreamCommand) (in, out) -> in.transferTo(out)
     };
 
     StreamConverter converter = StreamConverter.create(pipeline);
@@ -89,7 +88,7 @@ public class BasicUsageExamples {
 
     // Create pipeline: navigate JSON + process
     IStreamCommand[] pipeline = {
-      new JsonNavigateCommand(TreePath.fromJson("$.user.name"), new PassThroughRule()),
+      JsonNavigateCommand.create(TreePath.fromJson("$.user.name"), new PassThroughRule()),
       (IStreamCommand) (in, out) -> in.transferTo(out)
     };
 
@@ -112,7 +111,7 @@ public class BasicUsageExamples {
 
     // Create pipeline: navigate XML + process
     IStreamCommand[] pipeline = {
-      new XmlNavigateCommand(TreePath.fromXml("root/user/name"), new PassThroughRule()),
+      XmlNavigateCommand.create(TreePath.fromXml("root/user/name"), new PassThroughRule()),
       (IStreamCommand) (in, out) -> in.transferTo(out)
     };
 
@@ -134,7 +133,7 @@ public class BasicUsageExamples {
 
     // Create pipeline: convert encoding + process
     IStreamCommand[] pipeline = {
-      new CharacterConvertCommand("Shift_JIS", "UTF-8"),
+      CharacterConvertCommand.create("Shift_JIS", "UTF-8"),
       (IStreamCommand) (in, out) -> in.transferTo(out)
     };
 
@@ -175,8 +174,8 @@ public class BasicUsageExamples {
 
     // CSV → Character conversion → Output
     IStreamCommand[] pipeline = {
-      new CsvNavigateCommand(new CSVPath("name"), new PassThroughRule()),
-      new CharacterConvertCommand("Shift_JIS", "UTF-8")
+      CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule()),
+      CharacterConvertCommand.create("Shift_JIS", "UTF-8")
     };
 
     StreamConverter converter = StreamConverter.create(pipeline);
@@ -197,7 +196,7 @@ public class BasicUsageExamples {
 
     // Create pipeline for error handling demonstration
     IStreamCommand[] pipeline = {
-      new CsvNavigateCommand(new CSVPath("name"), new PassThroughRule()),
+      CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule()),
       (IStreamCommand) (in, out) -> in.transferTo(out)
     };
 

--- a/streamconverter-tools/src/test/java/com/streamconverter/benchmark/LargeDataBenchmark.java
+++ b/streamconverter-tools/src/test/java/com/streamconverter/benchmark/LargeDataBenchmark.java
@@ -528,8 +528,8 @@ class LargeDataBenchmark {
       // 複雑パイプラインを軽量化（文字コード変換を含む4段階）
       IStreamCommand[] pipeline = {
         (in, out) -> in.transferTo(out),
-        new CharacterConvertCommand("UTF-8", "UTF-16"),
-        new CharacterConvertCommand("UTF-16", "UTF-8"),
+        CharacterConvertCommand.create("UTF-8", "UTF-16"),
+        CharacterConvertCommand.create("UTF-16", "UTF-8"),
         (in, out) -> in.transferTo(out)
       };
 
@@ -785,7 +785,7 @@ class LargeDataBenchmark {
       case "JSON":
         return JsonNavigateCommand.create(TreePath.fromXml("/orders"), new PassThroughRule());
       case "CSV":
-        return CsvNavigateCommand.create(new CSVPath("name"), new PassThroughRule());
+        return CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule());
       default:
         return (in, out) -> in.transferTo(out);
     }

--- a/streamconverter-tools/src/test/java/com/streamconverter/benchmark/MemoryEfficiencyQuickTest.java
+++ b/streamconverter-tools/src/test/java/com/streamconverter/benchmark/MemoryEfficiencyQuickTest.java
@@ -39,7 +39,8 @@ class MemoryEfficiencyQuickTest {
 
     // 複雑パイプラインの文字コード変換部分のみテスト
     IStreamCommand[] pipeline = {
-      new CharacterConvertCommand("UTF-8", "UTF-16"), new CharacterConvertCommand("UTF-16", "UTF-8")
+      CharacterConvertCommand.create("UTF-8", "UTF-16"),
+      CharacterConvertCommand.create("UTF-16", "UTF-8")
     };
 
     // テスト実行

--- a/streamconverter-web/src/main/java/com/streamconverter/web/StreamProcessingController.java
+++ b/streamconverter-web/src/main/java/com/streamconverter/web/StreamProcessingController.java
@@ -59,7 +59,7 @@ public class StreamProcessingController {
                     processWithStreamConverter(
                         inputData,
                         CsvNavigateCommand.create(
-                            new CSVPath(columnName), new PassThroughRule()))))
+                            CSVPath.of(columnName), new PassThroughRule()))))
         .onErrorReturn(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
   }
 
@@ -171,7 +171,7 @@ public class StreamProcessingController {
 
       commands[i] =
           switch (commandType.toLowerCase()) {
-            case "csv" -> CsvNavigateCommand.create(new CSVPath(parameter), new PassThroughRule());
+            case "csv" -> CsvNavigateCommand.create(CSVPath.of(parameter), new PassThroughRule());
             case "json" -> JsonNavigateCommand.create(TreePath.fromJson(parameter), new PassThroughRule());
             case "process" -> (IStreamCommand) (in, out) -> in.transferTo(out);
             default -> throw new IllegalArgumentException("Unknown command type: " + commandType);


### PR DESCRIPTION
## Summary

- コンストラクタから例外をスローすることで発生する `CT_CONSTRUCTOR_THROW` 警告を全クラスで解消
- バリデーションロジックをコンストラクタから `static create()` / `of()` ファクトリメソッドへ移動
- `CsvFilterCommand.execute()` の `DLS_DEAD_LOCAL_STORE` を修正（初期化のみの ArrayList 代入を削除）
- `RV_RETURN_VALUE_IGNORED` を修正（意味のない `.toString()` 呼び出しを削除）

### 対象クラス

| クラス | 修正内容 |
|--------|----------|
| `CsvFilterCommand` | CT + DLS 修正、private コンストラクタ化 |
| `CsvNavigateCommand` | CT + RV 修正、3 つのコンストラクタすべて private 化 |
| `CsvValidateCommand` | CT 修正、`create()` ファクトリ追加 |
| `CharacterConvertCommand` | CT 修正、`create()` ファクトリ追加 |
| `JsonFilterCommand` | CT + RV 修正 |
| `JsonNavigateCommand` | CT 修正 |
| `XmlFilterCommand` | CT + RV 修正 |
| `XmlNavigateCommand` | CT 修正 |
| `ValidateCommand` | CT 修正、静的ファクトリに再構成 |
| `ChainRule` | CT 修正（private コンストラクタ）、`Builder.build()` へ検証移動 |
| `LowerCaseRule` | CT 修正、`create(Locale)` ファクトリ追加 |
| `CSVPath` | CT 修正、`of()` ファクトリ追加、`validateAndNormalize()` をファクトリに委譲 |

## Test plan

- [ ] `./gradlew :streamconverter-core:spotbugsMain` で警告 0 件
- [ ] `./gradlew :streamconverter-core:test :streamconverter-db:test` がグリーン

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)