### PR TITLE
feat(core): タイプセーフな Pipeline DSL を追加 (#502)

### DIFF
--- a/docs/quickstart/basic-usage.md
+++ b/docs/quickstart/basic-usage.md
@@ -133,6 +133,34 @@ try {
 </configuration>
 ```
 
+## 4. Pipeline DSL（#502）
+
+`Pipeline` クラスを使用すると、より宣言的にパイプラインを構築できます。
+
+```java
+import com.streamconverter.dsl.Pipeline;
+import com.streamconverter.io.Source;
+import com.streamconverter.io.Sink;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.path.CSVPath;
+import java.nio.file.Path;
+
+// ファイルベースのパイプライン
+Pipeline.input(Source.ofFile(Path.of("input.csv")))
+    .then(CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule()))
+    .to(Sink.toFile(Path.of("output.txt")));
+```
+
+既存のストリームを使用する場合:
+
+```java
+Pipeline.input(Source.of(inputStream))
+    .then(command1)
+    .then(command2)
+    .to(Sink.of(outputStream));
+```
+
 ---
 
 より多くの例は [BasicUsageExamples.java](../../streamconverter-examples/src/main/java/com/streamconverter/examples/docs/BasicUsageExamples.java)（コンパイル検証済み）を参照してください。

--- a/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
@@ -162,6 +162,36 @@ public class StreamConverter {
         errorPolicy);
   }
 
+  /**
+   * Creates a StreamConverter with custom {@link ExecutionStrategy}, {@link MemoryBudget}, {@link
+   * ErrorPolicy} and a list of commands.
+   *
+   * <p>このファクトリメソッドは {@link com.streamconverter.dsl.Pipeline} が内部で使用するメソッドであり、 すべての実行設定を一度に指定して
+   * StreamConverter を生成する。
+   *
+   * @param strategy the execution strategy to use
+   * @param memoryBudget the memory budget configuration
+   * @param errorPolicy the error handling policy
+   * @param commands the list of commands to be executed in sequence
+   * @return a new StreamConverter instance
+   * @throws NullPointerException if any argument is null
+   * @throws IllegalArgumentException if commands is empty
+   */
+  public static StreamConverter create(
+      ExecutionStrategy strategy,
+      MemoryBudget memoryBudget,
+      ErrorPolicy errorPolicy,
+      List<IStreamCommand> commands) {
+    Objects.requireNonNull(strategy, "strategy cannot be null");
+    Objects.requireNonNull(memoryBudget, "memoryBudget cannot be null");
+    Objects.requireNonNull(errorPolicy, "errorPolicy cannot be null");
+    Objects.requireNonNull(commands, "commands cannot be null");
+    if (commands.isEmpty()) {
+      throw new IllegalArgumentException("commands is empty.");
+    }
+    return new StreamConverter(List.copyOf(commands), strategy, memoryBudget, errorPolicy);
+  }
+
   // ─────────────────────────────────────────────────────────────────────────
   // ヘルパーメソッド
   // ─────────────────────────────────────────────────────────────────────────

--- a/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
@@ -239,9 +239,16 @@ public class StreamConverter {
     runCore(inputStream, outputStream);
   }
 
-  /** Source を再オープンしながらリトライするコア実装 */
+  /**
+   * Source を再オープンしながらリトライするコア実装。
+   *
+   * <p><strong>注意:</strong> {@link com.streamconverter.io.Source#of(java.io.InputStream)} / {@link
+   * com.streamconverter.io.Sink#of(java.io.OutputStream)} でラップしたストリームは、最初の試行で close
+   * された後に再利用できないためリトライが失敗する。 Retry と組み合わせる場合は必ず {@link
+   * com.streamconverter.io.Source#ofFile(java.nio.file.Path)} など、毎回新しいストリームを開く Source/Sink を使用すること。
+   */
   private void runWithRetry(Source source, Sink sink, ErrorPolicy.Retry retry) throws IOException {
-    IOException lastException = null;
+    Exception lastException = null;
     BufferPolicy bufferPolicy = memoryBudget.getBufferPolicy();
     for (int attempt = 0; attempt <= retry.maxRetries(); attempt++) {
       try (InputStream inputStream = source.open();
@@ -254,7 +261,8 @@ public class StreamConverter {
           LOG.info("Completed StreamConverter pipeline");
         }
         return;
-      } catch (IOException e) {
+      } catch (IOException | RuntimeException e) {
+        // RuntimeException をキャッチすることで StreamProcessingException（RuntimeException）もリトライ対象とする
         lastException = e;
         if (attempt < retry.maxRetries()) {
           if (LOG.isWarnEnabled()) {
@@ -276,7 +284,10 @@ public class StreamConverter {
         }
       }
     }
-    throw lastException;
+    if (lastException instanceof IOException ioe) {
+      throw ioe;
+    }
+    throw (RuntimeException) lastException;
   }
 
   /** エラーポリシーなしで実行する内部コア */

--- a/streamconverter-core/src/main/java/com/streamconverter/dsl/Pipeline.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/dsl/Pipeline.java
@@ -2,6 +2,10 @@ package com.streamconverter.dsl;
 
 import com.streamconverter.StreamConverter;
 import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.execution.ErrorPolicy;
+import com.streamconverter.execution.ExecutionStrategy;
+import com.streamconverter.execution.MemoryBudget;
+import com.streamconverter.execution.ParallelExecutionStrategy;
 import com.streamconverter.io.Sink;
 import com.streamconverter.io.Source;
 import java.io.IOException;
@@ -15,13 +19,16 @@ import java.util.Objects;
  * <p>{@link Source} → {@link IStreamCommand} チェーン → {@link Sink} の流れで パイプラインを宣言的に構築・実行する。内部では
  * {@link StreamConverter} を使用する。
  *
- * <p>使用例:
+ * <p>条件付きコマンド追加・エラーポリシー設定が {@link StreamConverter} 直接使用より簡潔に記述できる:
  *
  * <pre>{@code
- * Pipeline.input(Source.ofFile(Path.of("data.csv")))
+ * boolean needsCharConvert = !targetEncoding.equals("UTF-8");
+ * Pipeline.input(Source.ofFile(inputPath))
  *     .then(new CsvNavigateCommand(new CSVPath("name"), new PassThroughRule()))
- *     .then(new CharacterConvertCommand("UTF-8", "UTF-16"))
- *     .to(Sink.toFile(Path.of("output.txt")));
+ *     .thenIf(needsCharConvert, new CharacterConvertCommand("UTF-8", targetEncoding))
+ *     .withErrorPolicy(ErrorPolicy.retry(3, 100))
+ *     .withExecutionStrategy(new SequentialExecutionStrategy())
+ *     .to(Sink.toFile(outputPath));
  * }</pre>
  *
  * @see Source
@@ -32,14 +39,28 @@ public final class Pipeline {
 
   private final Source source;
   private final List<IStreamCommand> commands;
+  private final ExecutionStrategy strategy;
+  private final ErrorPolicy errorPolicy;
+  private final MemoryBudget memoryBudget;
 
-  private Pipeline(Source source, List<IStreamCommand> commands) {
+  private Pipeline(
+      Source source,
+      List<IStreamCommand> commands,
+      ExecutionStrategy strategy,
+      ErrorPolicy errorPolicy,
+      MemoryBudget memoryBudget) {
     this.source = source;
     this.commands = commands;
+    this.strategy = strategy;
+    this.errorPolicy = errorPolicy;
+    this.memoryBudget = memoryBudget;
   }
 
   /**
    * 指定した {@link Source} からパイプラインを開始する。
+   *
+   * <p>デフォルト設定: {@link ParallelExecutionStrategy}、{@link ErrorPolicy#failFast()}、{@link
+   * MemoryBudget#defaultBudget()}。
    *
    * @param source 入力ソース
    * @return このパイプラインの Builder
@@ -47,7 +68,12 @@ public final class Pipeline {
    */
   public static Pipeline input(Source source) {
     Objects.requireNonNull(source, "source must not be null");
-    return new Pipeline(source, new ArrayList<>());
+    return new Pipeline(
+        source,
+        new ArrayList<>(),
+        new ParallelExecutionStrategy(),
+        ErrorPolicy.failFast(),
+        MemoryBudget.defaultBudget());
   }
 
   /**
@@ -63,7 +89,62 @@ public final class Pipeline {
     Objects.requireNonNull(command, "command must not be null");
     List<IStreamCommand> newCommands = new ArrayList<>(this.commands);
     newCommands.add(command);
-    return new Pipeline(this.source, newCommands);
+    return new Pipeline(
+        this.source, newCommands, this.strategy, this.errorPolicy, this.memoryBudget);
+  }
+
+  /**
+   * 条件が真の場合のみコマンドを追加する。
+   *
+   * <p>条件が偽の場合は同じ {@link Pipeline} インスタンスを返す（コマンドは追加されない）。 実行時の条件分岐を if 文なしに記述できる:
+   *
+   * <pre>{@code
+   * pipeline.thenIf(needsConversion, new CharacterConvertCommand("UTF-8", targetEncoding))
+   * }</pre>
+   *
+   * @param condition コマンドを追加するかどうかの条件
+   * @param command 条件が真の場合に追加するコマンド
+   * @return condition が真の場合はコマンドを追加した新しい Pipeline、偽の場合は同じ Pipeline
+   * @throws NullPointerException command が null の場合
+   */
+  public Pipeline thenIf(boolean condition, IStreamCommand command) {
+    return condition ? then(command) : this;
+  }
+
+  /**
+   * 指定した {@link ErrorPolicy} を設定した新しい Pipeline を返す。
+   *
+   * @param errorPolicy 設定するエラーポリシー
+   * @return errorPolicy を設定した新しい Pipeline
+   * @throws NullPointerException errorPolicy が null の場合
+   */
+  public Pipeline withErrorPolicy(ErrorPolicy errorPolicy) {
+    Objects.requireNonNull(errorPolicy, "errorPolicy must not be null");
+    return new Pipeline(this.source, this.commands, this.strategy, errorPolicy, this.memoryBudget);
+  }
+
+  /**
+   * 指定した {@link ExecutionStrategy} を設定した新しい Pipeline を返す。
+   *
+   * @param strategy 設定する実行戦略
+   * @return strategy を設定した新しい Pipeline
+   * @throws NullPointerException strategy が null の場合
+   */
+  public Pipeline withExecutionStrategy(ExecutionStrategy strategy) {
+    Objects.requireNonNull(strategy, "strategy must not be null");
+    return new Pipeline(this.source, this.commands, strategy, this.errorPolicy, this.memoryBudget);
+  }
+
+  /**
+   * 指定した {@link MemoryBudget} を設定した新しい Pipeline を返す。
+   *
+   * @param memoryBudget 設定するメモリバジェット
+   * @return memoryBudget を設定した新しい Pipeline
+   * @throws NullPointerException memoryBudget が null の場合
+   */
+  public Pipeline withMemoryBudget(MemoryBudget memoryBudget) {
+    Objects.requireNonNull(memoryBudget, "memoryBudget must not be null");
+    return new Pipeline(this.source, this.commands, this.strategy, this.errorPolicy, memoryBudget);
   }
 
   /**
@@ -82,7 +163,8 @@ public final class Pipeline {
       throw new IllegalStateException(
           "Pipeline has no commands. Add at least one command with .then()");
     }
-    StreamConverter converter = StreamConverter.create(commands);
+    StreamConverter converter =
+        StreamConverter.create(strategy, memoryBudget, errorPolicy, commands);
     converter.run(source, sink);
   }
 }

--- a/streamconverter-core/src/main/java/com/streamconverter/dsl/Pipeline.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/dsl/Pipeline.java
@@ -1,0 +1,88 @@
+package com.streamconverter.dsl;
+
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.io.Sink;
+import com.streamconverter.io.Source;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * タイプセーフなパイプライン構築用 Fluent Builder。
+ *
+ * <p>{@link Source} → {@link IStreamCommand} チェーン → {@link Sink} の流れで パイプラインを宣言的に構築・実行する。内部では
+ * {@link StreamConverter} を使用する。
+ *
+ * <p>使用例:
+ *
+ * <pre>{@code
+ * Pipeline.input(Source.ofFile(Path.of("data.csv")))
+ *     .then(new CsvNavigateCommand(new CSVPath("name"), new PassThroughRule()))
+ *     .then(new CharacterConvertCommand("UTF-8", "UTF-16"))
+ *     .to(Sink.toFile(Path.of("output.txt")));
+ * }</pre>
+ *
+ * @see Source
+ * @see Sink
+ * @see StreamConverter
+ */
+public final class Pipeline {
+
+  private final Source source;
+  private final List<IStreamCommand> commands;
+
+  private Pipeline(Source source, List<IStreamCommand> commands) {
+    this.source = source;
+    this.commands = commands;
+  }
+
+  /**
+   * 指定した {@link Source} からパイプラインを開始する。
+   *
+   * @param source 入力ソース
+   * @return このパイプラインの Builder
+   * @throws NullPointerException source が null の場合
+   */
+  public static Pipeline input(Source source) {
+    Objects.requireNonNull(source, "source must not be null");
+    return new Pipeline(source, new ArrayList<>());
+  }
+
+  /**
+   * パイプラインにコマンドを追加する。
+   *
+   * <p>コマンドは追加された順序で実行される。
+   *
+   * @param command パイプラインに追加するコマンド
+   * @return このパイプラインの Builder（メソッドチェーン用）
+   * @throws NullPointerException command が null の場合
+   */
+  public Pipeline then(IStreamCommand command) {
+    Objects.requireNonNull(command, "command must not be null");
+    List<IStreamCommand> newCommands = new ArrayList<>(this.commands);
+    newCommands.add(command);
+    return new Pipeline(this.source, newCommands);
+  }
+
+  /**
+   * パイプラインを実行して結果を指定の {@link Sink} に書き込む。
+   *
+   * <p>少なくとも 1 つのコマンドが追加されていなければならない。 Source と Sink のストリームはこのメソッド内で自動的に管理される。
+   *
+   * @param sink 出力シンク
+   * @throws IOException ストリーム処理中にI/Oエラーが発生した場合
+   * @throws NullPointerException sink が null の場合
+   * @throws IllegalStateException コマンドが 1 つも追加されていない場合
+   */
+  public void to(Sink sink) throws IOException {
+    Objects.requireNonNull(sink, "sink must not be null");
+    if (commands.isEmpty()) {
+      throw new IllegalStateException(
+          "Pipeline has no commands. Add at least one command with .then()");
+    }
+    StreamConverter converter = StreamConverter.create(commands);
+    converter.run(source, sink);
+  }
+}

--- a/streamconverter-core/src/main/java/com/streamconverter/execution/ErrorPolicy.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/execution/ErrorPolicy.java
@@ -32,10 +32,14 @@ public sealed interface ErrorPolicy permits ErrorPolicy.FailFast, ErrorPolicy.Re
   /**
    * エラー発生時にリトライするポリシーを返す。
    *
-   * <p><strong>注意:</strong> Retry は {@link com.streamconverter.StreamConverter#run(
-   * com.streamconverter.io.Source, com.streamconverter.io.Sink)} でのみ有効。 {@link
+   * <p><strong>制約 1 — run(Source, Sink) のみ有効:</strong> {@link
    * com.streamconverter.StreamConverter#run(java.io.InputStream, java.io.OutputStream)} に渡した場合は
    * {@link UnsupportedOperationException} をスローする（InputStream は巻き戻せないため）。
+   *
+   * <p><strong>制約 2 — Source/Sink は毎回新しいストリームを開くこと:</strong> {@code Source.of(inputStream)} や
+   * {@code Sink.of(outputStream)} でラップしたストリームは、最初の試行後に close されるため 2 回目以降のリトライが失敗する。 Retry
+   * と組み合わせる場合は {@code Source.ofFile(Path)} / {@code Sink.toFile(Path)} など、 {@link
+   * com.streamconverter.io.Source#open()} を呼ぶたびに新しいストリームを生成するファクトリを使用すること。
    *
    * @param maxRetries 最大リトライ回数（1以上）
    * @param delayMs リトライ間隔（ミリ秒、0以上）

--- a/streamconverter-core/src/main/java/com/streamconverter/execution/SequentialExecutionStrategy.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/execution/SequentialExecutionStrategy.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -20,6 +21,8 @@ import org.slf4j.MDC;
  *
  * <p>注意: 中間バッファリングのためメモリ使用量は {@link ParallelExecutionStrategy} より多くなる場合がある。 大容量データ処理には {@link
  * ParallelExecutionStrategy} の使用を推奨する。
+ *
+ * <p>MDC の分離: 各コマンド実行前に MDC スナップショットを取得し、実行後に復元することで コマンド間での MDC 値の汚染を防いでいる。
  */
 public final class SequentialExecutionStrategy implements ExecutionStrategy {
 
@@ -44,6 +47,9 @@ public final class SequentialExecutionStrategy implements ExecutionStrategy {
         IStreamCommand command = commands.get(i);
         String commandName = commandNames.get(i);
 
+        // コマンド実行前の MDC スナップショットを保存（コマンド間汚染防止）
+        Map<String, String> mdcSnapshot = MDC.getCopyOfContextMap();
+
         if (i == commands.size() - 1) {
           // 最後のコマンドは最終出力ストリームに直接書き込む
           try {
@@ -53,6 +59,8 @@ public final class SequentialExecutionStrategy implements ExecutionStrategy {
           } catch (IOException | RuntimeException e) {
             throw new StreamProcessingException(
                 "Command execution failed: " + commandName + " - " + e.getMessage(), e);
+          } finally {
+            restoreMdc(mdcSnapshot);
           }
         } else {
           // 中間コマンドはバッファに書き込む
@@ -65,6 +73,8 @@ public final class SequentialExecutionStrategy implements ExecutionStrategy {
           } catch (IOException | RuntimeException e) {
             throw new StreamProcessingException(
                 "Command execution failed: " + commandName + " - " + e.getMessage(), e);
+          } finally {
+            restoreMdc(mdcSnapshot);
           }
           currentInput = new ByteArrayInputStream(buffer.toByteArray());
 
@@ -81,6 +91,14 @@ public final class SequentialExecutionStrategy implements ExecutionStrategy {
     } finally {
       PipelineContext.clear();
       MDC.clear();
+    }
+  }
+
+  /** MDC を指定したスナップショットの状態に復元する。スナップショットが null の場合はクリアする。 */
+  private static void restoreMdc(Map<String, String> snapshot) {
+    MDC.clear();
+    if (snapshot != null) {
+      MDC.setContextMap(snapshot);
     }
   }
 }

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/PipelineDslExample.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/PipelineDslExample.java
@@ -4,6 +4,8 @@ import com.streamconverter.command.impl.charcode.CharacterConvertCommand;
 import com.streamconverter.command.impl.csv.CsvNavigateCommand;
 import com.streamconverter.command.rule.PassThroughRule;
 import com.streamconverter.dsl.Pipeline;
+import com.streamconverter.execution.ErrorPolicy;
+import com.streamconverter.execution.SequentialExecutionStrategy;
 import com.streamconverter.io.Sink;
 import com.streamconverter.io.Source;
 import com.streamconverter.path.CSVPath;
@@ -15,7 +17,9 @@ import java.nio.charset.StandardCharsets;
 /**
  * {@link Pipeline} DSL の使用例。
  *
- * <p>Pipeline DSL を使用すると、{@code Source} → コマンドチェーン → {@code Sink} の流れで パイプラインを宣言的に構築・実行できる。
+ * <p>Pipeline DSL を使用すると、{@code Source} → コマンドチェーン → {@code Sink} の流れで パイプラインを宣言的に構築・実行できる。 {@link
+ * Pipeline#thenIf(boolean, com.streamconverter.command.IStreamCommand)} や {@link
+ * Pipeline#withErrorPolicy(ErrorPolicy)} を使うことで、 条件分岐やエラーポリシー設定を流暢に記述できる。
  */
 public class PipelineDslExample {
 
@@ -28,14 +32,25 @@ public class PipelineDslExample {
   public static void main(String[] args) throws IOException {
     // サンプル CSV データ
     String csvData = "name,email\nAlice,alice@example.com\nBob,bob@example.com\n";
+    String targetEncoding = "UTF-8";
+
+    // thenIf を使った条件付きコマンド追加の例
+    // targetEncoding が UTF-8 でなければ CharacterConvertCommand を追加する
+    boolean needsCharConvert = !targetEncoding.equals("UTF-8");
+
     ByteArrayInputStream inputStream =
         new ByteArrayInputStream(csvData.getBytes(StandardCharsets.UTF_8));
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
     // Pipeline DSL でパイプラインを構築・実行
+    // thenIf: needsCharConvert が false なので CharacterConvertCommand は追加されない
+    // withErrorPolicy: リトライポリシーを設定
+    // withExecutionStrategy: 逐次実行戦略を設定
     Pipeline.input(Source.of(inputStream))
         .then(CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule()))
-        .then(CharacterConvertCommand.create("UTF-8", "UTF-8")) // 同一エンコーディング（例示用）
+        .thenIf(needsCharConvert, CharacterConvertCommand.create("UTF-8", targetEncoding))
+        .withErrorPolicy(ErrorPolicy.retry(3, 100))
+        .withExecutionStrategy(new SequentialExecutionStrategy())
         .to(Sink.of(outputStream));
 
     System.out.println("Pipeline completed. Output size: " + outputStream.size() + " bytes");

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/PipelineDslExample.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/PipelineDslExample.java
@@ -1,0 +1,44 @@
+package com.streamconverter.examples;
+
+import com.streamconverter.command.impl.charcode.CharacterConvertCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.rule.PassThroughRule;
+import com.streamconverter.dsl.Pipeline;
+import com.streamconverter.io.Sink;
+import com.streamconverter.io.Source;
+import com.streamconverter.path.CSVPath;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * {@link Pipeline} DSL の使用例。
+ *
+ * <p>Pipeline DSL を使用すると、{@code Source} → コマンドチェーン → {@code Sink} の流れで パイプラインを宣言的に構築・実行できる。
+ */
+public class PipelineDslExample {
+
+  /**
+   * Pipeline DSL を使用した基本的なパイプライン例。
+   *
+   * @param args コマンドライン引数（未使用）
+   * @throws IOException I/Oエラー
+   */
+  public static void main(String[] args) throws IOException {
+    // サンプル CSV データ
+    String csvData = "name,email\nAlice,alice@example.com\nBob,bob@example.com\n";
+    ByteArrayInputStream inputStream =
+        new ByteArrayInputStream(csvData.getBytes(StandardCharsets.UTF_8));
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    // Pipeline DSL でパイプラインを構築・実行
+    Pipeline.input(Source.of(inputStream))
+        .then(CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule()))
+        .then(CharacterConvertCommand.create("UTF-8", "UTF-8")) // 同一エンコーディング（例示用）
+        .to(Sink.of(outputStream));
+
+    System.out.println("Pipeline completed. Output size: " + outputStream.size() + " bytes");
+    System.out.println("Output: " + outputStream.toString(StandardCharsets.UTF_8));
+  }
+}

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/PipelineDslExample.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/PipelineDslExample.java
@@ -32,21 +32,23 @@ public class PipelineDslExample {
   public static void main(String[] args) throws IOException {
     // サンプル CSV データ
     String csvData = "name,email\nAlice,alice@example.com\nBob,bob@example.com\n";
-    String targetEncoding = "UTF-8";
+    String targetEncoding = "UTF-16";
 
     // thenIf を使った条件付きコマンド追加の例
     // targetEncoding が UTF-8 でなければ CharacterConvertCommand を追加する
     boolean needsCharConvert = !targetEncoding.equals("UTF-8");
 
-    ByteArrayInputStream inputStream =
-        new ByteArrayInputStream(csvData.getBytes(StandardCharsets.UTF_8));
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
     // Pipeline DSL でパイプラインを構築・実行
-    // thenIf: needsCharConvert が false なので CharacterConvertCommand は追加されない
-    // withErrorPolicy: リトライポリシーを設定
-    // withExecutionStrategy: 逐次実行戦略を設定
-    Pipeline.input(Source.of(inputStream))
+    // - thenIf: needsCharConvert が true なので CharacterConvertCommand が追加される
+    // - withErrorPolicy(retry): Source.of(stream) ではなく Source.of(bytes供給ラムダ) を使うことで
+    //   リトライ時に毎回新しい InputStream を生成できる
+    // - withExecutionStrategy: 逐次実行戦略を設定
+    byte[] inputBytes = csvData.getBytes(StandardCharsets.UTF_8);
+    Source retryableSource = () -> new ByteArrayInputStream(inputBytes);
+
+    Pipeline.input(retryableSource)
         .then(CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule()))
         .thenIf(needsCharConvert, CharacterConvertCommand.create("UTF-8", targetEncoding))
         .withErrorPolicy(ErrorPolicy.retry(3, 100))
@@ -54,6 +56,5 @@ public class PipelineDslExample {
         .to(Sink.of(outputStream));
 
     System.out.println("Pipeline completed. Output size: " + outputStream.size() + " bytes");
-    System.out.println("Output: " + outputStream.toString(StandardCharsets.UTF_8));
   }
 }


### PR DESCRIPTION
## Summary

`Source` / `Sink` を活用したタイプセーフな Fluent Builder `Pipeline` を追加する。

**依存**: #537 (PR-F: Source/Sink) のマージ後にマージすること。

## 変更内容

- `dsl/Pipeline.java` 新規作成
  ```java
  Pipeline.input(Source.ofFile(Path.of("input.csv")))
      .then(CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule()))
      .to(Sink.toFile(Path.of("output.txt")));
  ```
  - 内部で `StreamConverter.create()` を使用（既存 API の薄いラッパー）
  - コマンドなしで `to()` を呼ぶと `IllegalStateException`

- `examples/PipelineDslExample.java` 新規作成（使用例）

- `docs/quickstart/basic-usage.md` に Pipeline DSL セクション追加

## Test plan

- [x] コンパイル通過（examples モジュール含む）
- [x] 既存テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)