### PR TITLE
docs(core): IStreamCommand・PipelineContext の Javadoc に MDC 関連クラスの導線を追加

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/IStreamCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/IStreamCommand.java
@@ -33,6 +33,11 @@ import org.slf4j.Logger;
  * StreamConverter converter = StreamConverter.create(copyCommand);
  * converter.run(inputStream, outputStream);
  * }</pre>
+ *
+ * <p><b>MDC への値の伝搬について:</b> {@code execute()} 内で {@code MDC.put()} を直接呼び出しても、
+ * 他コマンドのスレッドには伝搬されません。ストリームから抽出した値を全コマンドのログに反映させるには {@link
+ * com.streamconverter.command.rule.MdcPropagatingRule} を使用してください。子スレッドへの MDC 自動継承が必要な場合は {@link
+ * com.streamconverter.logging.MDCInitializer} を参照してください。
  */
 @FunctionalInterface
 public interface IStreamCommand {

--- a/streamconverter-core/src/main/java/com/streamconverter/context/PipelineContext.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/context/PipelineContext.java
@@ -21,6 +21,17 @@ import org.slf4j.MDC;
  *
  * // 他のコマンドのログ出力時に自動的にMDCに反映される
  * }</pre>
+ *
+ * <p><b>MDC 関連クラスの全体像:</b>
+ *
+ * <ul>
+ *   <li>{@link com.streamconverter.command.rule.MdcPropagatingRule} — ストリームから抽出した値を このコンテキスト経由で MDC
+ *       に伝搬する Rule 実装。コマンドから MDC へ値を書き込む際の推奨手段。
+ *   <li>{@link com.streamconverter.logging.PipelineContextTurboFilter} — ログ出力直前に {@link
+ *       #syncToMDC()} を呼び出し、共有値を MDC へ自動反映する Logback TurboFilter。
+ *   <li>{@link com.streamconverter.logging.MDCInitializer} — {@code InheritableMDCAdapter} を
+ *       インストールし、MDC コンテキストを子スレッドへ自動継承させる。アプリ起動時に一度呼ぶ。
+ * </ul>
  */
 public final class PipelineContext {
 


### PR DESCRIPTION
## 概要

MDC を使いたい実装者が正しいクラスに辿り着けるよう、Javadoc に導線を追加した。

## 変更内容

### `IStreamCommand`

`execute()` 内で `MDC.put()` を直書きしても他コマンドスレッドには伝搬されない旨を注記し、`MdcPropagatingRule` と `MDCInitializer` へのリンクを追加。

### `PipelineContext`

MDC 関連クラスの全体像をクラス Javadoc に追記:

- `MdcPropagatingRule` — MDC へ値を書き込む際の推奨手段
- `PipelineContextTurboFilter` — ログ出力直前に `syncToMDC()` で自動反映
- `MDCInitializer` — 子スレッドへの MDC 自動継承（アプリ起動時に一度呼ぶ）

## 背景

#481 の実装議論の中で「コマンド実装者が `MDC.put()` を直書きしても期待通りに動かない」という罠の存在を確認。原理的にその動線は発生しにくいが、Javadoc で先手を打つことにした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)