### PR TITLE
feat(core): Source / Sink インターフェースを追加し run(Source, Sink) を実装 (#507)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
@@ -6,6 +6,8 @@ import com.streamconverter.execution.ErrorPolicy;
 import com.streamconverter.execution.ExecutionStrategy;
 import com.streamconverter.execution.MemoryBudget;
 import com.streamconverter.execution.ParallelExecutionStrategy;
+import com.streamconverter.io.Sink;
+import com.streamconverter.io.Source;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -190,6 +192,25 @@ public class StreamConverter {
   // ─────────────────────────────────────────────────────────────────────────
   // 実行
   // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Source と Sink を使用してストリームを変換する。
+   *
+   * <p>Source と Sink のストリームはこのメソッド内で開かれ、処理完了後にクローズされる。
+   *
+   * @param source 入力ソース
+   * @param sink 出力シンク
+   * @throws IOException ストリーム処理中にI/Oエラーが発生した場合
+   * @throws NullPointerException source または sink が null の場合
+   */
+  public void run(Source source, Sink sink) throws IOException {
+    Objects.requireNonNull(source, "source must not be null");
+    Objects.requireNonNull(sink, "sink must not be null");
+    try (InputStream inputStream = source.open();
+        OutputStream outputStream = sink.open()) {
+      run(inputStream, outputStream);
+    }
+  }
 
   /**
    * 非同期並列処理でストリームを変換する。 メモリ効率を重視し、PipedStreamを使用して大容量ファイルに対応。

--- a/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
@@ -196,7 +196,8 @@ public class StreamConverter {
   /**
    * Source と Sink を使用してストリームを変換する。
    *
-   * <p>Source と Sink のストリームはこのメソッド内で開かれ、処理完了後にクローズされる。
+   * <p>Source と Sink のストリームはこのメソッド内で開かれ、処理完了後にクローズされる。 {@link ErrorPolicy#retry(int, long)}
+   * を使用している場合、失敗時に Source を再オープンしてリトライする。
    *
    * @param source 入力ソース
    * @param sink 出力シンク
@@ -206,45 +207,87 @@ public class StreamConverter {
   public void run(Source source, Sink sink) throws IOException {
     Objects.requireNonNull(source, "source must not be null");
     Objects.requireNonNull(sink, "sink must not be null");
-    try (InputStream inputStream = source.open();
-        OutputStream outputStream = sink.open()) {
-      run(inputStream, outputStream);
+    if (errorPolicy instanceof ErrorPolicy.Retry retry) {
+      runWithRetry(source, sink, retry);
+    } else {
+      try (InputStream inputStream = source.open();
+          OutputStream outputStream = sink.open()) {
+        runCore(inputStream, outputStream);
+      }
     }
   }
 
   /**
    * 非同期並列処理でストリームを変換する。 メモリ効率を重視し、PipedStreamを使用して大容量ファイルに対応。
    *
+   * <p><strong>注意:</strong> {@link ErrorPolicy#retry(int, long)} とともに使用する場合は、 InputStream は巻き戻せないため
+   * {@link UnsupportedOperationException} をスローする。 代わりに {@link #run(Source, Sink)} を使用すること。
+   *
    * @param inputStream 処理対象の入力ストリーム
    * @param outputStream 処理結果を書き込む出力ストリーム
    * @throws IOException ストリーム処理中にI/Oエラーが発生した場合
+   * @throws UnsupportedOperationException ErrorPolicy.Retry が設定されている場合
    */
   public void run(InputStream inputStream, OutputStream outputStream) throws IOException {
     Objects.requireNonNull(inputStream);
     Objects.requireNonNull(outputStream);
-
-    if (LOG.isInfoEnabled()) {
-      LOG.info("Starting StreamConverter with {} commands", commands.size());
-    }
-
-    BufferPolicy bufferPolicy = memoryBudget.getBufferPolicy();
-    executeCommands(inputStream, outputStream, bufferPolicy);
-
-    if (LOG.isInfoEnabled()) {
-      LOG.info("Completed StreamConverter pipeline");
-    }
-  }
-
-  /** 設定された実行戦略とエラーポリシーでコマンドを実行する */
-  private void executeCommands(
-      InputStream inputStream, OutputStream outputStream, BufferPolicy bufferPolicy)
-      throws IOException {
     if (errorPolicy instanceof ErrorPolicy.Retry) {
-      // InputStream は巻き戻せないためリトライ不可。run(Source, Sink) を使用すること。
       throw new UnsupportedOperationException(
           "ErrorPolicy.Retry requires run(Source, Sink) — InputStream cannot be rewound for retry."
               + " Use StreamConverter.run(Source, Sink) instead.");
     }
+    runCore(inputStream, outputStream);
+  }
+
+  /** Source を再オープンしながらリトライするコア実装 */
+  private void runWithRetry(Source source, Sink sink, ErrorPolicy.Retry retry) throws IOException {
+    IOException lastException = null;
+    BufferPolicy bufferPolicy = memoryBudget.getBufferPolicy();
+    for (int attempt = 0; attempt <= retry.maxRetries(); attempt++) {
+      try (InputStream inputStream = source.open();
+          OutputStream outputStream = sink.open()) {
+        if (LOG.isInfoEnabled()) {
+          LOG.info("Starting StreamConverter with {} commands", commands.size());
+        }
+        executionStrategy.execute(commands, commandNames, inputStream, outputStream, bufferPolicy);
+        if (LOG.isInfoEnabled()) {
+          LOG.info("Completed StreamConverter pipeline");
+        }
+        return;
+      } catch (IOException e) {
+        lastException = e;
+        if (attempt < retry.maxRetries()) {
+          if (LOG.isWarnEnabled()) {
+            LOG.warn(
+                "Command execution failed (attempt {}/{}), retrying in {}ms: {}",
+                attempt + 1,
+                retry.maxRetries() + 1,
+                retry.delayMs(),
+                e.getMessage());
+          }
+          if (retry.delayMs() > 0) {
+            try {
+              Thread.sleep(retry.delayMs());
+            } catch (InterruptedException ie) {
+              Thread.currentThread().interrupt();
+              throw new StreamProcessingException("Retry interrupted", ie);
+            }
+          }
+        }
+      }
+    }
+    throw lastException;
+  }
+
+  /** エラーポリシーなしで実行する内部コア */
+  private void runCore(InputStream inputStream, OutputStream outputStream) throws IOException {
+    if (LOG.isInfoEnabled()) {
+      LOG.info("Starting StreamConverter with {} commands", commands.size());
+    }
+    BufferPolicy bufferPolicy = memoryBudget.getBufferPolicy();
     executionStrategy.execute(commands, commandNames, inputStream, outputStream, bufferPolicy);
+    if (LOG.isInfoEnabled()) {
+      LOG.info("Completed StreamConverter pipeline");
+    }
   }
 }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/IStreamCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/IStreamCommand.java
@@ -1,5 +1,7 @@
 package com.streamconverter.command;
 
+import com.streamconverter.metrics.Metrics;
+import com.streamconverter.metrics.NoOpMetrics;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -81,21 +83,41 @@ public interface IStreamCommand {
    * @return a new {@link IStreamCommand} that delegates to this command and emits log records
    */
   default IStreamCommand withLogging(Logger logger, String commandName) {
+    return withLogging(logger, commandName, NoOpMetrics.INSTANCE);
+  }
+
+  /**
+   * Wraps this command with logging and metrics using an explicit command name.
+   *
+   * <p>Combines log output with {@link Metrics} recording for observability.
+   *
+   * @param logger the logger to write messages to
+   * @param commandName the human-readable name of this command to appear in log messages
+   * @param metrics the metrics collector to record execution events
+   * @return a new {@link IStreamCommand} that delegates to this command and emits log records and
+   *     metrics
+   */
+  default IStreamCommand withLogging(Logger logger, String commandName, Metrics metrics) {
     return (in, out) -> {
       logger.info("Starting command: {}", commandName);
+      metrics.recordCommandStart(commandName);
       long start = System.currentTimeMillis();
       try {
         this.execute(in, out);
-        logger.info(
-            "Completed command: {} ({}ms)", commandName, System.currentTimeMillis() - start);
+        long durationMs = System.currentTimeMillis() - start;
+        logger.info("Completed command: {} ({}ms)", commandName, durationMs);
+        metrics.recordCommandEnd(commandName, durationMs);
       } catch (IOException e) {
         logger.error("Failed command: {} - {}", commandName, e.getMessage(), e);
+        metrics.recordError(commandName, e);
         throw e;
       } catch (RuntimeException e) {
         logger.error("Failed command: {} - {}", commandName, e.getMessage(), e);
+        metrics.recordError(commandName, e);
         throw e;
       } catch (Error e) {
         logger.error("Fatal error in command: {} - {}", commandName, e.getMessage(), e);
+        metrics.recordError(commandName, e);
         throw e;
       }
     };

--- a/streamconverter-core/src/main/java/com/streamconverter/io/Sink.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/io/Sink.java
@@ -1,23 +1,23 @@
 package com.streamconverter.io;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Objects;
 
 /**
  * パイプラインの出力シンクを表すインターフェース。
  *
- * <p>{@link #open()} でストリームを取得し、try-with-resources で安全にクローズすること。 ファイル・既存ストリームへのファクトリメソッドを提供する。
+ * <p>{@link #open()} でストリームを取得する。{@link com.streamconverter.StreamConverter#run(Source, Sink)}
+ * に渡した場合、ストリームの close は {@code run} メソッドが責任を持って行う。
  *
  * <p>使用例:
  *
  * <pre>{@code
- * // ファイルへのシンク
- * try (OutputStream out = Sink.toFile(Path.of("output.csv")).open()) {
- *     converter.run(inputStream, out);
- * }
+ * // ファイルへのシンク（StreamConverter.run が close を管理）
+ * converter.run(source, Sink.toFile(Path.of("output.csv")));
  *
  * // Pipeline DSL での使用
  * Pipeline.input(Source.ofFile(Path.of("input.csv")))
@@ -31,6 +31,9 @@ public interface Sink {
   /**
    * 出力ストリームを開いて返す。
    *
+   * <p>呼び出し側（または {@link com.streamconverter.StreamConverter#run(Source, Sink)}）が 返されたストリームを close
+   * する責任を持つ。
+   *
    * @return 出力ストリーム
    * @throws IOException ストリームを開けない場合
    */
@@ -39,7 +42,10 @@ public interface Sink {
   /**
    * 既存の {@link OutputStream} を Sink としてラップする。
    *
-   * <p>ストリームのクローズは呼び出し側が管理する。
+   * <p><strong>所有権の注意:</strong> {@link com.streamconverter.StreamConverter#run(Source, Sink)}
+   * に渡すと、このストリームは {@code run} の完了時に close される。close 後にストリームを使用してはならない。 close
+   * されることを避けたい場合は、OutputStream を直接 {@link
+   * com.streamconverter.StreamConverter#run(java.io.InputStream, OutputStream)} に渡すこと。
    *
    * @param outputStream ラップする出力ストリーム
    * @return Sink
@@ -51,9 +57,9 @@ public interface Sink {
   }
 
   /**
-   * ファイルパスへの Sink を作成する。
+   * ファイルパスへの Sink を作成する（上書きモード）。
    *
-   * <p>{@link #open()} が呼ばれるたびに新しい {@link FileOutputStream} を開く（上書きモード）。
+   * <p>{@link #open()} が呼ばれるたびに新しい {@link OutputStream} を開く。既存ファイルは上書きされる。
    *
    * @param path 出力ファイルのパス
    * @return Sink
@@ -61,6 +67,8 @@ public interface Sink {
    */
   static Sink toFile(Path path) {
     Objects.requireNonNull(path, "path must not be null");
-    return () -> new FileOutputStream(path.toFile());
+    return () ->
+        Files.newOutputStream(
+            path, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
   }
 }

--- a/streamconverter-core/src/main/java/com/streamconverter/io/Sink.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/io/Sink.java
@@ -1,0 +1,66 @@
+package com.streamconverter.io;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * パイプラインの出力シンクを表すインターフェース。
+ *
+ * <p>{@link #open()} でストリームを取得し、try-with-resources で安全にクローズすること。 ファイル・既存ストリームへのファクトリメソッドを提供する。
+ *
+ * <p>使用例:
+ *
+ * <pre>{@code
+ * // ファイルへのシンク
+ * try (OutputStream out = Sink.toFile(Path.of("output.csv")).open()) {
+ *     converter.run(inputStream, out);
+ * }
+ *
+ * // Pipeline DSL での使用
+ * Pipeline.input(Source.ofFile(Path.of("input.csv")))
+ *     .then(new CsvNavigateCommand(...))
+ *     .to(Sink.toFile(Path.of("output.csv")));
+ * }</pre>
+ */
+@FunctionalInterface
+public interface Sink {
+
+  /**
+   * 出力ストリームを開いて返す。
+   *
+   * @return 出力ストリーム
+   * @throws IOException ストリームを開けない場合
+   */
+  OutputStream open() throws IOException;
+
+  /**
+   * 既存の {@link OutputStream} を Sink としてラップする。
+   *
+   * <p>ストリームのクローズは呼び出し側が管理する。
+   *
+   * @param outputStream ラップする出力ストリーム
+   * @return Sink
+   * @throws NullPointerException outputStream が null の場合
+   */
+  static Sink of(OutputStream outputStream) {
+    Objects.requireNonNull(outputStream, "outputStream must not be null");
+    return () -> outputStream;
+  }
+
+  /**
+   * ファイルパスへの Sink を作成する。
+   *
+   * <p>{@link #open()} が呼ばれるたびに新しい {@link FileOutputStream} を開く（上書きモード）。
+   *
+   * @param path 出力ファイルのパス
+   * @return Sink
+   * @throws NullPointerException path が null の場合
+   */
+  static Sink toFile(Path path) {
+    Objects.requireNonNull(path, "path must not be null");
+    return () -> new FileOutputStream(path.toFile());
+  }
+}

--- a/streamconverter-core/src/main/java/com/streamconverter/io/Source.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/io/Source.java
@@ -1,0 +1,66 @@
+package com.streamconverter.io;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * パイプラインの入力ソースを表すインターフェース。
+ *
+ * <p>{@link #open()} でストリームを取得し、try-with-resources で安全にクローズすること。 ファイル・既存ストリームからのファクトリメソッドを提供する。
+ *
+ * <p>使用例:
+ *
+ * <pre>{@code
+ * // ファイルからのソース
+ * try (InputStream in = Source.ofFile(Path.of("input.csv")).open()) {
+ *     converter.run(in, outputStream);
+ * }
+ *
+ * // Pipeline DSL での使用
+ * Pipeline.input(Source.ofFile(Path.of("input.csv")))
+ *     .then(new CsvNavigateCommand(...))
+ *     .to(Sink.toFile(Path.of("output.csv")));
+ * }</pre>
+ */
+@FunctionalInterface
+public interface Source {
+
+  /**
+   * 入力ストリームを開いて返す。
+   *
+   * @return 入力ストリーム
+   * @throws IOException ストリームを開けない場合
+   */
+  InputStream open() throws IOException;
+
+  /**
+   * 既存の {@link InputStream} を Source としてラップする。
+   *
+   * <p>ストリームのクローズは呼び出し側が管理する。
+   *
+   * @param inputStream ラップする入力ストリーム
+   * @return Source
+   * @throws NullPointerException inputStream が null の場合
+   */
+  static Source of(InputStream inputStream) {
+    Objects.requireNonNull(inputStream, "inputStream must not be null");
+    return () -> inputStream;
+  }
+
+  /**
+   * ファイルパスから Source を作成する。
+   *
+   * <p>{@link #open()} が呼ばれるたびに新しい {@link FileInputStream} を開く。
+   *
+   * @param path 入力ファイルのパス
+   * @return Source
+   * @throws NullPointerException path が null の場合
+   */
+  static Source ofFile(Path path) {
+    Objects.requireNonNull(path, "path must not be null");
+    return () -> new FileInputStream(path.toFile());
+  }
+}

--- a/streamconverter-core/src/main/java/com/streamconverter/io/Source.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/io/Source.java
@@ -1,23 +1,22 @@
 package com.streamconverter.io;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 
 /**
  * パイプラインの入力ソースを表すインターフェース。
  *
- * <p>{@link #open()} でストリームを取得し、try-with-resources で安全にクローズすること。 ファイル・既存ストリームからのファクトリメソッドを提供する。
+ * <p>{@link #open()} でストリームを取得する。{@link com.streamconverter.StreamConverter#run(Source, Sink)}
+ * に渡した場合、ストリームの close は {@code run} メソッドが責任を持って行う。
  *
  * <p>使用例:
  *
  * <pre>{@code
- * // ファイルからのソース
- * try (InputStream in = Source.ofFile(Path.of("input.csv")).open()) {
- *     converter.run(in, outputStream);
- * }
+ * // ファイルからのソース（StreamConverter.run が close を管理）
+ * converter.run(Source.ofFile(Path.of("input.csv")), sink);
  *
  * // Pipeline DSL での使用
  * Pipeline.input(Source.ofFile(Path.of("input.csv")))
@@ -31,6 +30,9 @@ public interface Source {
   /**
    * 入力ストリームを開いて返す。
    *
+   * <p>呼び出し側（または {@link com.streamconverter.StreamConverter#run(Source, Sink)}）が 返されたストリームを close
+   * する責任を持つ。
+   *
    * @return 入力ストリーム
    * @throws IOException ストリームを開けない場合
    */
@@ -39,7 +41,10 @@ public interface Source {
   /**
    * 既存の {@link InputStream} を Source としてラップする。
    *
-   * <p>ストリームのクローズは呼び出し側が管理する。
+   * <p><strong>所有権の注意:</strong> {@link com.streamconverter.StreamConverter#run(Source, Sink)}
+   * に渡すと、このストリームは {@code run} の完了時に close される。close 後にストリームを使用してはならない。 close
+   * されることを避けたい場合は、InputStream を直接 {@link com.streamconverter.StreamConverter#run(InputStream,
+   * java.io.OutputStream)} に渡すこと。
    *
    * @param inputStream ラップする入力ストリーム
    * @return Source
@@ -53,7 +58,7 @@ public interface Source {
   /**
    * ファイルパスから Source を作成する。
    *
-   * <p>{@link #open()} が呼ばれるたびに新しい {@link FileInputStream} を開く。
+   * <p>{@link #open()} が呼ばれるたびに新しい {@link InputStream} を開く。
    *
    * @param path 入力ファイルのパス
    * @return Source
@@ -61,6 +66,6 @@ public interface Source {
    */
   static Source ofFile(Path path) {
     Objects.requireNonNull(path, "path must not be null");
-    return () -> new FileInputStream(path.toFile());
+    return () -> Files.newInputStream(path);
   }
 }

--- a/streamconverter-core/src/main/java/com/streamconverter/metrics/LoggingMetrics.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/metrics/LoggingMetrics.java
@@ -1,0 +1,59 @@
+package com.streamconverter.metrics;
+
+import java.util.Objects;
+import org.slf4j.Logger;
+
+/**
+ * SLF4J ロガーを使用してメトリクスをログ出力する {@link Metrics} 実装。
+ *
+ * <p>コマンドの開始・終了・エラー・バイト数を INFO/WARN レベルでログ出力する。 本番環境での観測可能性向上や開発時のデバッグに使用する。
+ *
+ * <p>使用例:
+ *
+ * <pre>{@code
+ * Logger metricsLogger = LoggerFactory.getLogger("com.example.metrics");
+ * Metrics metrics = new LoggingMetrics(metricsLogger);
+ *
+ * IStreamCommand command = rawCommand.withLogging(logger, "MyCommand", metrics);
+ * }</pre>
+ */
+public final class LoggingMetrics implements Metrics {
+
+  private final Logger logger;
+
+  /**
+   * 指定ロガーを使用する LoggingMetrics を作成する。
+   *
+   * @param logger ログ出力先のロガー
+   * @throws NullPointerException logger が null の場合
+   */
+  public LoggingMetrics(Logger logger) {
+    this.logger = Objects.requireNonNull(logger, "logger must not be null");
+  }
+
+  @Override
+  public void recordCommandStart(String commandName) {
+    if (logger.isInfoEnabled()) {
+      logger.info("[metrics] command.start name={}", commandName);
+    }
+  }
+
+  @Override
+  public void recordCommandEnd(String commandName, long durationMs) {
+    if (logger.isInfoEnabled()) {
+      logger.info("[metrics] command.end name={} durationMs={}", commandName, durationMs);
+    }
+  }
+
+  @Override
+  public void recordError(String commandName, Throwable t) {
+    logger.warn("[metrics] command.error name={} error={}", commandName, t.getMessage(), t);
+  }
+
+  @Override
+  public void recordBytesProcessed(long bytes) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("[metrics] bytes.processed count={}", bytes);
+    }
+  }
+}

--- a/streamconverter-core/src/main/java/com/streamconverter/metrics/Metrics.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/metrics/Metrics.java
@@ -1,0 +1,50 @@
+package com.streamconverter.metrics;
+
+/**
+ * パイプライン実行の観測可能性（Observability）インターフェース。
+ *
+ * <p>コマンドの開始・終了・エラー・バイト数処理を記録するフックを提供する。 デフォルト実装は {@link NoOpMetrics}（何もしない）。 SLF4J ベースの実装は {@link
+ * LoggingMetrics} を参照。
+ *
+ * <p>使用例:
+ *
+ * <pre>{@code
+ * // ログベースのメトリクス
+ * Metrics metrics = new LoggingMetrics(LoggerFactory.getLogger("pipeline.metrics"));
+ *
+ * // StreamConverter に適用（IStreamCommand.withLogging 経由）
+ * IStreamCommand command = rawCommand.withLogging(logger, "MyCommand", metrics);
+ * }</pre>
+ */
+public interface Metrics {
+
+  /**
+   * コマンド開始を記録する。
+   *
+   * @param commandName コマンド名
+   */
+  void recordCommandStart(String commandName);
+
+  /**
+   * コマンド正常終了を記録する。
+   *
+   * @param commandName コマンド名
+   * @param durationMs 実行時間（ミリ秒）
+   */
+  void recordCommandEnd(String commandName, long durationMs);
+
+  /**
+   * コマンドエラーを記録する。
+   *
+   * @param commandName コマンド名
+   * @param t 発生した例外
+   */
+  void recordError(String commandName, Throwable t);
+
+  /**
+   * 処理バイト数を記録する。
+   *
+   * @param bytes 処理したバイト数
+   */
+  void recordBytesProcessed(long bytes);
+}

--- a/streamconverter-core/src/main/java/com/streamconverter/metrics/NoOpMetrics.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/metrics/NoOpMetrics.java
@@ -1,0 +1,37 @@
+package com.streamconverter.metrics;
+
+/**
+ * 何も記録しない {@link Metrics} のデフォルト実装。
+ *
+ * <p>メトリクス収集が不要な場合のデフォルト実装として使用する。 すべてのメソッドは何もしない（no-op）。
+ *
+ * <p>{@code StreamConverter} はデフォルトでこの実装を使用する。
+ */
+public final class NoOpMetrics implements Metrics {
+
+  /** デフォルトの NoOpMetrics シングルトンインスタンス。 */
+  public static final NoOpMetrics INSTANCE = new NoOpMetrics();
+
+  /** インスタンス化を許可（シングルトン利用を推奨するが強制しない）。 */
+  public NoOpMetrics() {}
+
+  @Override
+  public void recordCommandStart(String commandName) {
+    // no-op
+  }
+
+  @Override
+  public void recordCommandEnd(String commandName, long durationMs) {
+    // no-op
+  }
+
+  @Override
+  public void recordError(String commandName, Throwable t) {
+    // no-op
+  }
+
+  @Override
+  public void recordBytesProcessed(long bytes) {
+    // no-op
+  }
+}


### PR DESCRIPTION
## Summary

入力元と出力先を `Source` / `Sink` インターフェースで統一し、`StreamConverter.run(Source, Sink)` オーバーロードを追加する。

**依存**: #536 (PR-E: Observability) のマージ後にマージすること。

## 変更内容

- `io/Source.java` インターフェース (`@FunctionalInterface`)
  - `open()` — InputStream を開く
  - `of(InputStream)` — 既存ストリームをラップ
  - `ofFile(Path)` — ファイルから開く

- `io/Sink.java` インターフェース (`@FunctionalInterface`)
  - `open()` — OutputStream を開く
  - `of(OutputStream)` — 既存ストリームをラップ
  - `toFile(Path)` — ファイルへ書き出す

- `StreamConverter.run(Source, Sink)` オーバーロード追加
  - try-with-resources でストリームの開閉を自動管理
  - 既存の `run(InputStream, OutputStream)` は後方互換を維持

## Test plan

- [x] コンパイル通過
- [x] 既存テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)