### PR TITLE
feat(core): Observability 基盤 - Metrics インターフェースと withLogging 拡張 (#506)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/IStreamCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/IStreamCommand.java
@@ -1,5 +1,7 @@
 package com.streamconverter.command;
 
+import com.streamconverter.metrics.Metrics;
+import com.streamconverter.metrics.NoOpMetrics;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -81,21 +83,41 @@ public interface IStreamCommand {
    * @return a new {@link IStreamCommand} that delegates to this command and emits log records
    */
   default IStreamCommand withLogging(Logger logger, String commandName) {
+    return withLogging(logger, commandName, NoOpMetrics.INSTANCE);
+  }
+
+  /**
+   * Wraps this command with logging and metrics using an explicit command name.
+   *
+   * <p>Combines log output with {@link Metrics} recording for observability.
+   *
+   * @param logger the logger to write messages to
+   * @param commandName the human-readable name of this command to appear in log messages
+   * @param metrics the metrics collector to record execution events
+   * @return a new {@link IStreamCommand} that delegates to this command and emits log records and
+   *     metrics
+   */
+  default IStreamCommand withLogging(Logger logger, String commandName, Metrics metrics) {
     return (in, out) -> {
       logger.info("Starting command: {}", commandName);
+      metrics.recordCommandStart(commandName);
       long start = System.currentTimeMillis();
       try {
         this.execute(in, out);
-        logger.info(
-            "Completed command: {} ({}ms)", commandName, System.currentTimeMillis() - start);
+        long durationMs = System.currentTimeMillis() - start;
+        logger.info("Completed command: {} ({}ms)", commandName, durationMs);
+        metrics.recordCommandEnd(commandName, durationMs);
       } catch (IOException e) {
         logger.error("Failed command: {} - {}", commandName, e.getMessage(), e);
+        metrics.recordError(commandName, e);
         throw e;
       } catch (RuntimeException e) {
         logger.error("Failed command: {} - {}", commandName, e.getMessage(), e);
+        metrics.recordError(commandName, e);
         throw e;
       } catch (Error e) {
         logger.error("Fatal error in command: {} - {}", commandName, e.getMessage(), e);
+        metrics.recordError(commandName, e);
         throw e;
       }
     };

--- a/streamconverter-core/src/main/java/com/streamconverter/metrics/LoggingMetrics.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/metrics/LoggingMetrics.java
@@ -1,0 +1,59 @@
+package com.streamconverter.metrics;
+
+import java.util.Objects;
+import org.slf4j.Logger;
+
+/**
+ * SLF4J ロガーを使用してメトリクスをログ出力する {@link Metrics} 実装。
+ *
+ * <p>コマンドの開始・終了・エラー・バイト数を INFO/WARN レベルでログ出力する。 本番環境での観測可能性向上や開発時のデバッグに使用する。
+ *
+ * <p>使用例:
+ *
+ * <pre>{@code
+ * Logger metricsLogger = LoggerFactory.getLogger("com.example.metrics");
+ * Metrics metrics = new LoggingMetrics(metricsLogger);
+ *
+ * IStreamCommand command = rawCommand.withLogging(logger, "MyCommand", metrics);
+ * }</pre>
+ */
+public final class LoggingMetrics implements Metrics {
+
+  private final Logger logger;
+
+  /**
+   * 指定ロガーを使用する LoggingMetrics を作成する。
+   *
+   * @param logger ログ出力先のロガー
+   * @throws NullPointerException logger が null の場合
+   */
+  public LoggingMetrics(Logger logger) {
+    this.logger = Objects.requireNonNull(logger, "logger must not be null");
+  }
+
+  @Override
+  public void recordCommandStart(String commandName) {
+    if (logger.isInfoEnabled()) {
+      logger.info("[metrics] command.start name={}", commandName);
+    }
+  }
+
+  @Override
+  public void recordCommandEnd(String commandName, long durationMs) {
+    if (logger.isInfoEnabled()) {
+      logger.info("[metrics] command.end name={} durationMs={}", commandName, durationMs);
+    }
+  }
+
+  @Override
+  public void recordError(String commandName, Throwable t) {
+    logger.warn("[metrics] command.error name={} error={}", commandName, t.getMessage(), t);
+  }
+
+  @Override
+  public void recordBytesProcessed(long bytes) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("[metrics] bytes.processed count={}", bytes);
+    }
+  }
+}

--- a/streamconverter-core/src/main/java/com/streamconverter/metrics/Metrics.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/metrics/Metrics.java
@@ -1,0 +1,50 @@
+package com.streamconverter.metrics;
+
+/**
+ * パイプライン実行の観測可能性（Observability）インターフェース。
+ *
+ * <p>コマンドの開始・終了・エラー・バイト数処理を記録するフックを提供する。 デフォルト実装は {@link NoOpMetrics}（何もしない）。 SLF4J ベースの実装は {@link
+ * LoggingMetrics} を参照。
+ *
+ * <p>使用例:
+ *
+ * <pre>{@code
+ * // ログベースのメトリクス
+ * Metrics metrics = new LoggingMetrics(LoggerFactory.getLogger("pipeline.metrics"));
+ *
+ * // StreamConverter に適用（IStreamCommand.withLogging 経由）
+ * IStreamCommand command = rawCommand.withLogging(logger, "MyCommand", metrics);
+ * }</pre>
+ */
+public interface Metrics {
+
+  /**
+   * コマンド開始を記録する。
+   *
+   * @param commandName コマンド名
+   */
+  void recordCommandStart(String commandName);
+
+  /**
+   * コマンド正常終了を記録する。
+   *
+   * @param commandName コマンド名
+   * @param durationMs 実行時間（ミリ秒）
+   */
+  void recordCommandEnd(String commandName, long durationMs);
+
+  /**
+   * コマンドエラーを記録する。
+   *
+   * @param commandName コマンド名
+   * @param t 発生した例外
+   */
+  void recordError(String commandName, Throwable t);
+
+  /**
+   * 処理バイト数を記録する。
+   *
+   * @param bytes 処理したバイト数
+   */
+  void recordBytesProcessed(long bytes);
+}

--- a/streamconverter-core/src/main/java/com/streamconverter/metrics/NoOpMetrics.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/metrics/NoOpMetrics.java
@@ -1,0 +1,37 @@
+package com.streamconverter.metrics;
+
+/**
+ * 何も記録しない {@link Metrics} のデフォルト実装。
+ *
+ * <p>メトリクス収集が不要な場合のデフォルト実装として使用する。 すべてのメソッドは何もしない（no-op）。
+ *
+ * <p>{@code StreamConverter} はデフォルトでこの実装を使用する。
+ */
+public final class NoOpMetrics implements Metrics {
+
+  /** デフォルトの NoOpMetrics シングルトンインスタンス。 */
+  public static final NoOpMetrics INSTANCE = new NoOpMetrics();
+
+  /** インスタンス化を許可（シングルトン利用を推奨するが強制しない）。 */
+  public NoOpMetrics() {}
+
+  @Override
+  public void recordCommandStart(String commandName) {
+    // no-op
+  }
+
+  @Override
+  public void recordCommandEnd(String commandName, long durationMs) {
+    // no-op
+  }
+
+  @Override
+  public void recordError(String commandName, Throwable t) {
+    // no-op
+  }
+
+  @Override
+  public void recordBytesProcessed(long bytes) {
+    // no-op
+  }
+}


### PR DESCRIPTION
## Summary

パイプライン実行の観測可能性（Observability）基盤を追加する。`IStreamCommand.withLogging()` を拡張し、メトリクス収集をオプションで組み込めるようにする。

**依存**: #535 (PR-D: ExecutionStrategy) のマージ後にマージすること。

## 変更内容

- `metrics/Metrics.java` インターフェース
  - `recordCommandStart / recordCommandEnd / recordError / recordBytesProcessed`

- `metrics/NoOpMetrics.java` — デフォルト no-op 実装（`INSTANCE` シングルトン）

- `metrics/LoggingMetrics.java` — SLF4J ベース実装
  INFO/WARN レベルでコマンド実行イベントをログ出力

- `IStreamCommand.withLogging(Logger, String, Metrics)` デフォルトメソッド追加
  - 既存 `withLogging(Logger, String)` は `NoOpMetrics.INSTANCE` を使用するよう委譲に変更（後方互換）

## Test plan

- [x] コンパイル通過
- [x] 既存テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)