### PR TITLE
docs(examples): basic-usage.md のコード例を現行 API に修正し CI 検証を追加 (#395)

### DIFF
--- a/docs/quickstart/basic-usage.md
+++ b/docs/quickstart/basic-usage.md
@@ -21,8 +21,8 @@ import com.streamconverter.path.CSVPath;
 
 // 2つのコマンドを組み合わせたパイプライン
 IStreamCommand[] pipeline = {
-    CsvNavigateCommand.create(new CSVPath("email"), new TrimRule()),
-    new CharacterConvertCommand("UTF-8", "Shift_JIS")
+    CsvNavigateCommand.create(CSVPath.of("email"), new TrimRule()),
+    CharacterConvertCommand.create("UTF-8", "Shift_JIS")
 };
 
 StreamConverter converter = StreamConverter.create(pipeline);
@@ -49,7 +49,7 @@ import com.streamconverter.path.TreePath;
 
 // 3つのコマンドを組み合わせた実用的なパイプライン
 IStreamCommand[] pipeline = {
-    CsvNavigateCommand.create(new CSVPath("productId"), new PassThroughRule()),
+    CsvNavigateCommand.create(CSVPath.of("productId"), new PassThroughRule()),
     new SendHttpCommand("https://api.example.com/products"),
     JsonNavigateCommand.create(TreePath.fromJson("$.result"), new PassThroughRule())
 };
@@ -60,69 +60,79 @@ converter.run(inputStream, outputStream);
 
 このパイプラインは以下の処理を実行します：
 1. CSVファイルから `productId` 列を抽出
-2. 抽出したIDをHTTP APIに送信
+2. 抽出したIDをHTTP APIに送信（`SendHttpCommand` は `streamconverter-http` モジュールで提供）
 3. APIレスポンス（JSON）から `result` フィールドを抽出
 
-## 3. ExecutionContext とメトリクス取得
+## 3. MDC によるログトレーシング
 
-実運用環境では、処理の追跡とメトリクス収集が重要です。ExecutionContextを使用してログトレースとパフォーマンス測定を行います。
+実運用環境では、ログにリクエスト・ジョブレベルのコンテキスト情報を付加することで、分散トレーシングが容易になります。SLF4J の MDC と `MdcPropagatingRule` を組み合わせることで、ストリームから抽出した値を自動的にログコンテキストへ伝搬できます。
 
 ```java
-import java.util.List;
-
-import com.streamconverter.CommandResult;
 import com.streamconverter.StreamConverter;
 import com.streamconverter.command.IStreamCommand;
 import com.streamconverter.command.impl.csv.CsvNavigateCommand;
-import com.streamconverter.command.impl.SendHttpCommand;
-import com.streamconverter.command.impl.json.JsonNavigateCommand;
-import com.streamconverter.command.impl.json.JsonValidateCommand;
-import com.streamconverter.command.rule.PassThroughRule;
-import com.streamconverter.context.ExecutionContext;
+import com.streamconverter.command.rule.MdcPropagatingRule;
+import com.streamconverter.logging.MDCInitializer;
 import com.streamconverter.path.CSVPath;
-import com.streamconverter.path.TreePath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
-// ExecutionContextを作成してトレーシング情報を設定
-ExecutionContext context = ExecutionContext.builder()
-    .globalContext("jobId", "daily-import")
-    .globalContext("environment", "production")
-    .userContext("operator", "batch-service")
-    .build();
+private static final Logger LOG = LoggerFactory.getLogger(MyProcessor.class);
 
-// 4つのコマンドを組み合わせた高度なパイプライン
-IStreamCommand[] pipeline = {
-    CsvNavigateCommand.create(new CSVPath("productId"), new PassThroughRule()),
-    new SendHttpCommand("https://api.example.com/products"),
-    JsonNavigateCommand.create(TreePath.fromJson("$.result"), new PassThroughRule()),
-    JsonValidateCommand.create("schemas/product-schema.json")
-};
+// アプリ起動時に一度呼び出し、MDC を子スレッドへ継承可能にする
+MDCInitializer.initialize();
 
-// ExecutionContext付きでパイプラインを実行
-StreamConverter converter = StreamConverter.createWithContext(context, pipeline);
-List<CommandResult> results = converter.run(inputStream, outputStream);
+// ジョブレベルのトレーシング情報を親スレッドの MDC に設定
+MDC.put("jobId", "daily-import");
+MDC.put("environment", "production");
 
-// 各コマンドの実行結果を確認
-results.forEach(result -> {
-    if (result.isSuccessful()) {
-        LOG.info("{} -> {} ms (input: {} bytes, output: {} bytes)",
-            result.getCommandName(),
-            result.getExecutionTimeMillis(),
-            result.getInputBytes(),
-            result.getOutputBytes());
-    } else {
-        LOG.error("{} failed: {}", result.getCommandName(), result.getErrorMessage());
-    }
-});
+try {
+    IStreamCommand[] pipeline = {
+        CsvNavigateCommand.create(CSVPath.of("productId"), new MdcPropagatingRule("productId")),
+        (IStreamCommand) (in, out) -> {
+            // 上流コマンドと並列実行されるため、開始時点での productId の有無は非決定的
+            // （入力が小さい場合は上流が先に完了し、既に MDC に含まれることもある）
+            LOG.info("Command start"); // MDC: jobId, environment（productId は不定）
+            in.transferTo(out);
+            // transferTo 完了後は上流が全行処理済みのため productId が MDC に確実に存在する
+            LOG.info("Command end");   // MDC: jobId, environment, productId
+        }
+    };
+    StreamConverter converter = StreamConverter.create(pipeline);
+    converter.run(inputStream, outputStream);
+} finally {
+    MDC.clear();
+}
 ```
 
 このパイプラインは以下の処理を実行します：
-1. CSVファイルから `productId` 列を抽出
-2. 抽出したIDをHTTP APIに送信
-3. APIレスポンス（JSON）から `result` フィールドを抽出
-4. JSONスキーマで検証
+1. `MDCInitializer.initialize()` でアプリ起動時に MDC の子スレッド継承を有効化
+2. `MDC.put()` でジョブ/リクエストレベルのコンテキストを設定
+3. `MdcPropagatingRule` でストリームから抽出した値（`productId`）を MDC に自動伝搬
+4. 後続コマンドのすべてのログに `jobId`・`environment`・`productId` が付加される
 
-ExecutionContextにより、すべてのログに `jobId`, `environment`, `operator` の情報が自動的に付加され、マルチスレッド環境でも正確なトレーシングが可能になります。
+### Logback の設定
+
+`MdcPropagatingRule` が書き込む値は `PipelineContext` 経由で伝搬されます。別コマンドのスレッドのログに反映させるには、`logback.xml` に `PipelineContextTurboFilter` を追加してください。
+
+```xml
+<configuration>
+    <turboFilter class="com.streamconverter.logging.PipelineContextTurboFilter"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- %mdc で MDC の全キー=値 を出力 -->
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} MDC={%mdc} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>
+```
 
 ---
 
-より多くの例は [streamconverter-examples](../../streamconverter-examples/src/main/java/com/streamconverter/examples/) を参照してください。
+より多くの例は [BasicUsageExamples.java](../../streamconverter-examples/src/main/java/com/streamconverter/examples/docs/BasicUsageExamples.java)（コンパイル検証済み）を参照してください。

--- a/docs/quickstart/basic-usage.md
+++ b/docs/quickstart/basic-usage.md
@@ -89,7 +89,7 @@ MDC.put("environment", "production");
 
 try {
     IStreamCommand[] pipeline = {
-        CsvNavigateCommand.create(CSVPath.of("productId"), new MdcPropagatingRule("productId")),
+        CsvNavigateCommand.create(CSVPath.of("productId"), MdcPropagatingRule.create("productId")),
         (IStreamCommand) (in, out) -> {
             // 上流コマンドと並列実行されるため、開始時点での productId の有無は非決定的
             // （入力が小さい場合は上流が先に完了し、既に MDC に含まれることもある）

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
@@ -11,8 +11,9 @@ import com.streamconverter.context.PipelineContext;
  *
  * <ol>
  *   <li><b>後続コマンドへの伝搬</b> — 値を {@link com.streamconverter.context.PipelineContext}
- *       の共有値として格納し、{@link com.streamconverter.logging.PipelineContextTurboFilter PipelineContextTurboFilter} が他コマンドのログ出力直前に {@code syncToMDC()}
- *       で自動反映する。{@code MDC.put} だけでは呼び出しスレッド内しか効かない。
+ *       の共有値として格納し、{@link com.streamconverter.logging.PipelineContextTurboFilter
+ *       PipelineContextTurboFilter} が他コマンドのログ出力直前に {@code syncToMDC()} で自動反映する。{@code MDC.put}
+ *       だけでは呼び出しスレッド内しか効かない。
  *   <li><b>実行タイミング非依存</b> — 子スレッド起動後に値を書いても {@code PipelineContext} 経由なら {@code TurboFilter}
  *       が毎ログ前に同期するため順序非依存。
  *   <li><b>スレッドからのコンテキスト切り離し</b> — {@code PipelineContext.clear()} により、このスレッドとの関連付けを解除できる。

--- a/streamconverter-examples/build.gradle.kts
+++ b/streamconverter-examples/build.gradle.kts
@@ -81,6 +81,13 @@ tasks.register<JavaExec>("runDatabaseRuleDemo") {
     mainClass.set("com.streamconverter.examples.DatabaseRuleDemo")
 }
 
+tasks.register<JavaExec>("runBasicUsageExamples") {
+    group = "application"
+    description = "Run BasicUsageExamples (docs examples)"
+    classpath = sourceSets.main.get().runtimeClasspath
+    mainClass.set("com.streamconverter.examples.docs.BasicUsageExamples")
+}
+
 // Spotless configuration for code formatting
 spotless {
     java {

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/docs/BasicUsageExamples.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/docs/BasicUsageExamples.java
@@ -247,7 +247,7 @@ public class BasicUsageExamples {
 
     try {
       IStreamCommand[] pipeline = {
-        CsvNavigateCommand.create(CSVPath.of("productId"), new MdcPropagatingRule("productId")),
+        CsvNavigateCommand.create(CSVPath.of("productId"), MdcPropagatingRule.create("productId")),
         (IStreamCommand)
             (in, out) -> {
               // Both commands run concurrently on separate virtual threads. productId is written

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/docs/BasicUsageExamples.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/docs/BasicUsageExamples.java
@@ -10,7 +10,9 @@ import com.streamconverter.command.impl.csv.CsvFilterCommand;
 import com.streamconverter.command.impl.csv.CsvNavigateCommand;
 import com.streamconverter.command.impl.json.JsonNavigateCommand;
 import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.command.rule.MdcPropagatingRule;
 import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.logging.MDCInitializer;
 import com.streamconverter.path.CSVPath;
 import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
@@ -18,6 +20,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 /**
  * Verifiable code examples for StreamConverter documentation.
@@ -29,6 +34,22 @@ import java.nio.charset.StandardCharsets;
  * <p>All examples in this file are tested to ensure they compile and execute correctly.
  */
 public class BasicUsageExamples {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BasicUsageExamples.class);
+
+  /** Run all examples. */
+  public static void main(String[] args) throws Exception {
+    BasicUsageExamples ex = new BasicUsageExamples();
+    ex.csvNavigateBasic();
+    ex.csvFilterBasic();
+    ex.jsonNavigateBasic();
+    ex.xmlNavigateBasic();
+    ex.characterConvertBasic();
+    ex.lineEndingNormalizeBasic();
+    ex.simplePipeline();
+    ex.errorHandlingBasic();
+    ex.mdcLoggingBasic();
+  }
 
   // [START csv-navigate-basic]
   /**
@@ -208,5 +229,44 @@ public class BasicUsageExamples {
       throw e;
     }
   }
+
   // [END error-handling-basic]
+
+  // [START mdc-logging-basic]
+  /** MDC logging pipeline example - demonstrates MDC context propagation for log tracing. */
+  public void mdcLoggingBasic() throws Exception {
+    String csvData = "id,productId\n1,P-001\n2,P-002\n";
+    InputStream inputStream = new ByteArrayInputStream(csvData.getBytes(StandardCharsets.UTF_8));
+    OutputStream outputStream = new ByteArrayOutputStream();
+
+    // Enable MDC inheritance to worker threads (call once at application startup)
+    MDCInitializer.initialize();
+
+    MDC.put("jobId", "daily-import");
+    MDC.put("environment", "production");
+
+    try {
+      IStreamCommand[] pipeline = {
+        CsvNavigateCommand.create(CSVPath.of("productId"), new MdcPropagatingRule("productId")),
+        (IStreamCommand)
+            (in, out) -> {
+              // Both commands run concurrently on separate virtual threads. productId is written
+              // to PipelineContext by MdcPropagatingRule as the upstream parses each row, so its
+              // presence in MDC at "Command start" is nondeterministic for small inputs where the
+              // upstream may finish before this thread logs.
+              LOG.info(
+                  "Command start"); // MDC: jobId, environment (productId may or may not be set)
+              in.transferTo(out);
+              // After transferTo completes, the upstream has finished all rows — productId is
+              // guaranteed to be in MDC at this point.
+              LOG.info("Command end"); // MDC: jobId, environment, productId
+            }
+      };
+      StreamConverter converter = StreamConverter.create(pipeline);
+      converter.run(inputStream, outputStream);
+    } finally {
+      MDC.clear();
+    }
+  }
+  // [END mdc-logging-basic]
 }

--- a/streamconverter-examples/src/main/resources/logback.xml
+++ b/streamconverter-examples/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- パイプライン内コマンド間のMDC共有値を自動同期 -->
+    <turboFilter class="com.streamconverter.logging.PipelineContextTurboFilter"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- MDC値 (jobId, environment, productId など) を出力に含める -->
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} MDC={%mdc} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

- `CSVPath.of()` / `CharacterConvertCommand.create()` へ廃止 API を修正（Section 1, 2）
- Section 3 を廃止 `ExecutionContext` 例から `MdcPropagatingRule` + MDC トレーシング例へ差し替え
- `MDCInitializer.initialize()` による子スレッド継承と `PipelineContextTurboFilter` の設定方法を追記
- 上流コマンドとの並列実行による `productId` の MDC 伝搬タイミング（非決定的）を明示
- `BasicUsageExamples.java` に `mdcLoggingBasic()` を追加（コンパイル検証済み）
- `main()` で全サンプルを実行し `runBasicUsageExamples` タスクで手動検証可能に
- `streamconverter-examples` に `logback.xml` を追加（MDC 値をログ出力パターンに含める）

> **Note**: PR #529 を develop ベースに切り直したものです。#529 はクローズしてください。

## Test plan

- [ ] `./gradlew :streamconverter-examples:compileJava` が成功すること
- [ ] `./gradlew :streamconverter-examples:runBasicUsageExamples` で全例が正常実行されること
- [ ] `mdcLoggingBasic` のログで `Command end` に `jobId`・`environment`・`productId` が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)