### PR TITLE
feat(core): MdcPropagatingRule に create(String) ファクトリを追加 (#481)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
@@ -15,7 +15,7 @@ import com.streamconverter.context.PipelineContext;
  *       で自動反映する。{@code MDC.put} だけでは呼び出しスレッド内しか効かない。
  *   <li><b>実行タイミング非依存</b> — 子スレッド起動後に値を書いても {@code PipelineContext} 経由なら {@code TurboFilter}
  *       が毎ログ前に同期するため順序非依存。
- *   <li><b>一括クリア</b> — {@code PipelineContext.clear()} で管理される。
+ *   <li><b>スレッドからのコンテキスト切り離し</b> — {@code PipelineContext.clear()} により、このスレッドとの関連付けを解除できる。
  * </ol>
  *
  * <p>使用例:

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
@@ -11,7 +11,7 @@ import com.streamconverter.context.PipelineContext;
  *
  * <ol>
  *   <li><b>後続コマンドへの伝搬</b> — 値を {@link com.streamconverter.context.PipelineContext}
- *       の共有値として格納し、{@code PipelineContextTurboFilter} が他コマンドのログ出力直前に {@code syncToMDC()}
+ *       の共有値として格納し、{@link com.streamconverter.logging.PipelineContextTurboFilter PipelineContextTurboFilter} が他コマンドのログ出力直前に {@code syncToMDC()}
  *       で自動反映する。{@code MDC.put} だけでは呼び出しスレッド内しか効かない。
  *   <li><b>実行タイミング非依存</b> — 子スレッド起動後に値を書いても {@code PipelineContext} 経由なら {@code TurboFilter}
  *       が毎ログ前に同期するため順序非依存。

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
@@ -7,13 +7,24 @@ import com.streamconverter.context.PipelineContext;
  *
  * <p>ストリームデータから抽出された値を、パイプライン内の全コマンドのログ出力に 自動反映するために使用する。値はパススルーされ、変換は行わない。
  *
+ * <p>{@code MDC.put} だけのルールとの違い:
+ *
+ * <ol>
+ *   <li><b>後続コマンドへの伝搬</b> — 値を {@link com.streamconverter.context.PipelineContext}
+ *       の共有値として格納し、{@code PipelineContextTurboFilter} が他コマンドのログ出力直前に {@code syncToMDC()}
+ *       で自動反映する。{@code MDC.put} だけでは呼び出しスレッド内しか効かない。
+ *   <li><b>実行タイミング非依存</b> — 子スレッド起動後に値を書いても {@code PipelineContext} 経由なら {@code TurboFilter}
+ *       が毎ログ前に同期するため順序非依存。
+ *   <li><b>一括クリア</b> — {@code PipelineContext.clear()} で管理される。
+ * </ol>
+ *
  * <p>使用例:
  *
  * <pre>{@code
  * // XMLの orderId を抽出してMDCに伝搬
  * XmlNavigateCommand command = XmlNavigateCommand.create(
  *     TreePath.fromXPath("/order/@id"),
- *     new MdcPropagatingRule("orderId")
+ *     MdcPropagatingRule.create("orderId")
  * );
  * }</pre>
  */
@@ -21,17 +32,30 @@ public final class MdcPropagatingRule implements IRule {
 
   private final String mdcKey;
 
-  /**
-   * 指定されたMDCキーに値を伝搬するルールを作成する。
-   *
-   * @param mdcKey MDCに設定するキー名
-   * @throws IllegalArgumentException mdcKeyがnullの場合
-   */
-  public MdcPropagatingRule(String mdcKey) {
-    if (mdcKey == null) {
-      throw new IllegalArgumentException("mdcKey must not be null");
-    }
+  private MdcPropagatingRule(String mdcKey) {
     this.mdcKey = mdcKey;
+  }
+
+  /**
+   * 指定されたキーにストリーム値を伝搬するルールを作成します。
+   *
+   * <p>使用例:
+   *
+   * <pre>{@code
+   * XmlNavigateCommand.create(
+   *     TreePath.fromXml("request/userId"),
+   *     MdcPropagatingRule.create("userId"));
+   * }</pre>
+   *
+   * @param mdcKey MDC／PipelineContext に格納するキー名
+   * @return 伝搬ルールのインスタンス
+   * @throws IllegalArgumentException mdcKey が null または空の場合
+   */
+  public static MdcPropagatingRule create(String mdcKey) {
+    if (mdcKey == null || mdcKey.isEmpty()) {
+      throw new IllegalArgumentException("mdcKey cannot be null or empty");
+    }
+    return new MdcPropagatingRule(mdcKey);
   }
 
   /**

--- a/streamconverter-core/src/test/java/com/streamconverter/command/rule/MdcPropagatingRuleTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/rule/MdcPropagatingRuleTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.streamconverter.context.PipelineContext;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -126,18 +127,21 @@ class MdcPropagatingRuleTest {
     Thread child =
         new Thread(
             () -> {
-              // 親の MDC はクリア済みのため、継承の有無によらず子スレッドの MDC は空
-              mdcBeforeSync.set(MDC.get("orderId"));
-              // 同一 ctx を子スレッドに設定して syncToMDC で反映
-              PipelineContext.set(ctx);
-              PipelineContext.syncToMDC();
-              mdcAfterSync.set(MDC.get("orderId"));
-              PipelineContext.clear();
-              MDC.clear();
-              latch.countDown();
+              try {
+                // 親の MDC はクリア済みのため、継承の有無によらず子スレッドの MDC は空
+                mdcBeforeSync.set(MDC.get("orderId"));
+                // 同一 ctx を子スレッドに設定して syncToMDC で反映
+                PipelineContext.set(ctx);
+                PipelineContext.syncToMDC();
+                mdcAfterSync.set(MDC.get("orderId"));
+                PipelineContext.clear();
+                MDC.clear();
+              } finally {
+                latch.countDown();
+              }
             });
     child.start();
-    latch.await();
+    assertTrue(latch.await(5, TimeUnit.SECONDS), "Child thread did not complete in time");
 
     assertNull(mdcBeforeSync.get(), "親の MDC クリア後は子スレッドでも syncToMDC 前は orderId が見えない");
     assertEquals("ORD-999", mdcAfterSync.get(), "PipelineContext.syncToMDC() 後は MDC に反映される");

--- a/streamconverter-core/src/test/java/com/streamconverter/command/rule/MdcPropagatingRuleTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/rule/MdcPropagatingRuleTest.java
@@ -114,6 +114,11 @@ class MdcPropagatingRuleTest {
     PipelineContext.set(ctx);
     MdcPropagatingRule.create("orderId").apply("ORD-999");
 
+    // 親スレッドの MDC をクリアしてから子スレッドを生成する。
+    // これにより InheritableMDCAdapter の有無に関わらず、子スレッドは
+    // PipelineContext.syncToMDC() を呼ぶまで orderId を参照できないことを確認できる。
+    MDC.clear();
+
     CountDownLatch latch = new CountDownLatch(1);
     AtomicReference<String> mdcBeforeSync = new AtomicReference<>();
     AtomicReference<String> mdcAfterSync = new AtomicReference<>();
@@ -121,7 +126,7 @@ class MdcPropagatingRuleTest {
     Thread child =
         new Thread(
             () -> {
-              // InheritableMDCAdapter がインストールされていないため、子スレッドの MDC は空
+              // 親の MDC はクリア済みのため、継承の有無によらず子スレッドの MDC は空
               mdcBeforeSync.set(MDC.get("orderId"));
               // 同一 ctx を子スレッドに設定して syncToMDC で反映
               PipelineContext.set(ctx);
@@ -134,7 +139,7 @@ class MdcPropagatingRuleTest {
     child.start();
     latch.await();
 
-    assertNull(mdcBeforeSync.get(), "InheritableMDCAdapter 未インストール時は子スレッドの MDC は空");
+    assertNull(mdcBeforeSync.get(), "親の MDC クリア後は子スレッドでも syncToMDC 前は orderId が見えない");
     assertEquals("ORD-999", mdcAfterSync.get(), "PipelineContext.syncToMDC() 後は MDC に反映される");
   }
 

--- a/streamconverter-core/src/test/java/com/streamconverter/command/rule/MdcPropagatingRuleTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/rule/MdcPropagatingRuleTest.java
@@ -3,7 +3,10 @@ package com.streamconverter.command.rule;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.streamconverter.context.PipelineContext;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 
@@ -20,7 +23,7 @@ class MdcPropagatingRuleTest {
     PipelineContext ctx = new PipelineContext();
     PipelineContext.set(ctx);
 
-    MdcPropagatingRule rule = new MdcPropagatingRule("orderId");
+    MdcPropagatingRule rule = MdcPropagatingRule.create("orderId");
     String result = rule.apply("ORD-001");
 
     assertEquals("ORD-001", result);
@@ -33,7 +36,7 @@ class MdcPropagatingRuleTest {
     PipelineContext ctx = new PipelineContext();
     PipelineContext.set(ctx);
 
-    MdcPropagatingRule rule = new MdcPropagatingRule("key");
+    MdcPropagatingRule rule = MdcPropagatingRule.create("key");
     String input = "test-value";
     String result = rule.apply(input);
 
@@ -42,20 +45,39 @@ class MdcPropagatingRuleTest {
 
   @Test
   void applyWithNullInputThrowsException() {
-    MdcPropagatingRule rule = new MdcPropagatingRule("key");
+    MdcPropagatingRule rule = MdcPropagatingRule.create("key");
 
     assertThrows(IllegalArgumentException.class, () -> rule.apply(null));
   }
 
   @Test
-  void constructorWithNullKeyThrowsException() {
-    assertThrows(IllegalArgumentException.class, () -> new MdcPropagatingRule(null));
+  @DisplayName("create_nullKeyThrows")
+  void create_nullKeyThrows() {
+    assertThrows(IllegalArgumentException.class, () -> MdcPropagatingRule.create(null));
+  }
+
+  @Test
+  @DisplayName("create_emptyKeyThrows")
+  void create_emptyKeyThrows() {
+    assertThrows(IllegalArgumentException.class, () -> MdcPropagatingRule.create(""));
+  }
+
+  @Test
+  @DisplayName("create_returnsRuleThatStoresValueInPipelineContext")
+  void create_returnsRuleThatStoresValueInPipelineContext() {
+    PipelineContext ctx = new PipelineContext();
+    PipelineContext.set(ctx);
+
+    MdcPropagatingRule rule = MdcPropagatingRule.create("userId");
+    rule.apply("user-123");
+
+    assertEquals("user-123", PipelineContext.getShared("userId"));
+    assertEquals("user-123", MDC.get("userId"));
   }
 
   @Test
   void applyWithoutPipelineContextIsNoOp() {
-    // PipelineContext未設定時でもapplyは例外なく動作する
-    MdcPropagatingRule rule = new MdcPropagatingRule("key");
+    MdcPropagatingRule rule = MdcPropagatingRule.create("key");
     String result = rule.apply("value");
 
     assertEquals("value", result);
@@ -64,14 +86,14 @@ class MdcPropagatingRuleTest {
 
   @Test
   void toStringContainsKey() {
-    MdcPropagatingRule rule = new MdcPropagatingRule("orderId");
+    MdcPropagatingRule rule = MdcPropagatingRule.create("orderId");
     assertEquals("MdcPropagatingRule{mdcKey='orderId'}", rule.toString());
   }
 
   @Test
   void equalsSameKey() {
-    MdcPropagatingRule rule1 = new MdcPropagatingRule("key");
-    MdcPropagatingRule rule2 = new MdcPropagatingRule("key");
+    MdcPropagatingRule rule1 = MdcPropagatingRule.create("key");
+    MdcPropagatingRule rule2 = MdcPropagatingRule.create("key");
 
     assertEquals(rule1, rule2);
     assertEquals(rule1.hashCode(), rule2.hashCode());
@@ -79,9 +101,55 @@ class MdcPropagatingRuleTest {
 
   @Test
   void equalsDifferentKey() {
-    MdcPropagatingRule rule1 = new MdcPropagatingRule("key1");
-    MdcPropagatingRule rule2 = new MdcPropagatingRule("key2");
+    MdcPropagatingRule rule1 = MdcPropagatingRule.create("key1");
+    MdcPropagatingRule rule2 = MdcPropagatingRule.create("key2");
 
     assertNotEquals(rule1, rule2);
+  }
+
+  @Test
+  @DisplayName("MdcPropagatingRuleはPipelineContext経由で別スレッドでもsyncToMDC後に値を取得できる")
+  void mdcPropagatingRulePropagatesViaPipelineContextAcrossThreads() throws Exception {
+    PipelineContext ctx = new PipelineContext();
+    PipelineContext.set(ctx);
+    MdcPropagatingRule.create("orderId").apply("ORD-999");
+
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<String> mdcBeforeSync = new AtomicReference<>();
+    AtomicReference<String> mdcAfterSync = new AtomicReference<>();
+
+    Thread child =
+        new Thread(
+            () -> {
+              // InheritableMDCAdapter がインストールされていないため、子スレッドの MDC は空
+              mdcBeforeSync.set(MDC.get("orderId"));
+              // 同一 ctx を子スレッドに設定して syncToMDC で反映
+              PipelineContext.set(ctx);
+              PipelineContext.syncToMDC();
+              mdcAfterSync.set(MDC.get("orderId"));
+              PipelineContext.clear();
+              MDC.clear();
+              latch.countDown();
+            });
+    child.start();
+    latch.await();
+
+    assertNull(mdcBeforeSync.get(), "InheritableMDCAdapter 未インストール時は子スレッドの MDC は空");
+    assertEquals("ORD-999", mdcAfterSync.get(), "PipelineContext.syncToMDC() 後は MDC に反映される");
+  }
+
+  @Test
+  @DisplayName("PipelineContext 未設定スレッドで MDC.put のみのルールを apply した場合、後続スレッドへ伝搬しない")
+  void rawMdcPutDoesNotPersistInPipelineContext() {
+    MDC.put("rawKey", "raw-value");
+
+    assertNull(
+        PipelineContext.getShared("rawKey"), "MDC.put だけでは PipelineContext.sharedValues に入らない");
+
+    PipelineContext ctx = new PipelineContext();
+    PipelineContext.set(ctx);
+    assertNull(
+        PipelineContext.getShared("rawKey"),
+        "後から PipelineContext を設定しても MDC.put の値は sharedValues に届かない");
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/rule/MdcPropagatingRuleTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/rule/MdcPropagatingRuleTest.java
@@ -139,7 +139,7 @@ class MdcPropagatingRuleTest {
   }
 
   @Test
-  @DisplayName("PipelineContext 未設定スレッドで MDC.put のみのルールを apply した場合、後続スレッドへ伝搬しない")
+  @DisplayName("PipelineContext 未設定スレッドで MDC.put を直接呼んでも後続スレッドへ伝搬しない")
   void rawMdcPutDoesNotPersistInPipelineContext() {
     MDC.put("rawKey", "raw-value");
 


### PR DESCRIPTION
## 概要

`MdcPropagatingRule` に `create(String mdcKey)` ファクトリメソッドを追加し、コンストラクタを `private` 化した。

## 変更内容

- `MdcPropagatingRule` のコンストラクタを `private` に変更（SpotBugs `CT_CONSTRUCTOR_THROW` 解消）
- `public static MdcPropagatingRule create(String mdcKey)` ファクトリを追加（null/空文字チェック付き）
- クラス Javadoc に `MDC.put` との差異（後続コマンドへの伝搬・実行タイミング非依存・一括クリア）を追記

### API 変更

```java
// Before
new MdcPropagatingRule("userId")

// After
MdcPropagatingRule.create("userId")
```

> **注意:** コンストラクタの `private` 化は破壊的変更。意図的な設計判断として採用。

## テスト

- `create_nullKeyThrows` — null ガード
- `create_emptyKeyThrows` — 空文字ガード
- `create_returnsRuleThatStoresValueInPipelineContext` — 正常系
- `mdcPropagatingRulePropagatesViaPipelineContextAcrossThreads` — 別スレッドでの `PipelineContext.syncToMDC()` 伝搬
- `rawMdcPutDoesNotPersistInPipelineContext` — `MDC.put` だけでは `PipelineContext` に記録されないことを実証
- 既存テストの `new MdcPropagatingRule(...)` → `MdcPropagatingRule.create(...)` に置換

## レビュー

Codex レビュー済み（コンストラクタ `private` 化の破壊的変更を指摘、意図的に採用）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)