### PR TITLE
feat(core): FileBufferCommand によるパイプラインステージ間バッファリング (#545)

### DIFF
--- a/docs/quickstart/basic-usage.md
+++ b/docs/quickstart/basic-usage.md
@@ -63,7 +63,35 @@ converter.run(inputStream, outputStream);
 2. 抽出したIDをHTTP APIに送信（`SendHttpCommand` は `streamconverter-http` モジュールで提供）
 3. APIレスポンス（JSON）から `result` フィールドを抽出
 
-## 3. MDC によるログトレーシング
+## 3. バリデーションとバッファリング
+
+バリデーションコマンドが失敗した場合に不正データが後続コマンドへ流れないようにするには、`FileBufferCommand` をステージ間に挟みます。
+
+```java
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.impl.FileBufferCommand;
+
+StreamConverter converter = StreamConverter.create(
+    validateCmd,                  // バリデーション（失敗時は IOException をスロー）
+    FileBufferCommand.create(),   // 一時ファイルでステージを分離
+    transformCmd                  // バリデーション通過後のみ実行される
+);
+converter.run(inputStream, outputStream);
+```
+
+`validateCmd` が `IOException` をスローすると、`transformCmd` はまったく実行されません。一時ファイルは実行終了後に自動削除されます。
+
+機密データを扱うパイプラインでは、AES-256-GCM で一時ファイルを暗号化するモードを使用できます：
+
+```java
+StreamConverter converter = StreamConverter.create(
+    validateCmd,
+    FileBufferCommand.createEncrypted(),  // 一時ファイルを AES-256-GCM で暗号化
+    transformCmd
+);
+```
+
+## 4. MDC によるログトレーシング
 
 実運用環境では、ログにリクエスト・ジョブレベルのコンテキスト情報を付加することで、分散トレーシングが容易になります。SLF4J の MDC と `MdcPropagatingRule` を組み合わせることで、ストリームから抽出した値を自動的にログコンテキストへ伝搬できます。
 

--- a/docs/reference/CLAUDE_ARCHITECTURE.md
+++ b/docs/reference/CLAUDE_ARCHITECTURE.md
@@ -56,6 +56,12 @@ Foundation Layer   → Path handlers, utilities, security components
 - `JsonFilterCommand` - Filter JSON elements
 - `XmlFilterCommand` - Filter XML nodes
 
+### Pipeline Control
+- `FileBufferCommand` - Buffer data through a temporary file between pipeline stages
+  - `FileBufferCommand.create()` — 平文モード
+  - `FileBufferCommand.createEncrypted()` — AES-256-GCM 暗号化モード（機密データ向け）
+  - バリデーション失敗時に不正データが下流へ流れる問題（`ConsumerCommand` + `TeeInputStream` パターンの issue #545）を解決する
+
 ## Testing Patterns
 
 - **Unit Tests**: Standard JUnit 5 with Mockito

--- a/docs/reference/CLAUDE_EXAMPLES.md
+++ b/docs/reference/CLAUDE_EXAMPLES.md
@@ -64,6 +64,35 @@ StreamConverter.createWithContext(context, extractUserId, processor)
 - Downstream commands are MDC-agnostic
 - Works correctly in multi-threaded environments
 
+### Validate-then-Transform with FileBufferCommand
+
+バリデーションが失敗した場合でも不正データが下流コマンドへ流れないようにしたい場合、`FileBufferCommand` をステージ間に挟む。
+
+```java
+// バリデーション失敗時に不正データが transformCmd へ到達しないことを保証する
+StreamConverter converter = StreamConverter.create(
+    validateCmd,
+    FileBufferCommand.create(),   // ← 一時ファイルでステージを分離
+    transformCmd
+);
+converter.run(inputStream, outputStream);
+```
+
+機密データを扱う場合は暗号化モードを使用する：
+
+```java
+StreamConverter converter = StreamConverter.create(
+    validateCmd,
+    FileBufferCommand.createEncrypted(),  // AES-256-GCM で一時ファイルを暗号化
+    transformCmd
+);
+```
+
+**一時ファイルのライフサイクル**:
+- `execute()` 開始時に `Files.createTempFile("streamconverter-", ".tmp")` で作成
+- 正常終了・例外発生を問わず `finally` で削除
+- JVM 異常終了に備えて ShutdownHook も登録（正常終了時は解除）
+
 ### Testing Network-Dependent Code
 
 ```java

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/FileBufferCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/FileBufferCommand.java
@@ -42,6 +42,7 @@ public class FileBufferCommand extends AbstractStreamCommand {
   private static final int GCM_IV_LENGTH = 12;
   private static final int GCM_TAG_LENGTH = 128;
   private static final String CIPHER_ALGORITHM = "AES/GCM/NoPadding";
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
   private final boolean encrypted;
 
@@ -165,7 +166,7 @@ public class FileBufferCommand extends AbstractStreamCommand {
   private SecretKey generateAesKey() throws IOException {
     try {
       KeyGenerator keyGen = KeyGenerator.getInstance("AES");
-      keyGen.init(AES_KEY_BITS, new SecureRandom());
+      keyGen.init(AES_KEY_BITS, SECURE_RANDOM);
       return keyGen.generateKey();
     } catch (GeneralSecurityException e) {
       throw new IOException("Failed to generate AES key", e);
@@ -174,7 +175,7 @@ public class FileBufferCommand extends AbstractStreamCommand {
 
   private byte[] generateIv() {
     byte[] iv = new byte[GCM_IV_LENGTH];
-    new SecureRandom().nextBytes(iv);
+    SECURE_RANDOM.nextBytes(iv);
     return iv;
   }
 

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/FileBufferCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/FileBufferCommand.java
@@ -1,0 +1,206 @@
+package com.streamconverter.command.impl;
+
+import com.streamconverter.command.AbstractStreamCommand;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+/**
+ * A pipeline command that buffers data through a temporary file between pipeline stages.
+ *
+ * <p>This command solves the problem where validation failures in a preceding stage can cause
+ * invalid data to be written to the output stream. By buffering through a temporary file, the
+ * upstream stage completes fully before the downstream stage begins, ensuring data integrity.
+ *
+ * <p>Usage example:
+ *
+ * <pre>{@code
+ * StreamConverter.create(
+ *     validateCmd,
+ *     FileBufferCommand.create(),
+ *     transformCmd
+ * );
+ * }</pre>
+ *
+ * <p>The encrypted variant ({@link #createEncrypted()}) uses AES-256-GCM to protect sensitive data
+ * written to the temporary file.
+ */
+public class FileBufferCommand extends AbstractStreamCommand {
+
+  private static final int BUFFER_SIZE = 64 * 1024;
+  private static final int AES_KEY_BITS = 256;
+  private static final int GCM_IV_LENGTH = 12;
+  private static final int GCM_TAG_LENGTH = 128;
+  private static final String CIPHER_ALGORITHM = "AES/GCM/NoPadding";
+
+  private final boolean encrypted;
+
+  private FileBufferCommand(boolean encrypted) {
+    this.encrypted = encrypted;
+  }
+
+  /**
+   * Creates a {@code FileBufferCommand} that buffers data through a plaintext temporary file.
+   *
+   * @return a new {@code FileBufferCommand} instance
+   */
+  public static FileBufferCommand create() {
+    return new FileBufferCommand(false);
+  }
+
+  /**
+   * Creates a {@code FileBufferCommand} that buffers data through an AES-256-GCM encrypted
+   * temporary file.
+   *
+   * <p>The encryption key and IV are generated per execution and never persisted, providing
+   * confidentiality for sensitive pipeline data.
+   *
+   * @return a new {@code FileBufferCommand} instance with encryption enabled
+   */
+  public static FileBufferCommand createEncrypted() {
+    return new FileBufferCommand(true);
+  }
+
+  /**
+   * Executes the buffering operation: writes the input stream to a temporary file, then reads the
+   * temporary file to the output stream.
+   *
+   * @param inputStream the input stream to read data from
+   * @param outputStream the output stream to write data to
+   * @throws IOException if an I/O error occurs, or if decryption authentication fails
+   */
+  @Override
+  public void execute(InputStream inputStream, OutputStream outputStream) throws IOException {
+    Path tempFile = Files.createTempFile("streamconverter-", ".tmp");
+    Thread shutdownHook = new Thread(() -> deleteSilently(tempFile), "FileBufferCommand-cleanup");
+    Runtime.getRuntime().addShutdownHook(shutdownHook);
+
+    try {
+      if (encrypted) {
+        SecretKey key = generateAesKey();
+        byte[] iv = generateIv();
+        writeEncrypted(inputStream, tempFile, key, iv);
+        readDecrypted(tempFile, outputStream, key, iv);
+      } else {
+        write(inputStream, tempFile);
+        read(tempFile, outputStream);
+      }
+    } finally {
+      try {
+        Files.deleteIfExists(tempFile);
+      } finally {
+        deregisterShutdownHook(shutdownHook);
+      }
+    }
+  }
+
+  private void write(InputStream inputStream, Path tempFile) throws IOException {
+    try (OutputStream fileOut = Files.newOutputStream(tempFile)) {
+      byte[] buffer = new byte[BUFFER_SIZE];
+      int bytesRead;
+      while ((bytesRead = inputStream.read(buffer)) != -1) {
+        fileOut.write(buffer, 0, bytesRead);
+      }
+    }
+  }
+
+  private void read(Path tempFile, OutputStream outputStream) throws IOException {
+    try (InputStream fileIn = Files.newInputStream(tempFile)) {
+      byte[] buffer = new byte[BUFFER_SIZE];
+      int bytesRead;
+      while ((bytesRead = fileIn.read(buffer)) != -1) {
+        outputStream.write(buffer, 0, bytesRead);
+      }
+    }
+  }
+
+  private void writeEncrypted(InputStream inputStream, Path tempFile, SecretKey key, byte[] iv)
+      throws IOException {
+    try (OutputStream fileOut = Files.newOutputStream(tempFile)) {
+      fileOut.write(iv);
+      Cipher cipher = initCipher(Cipher.ENCRYPT_MODE, key, iv);
+      try (CipherOutputStream cipherOut = new CipherOutputStream(fileOut, cipher)) {
+        byte[] buffer = new byte[BUFFER_SIZE];
+        int bytesRead;
+        while ((bytesRead = inputStream.read(buffer)) != -1) {
+          cipherOut.write(buffer, 0, bytesRead);
+        }
+      }
+    }
+  }
+
+  private void readDecrypted(Path tempFile, OutputStream outputStream, SecretKey key, byte[] iv)
+      throws IOException {
+    try (InputStream fileIn = Files.newInputStream(tempFile)) {
+      byte[] storedIv = new byte[GCM_IV_LENGTH];
+      int totalRead = 0;
+      while (totalRead < GCM_IV_LENGTH) {
+        int bytesRead = fileIn.read(storedIv, totalRead, GCM_IV_LENGTH - totalRead);
+        if (bytesRead == -1) {
+          throw new IOException("Unexpected end of encrypted file while reading IV");
+        }
+        totalRead += bytesRead;
+      }
+      Cipher cipher = initCipher(Cipher.DECRYPT_MODE, key, storedIv);
+      try (CipherInputStream cipherIn = new CipherInputStream(fileIn, cipher)) {
+        byte[] buffer = new byte[BUFFER_SIZE];
+        int bytesRead;
+        while ((bytesRead = cipherIn.read(buffer)) != -1) {
+          outputStream.write(buffer, 0, bytesRead);
+        }
+      }
+    }
+  }
+
+  private SecretKey generateAesKey() throws IOException {
+    try {
+      KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+      keyGen.init(AES_KEY_BITS, new SecureRandom());
+      return keyGen.generateKey();
+    } catch (GeneralSecurityException e) {
+      throw new IOException("Failed to generate AES key", e);
+    }
+  }
+
+  private byte[] generateIv() {
+    byte[] iv = new byte[GCM_IV_LENGTH];
+    new SecureRandom().nextBytes(iv);
+    return iv;
+  }
+
+  private Cipher initCipher(int mode, SecretKey key, byte[] iv) throws IOException {
+    try {
+      Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+      cipher.init(mode, key, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+      return cipher;
+    } catch (GeneralSecurityException e) {
+      throw new IOException("Encryption/decryption failed", e);
+    }
+  }
+
+  private void deleteSilently(Path path) {
+    try {
+      Files.deleteIfExists(path);
+    } catch (IOException e) {
+      log.warn("Failed to delete temporary file: {}", path, e);
+    }
+  }
+
+  private void deregisterShutdownHook(Thread shutdownHook) {
+    try {
+      Runtime.getRuntime().removeShutdownHook(shutdownHook);
+    } catch (IllegalStateException e) {
+      log.debug("JVM is shutting down; could not deregister shutdown hook", e);
+    }
+  }
+}

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/FileBufferCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/FileBufferCommand.java
@@ -84,14 +84,14 @@ public class FileBufferCommand extends AbstractStreamCommand {
   public void execute(InputStream inputStream, OutputStream outputStream) throws IOException {
     Path tempFile = Files.createTempFile("streamconverter-", ".tmp");
     Thread shutdownHook = new Thread(() -> deleteSilently(tempFile), "FileBufferCommand-cleanup");
-    Runtime.getRuntime().addShutdownHook(shutdownHook);
 
     try {
+      registerShutdownHook(shutdownHook, tempFile);
       if (encrypted) {
         SecretKey key = generateAesKey();
         byte[] iv = generateIv();
         writeEncrypted(inputStream, tempFile, key, iv);
-        readDecrypted(tempFile, outputStream, key, iv);
+        readDecrypted(tempFile, outputStream, key);
       } else {
         write(inputStream, tempFile);
         read(tempFile, outputStream);
@@ -140,7 +140,7 @@ public class FileBufferCommand extends AbstractStreamCommand {
     }
   }
 
-  private void readDecrypted(Path tempFile, OutputStream outputStream, SecretKey key, byte[] iv)
+  private void readDecrypted(Path tempFile, OutputStream outputStream, SecretKey key)
       throws IOException {
     try (InputStream fileIn = Files.newInputStream(tempFile)) {
       byte[] storedIv = new byte[GCM_IV_LENGTH];
@@ -189,11 +189,14 @@ public class FileBufferCommand extends AbstractStreamCommand {
     }
   }
 
-  private void deleteSilently(Path path) {
+  private void registerShutdownHook(Thread shutdownHook, Path tempFile) {
     try {
-      Files.deleteIfExists(path);
-    } catch (IOException e) {
-      log.warn("Failed to delete temporary file: {}", path, e);
+      Runtime.getRuntime().addShutdownHook(shutdownHook);
+    } catch (IllegalStateException | SecurityException e) {
+      // JVM shutting down or security manager disallows hooks: fall back to deleteOnExit
+      log.debug(
+          "Could not register shutdown hook; falling back to deleteOnExit for {}", tempFile, e);
+      tempFile.toFile().deleteOnExit();
     }
   }
 
@@ -202,6 +205,16 @@ public class FileBufferCommand extends AbstractStreamCommand {
       Runtime.getRuntime().removeShutdownHook(shutdownHook);
     } catch (IllegalStateException e) {
       log.debug("JVM is shutting down; could not deregister shutdown hook", e);
+    } catch (SecurityException e) {
+      log.debug("Security manager prevented shutdown hook deregistration", e);
+    }
+  }
+
+  private void deleteSilently(Path path) {
+    try {
+      Files.deleteIfExists(path);
+    } catch (IOException e) {
+      log.warn("Failed to delete temporary file: {}", path, e);
     }
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/FileBufferCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/FileBufferCommandTest.java
@@ -1,0 +1,319 @@
+package com.streamconverter.command.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.streamconverter.StreamConverter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("FileBufferCommand Tests")
+class FileBufferCommandTest {
+
+  // ---------------------------------------------------------------------------
+  // Plain mode
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("Plain: input bytes are fully reproduced in output")
+  void testPlain_inputEqualsOutput() throws IOException {
+    byte[] input = "Hello, FileBufferCommand!".getBytes(StandardCharsets.UTF_8);
+    byte[] output = execute(FileBufferCommand.create(), input);
+    assertArrayEquals(input, output);
+  }
+
+  @Test
+  @DisplayName("Plain: empty input produces empty output")
+  void testPlain_emptyInput() throws IOException {
+    byte[] output = execute(FileBufferCommand.create(), new byte[0]);
+    assertEquals(0, output.length);
+  }
+
+  @Test
+  @DisplayName("Plain: data larger than 64 KB is transferred correctly")
+  void testPlain_largeInput() throws IOException {
+    byte[] input = buildLargeInput(128 * 1024); // 128 KB
+    byte[] output = execute(FileBufferCommand.create(), input);
+    assertArrayEquals(input, output);
+  }
+
+  @Test
+  @DisplayName("Plain: temporary file is deleted after execution")
+  void testPlain_tempFileDeletedAfterExecution() throws IOException {
+    // Track temp files before and after execution
+    Path tempDir = Path.of(System.getProperty("java.io.tmpdir"));
+    String[] before = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
+    if (before == null) before = new String[0];
+
+    byte[] input = "test data".getBytes(StandardCharsets.UTF_8);
+    execute(FileBufferCommand.create(), input);
+
+    String[] after = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
+    if (after == null) after = new String[0];
+
+    // No new streamconverter temp files should remain
+    assertEquals(before.length, after.length, "Temporary file should be deleted after execution");
+  }
+
+  @Test
+  @DisplayName("Plain: temporary file is deleted even when IOException is thrown mid-read")
+  void testPlain_tempFileDeletedOnException() {
+    Path tempDir = Path.of(System.getProperty("java.io.tmpdir"));
+    String[] before = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
+    if (before == null) before = new String[0];
+    final int beforeCount = before.length;
+
+    InputStream failingStream =
+        new InputStream() {
+          private int count = 0;
+
+          @Override
+          public int read(byte[] buf, int off, int len) throws IOException {
+            if (count++ > 2) throw new IOException("Simulated read failure");
+            buf[off] = 'X';
+            return 1;
+          }
+
+          @Override
+          public int read() throws IOException {
+            return 'X';
+          }
+        };
+
+    assertThrows(
+        IOException.class,
+        () -> {
+          ByteArrayOutputStream out = new ByteArrayOutputStream();
+          FileBufferCommand.create().execute(failingStream, out);
+        });
+
+    String[] after = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
+    if (after == null) after = new String[0];
+    assertEquals(beforeCount, after.length, "Temporary file should be deleted after exception");
+  }
+
+  @Test
+  @DisplayName("Plain: shutdown hook is deregistered after normal execution")
+  void testPlain_shutdownHookDeregisteredAfterExecution() throws IOException {
+    int hooksBefore = countShutdownHooks();
+    execute(FileBufferCommand.create(), "data".getBytes(StandardCharsets.UTF_8));
+    int hooksAfter = countShutdownHooks();
+    assertEquals(hooksBefore, hooksAfter, "Shutdown hook count should be the same after execution");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Encrypted mode
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("Encrypted: input bytes are fully reproduced in output")
+  void testEncrypted_inputEqualsOutput() throws IOException {
+    byte[] input = "Sensitive data for encryption test.".getBytes(StandardCharsets.UTF_8);
+    byte[] output = execute(FileBufferCommand.createEncrypted(), input);
+    assertArrayEquals(input, output);
+  }
+
+  @Test
+  @DisplayName("Encrypted: empty input produces empty output")
+  void testEncrypted_emptyInput() throws IOException {
+    byte[] output = execute(FileBufferCommand.createEncrypted(), new byte[0]);
+    assertEquals(0, output.length);
+  }
+
+  @Test
+  @DisplayName("Encrypted: data larger than 64 KB is transferred correctly")
+  void testEncrypted_largeInput() throws IOException {
+    byte[] input = buildLargeInput(128 * 1024);
+    byte[] output = execute(FileBufferCommand.createEncrypted(), input);
+    assertArrayEquals(input, output);
+  }
+
+  @Test
+  @DisplayName("Encrypted: temporary file bytes differ from plaintext (directly verified)")
+  void testEncrypted_tempFileContainsEncryptedData() throws Exception {
+    byte[] input = "Sensitive plaintext payload.".getBytes(StandardCharsets.UTF_8);
+
+    Path tempDir = Path.of(System.getProperty("java.io.tmpdir"));
+    AtomicReference<byte[]> capturedTempFileBytes = new AtomicReference<>();
+    CountDownLatch firstWriteReceived = new CountDownLatch(1);
+    CountDownLatch writeMayProceed = new CountDownLatch(1);
+
+    // readDecrypted() が outputStream.write() を呼んだ瞬間 = 暗号化書き込みが完全に終わった後。
+    // その最初の write() で一時ファイルを横取りし、処理をブロックする。
+    OutputStream interceptingOutput =
+        new OutputStream() {
+          private boolean intercepted = false;
+
+          @Override
+          public void write(byte[] buf, int off, int len) throws IOException {
+            maybeIntercept();
+          }
+
+          @Override
+          public void write(int b) throws IOException {
+            maybeIntercept();
+          }
+
+          private void maybeIntercept() throws IOException {
+            if (!intercepted) {
+              intercepted = true;
+              // この時点で一時ファイルへの書き込みは完了している
+              String[] tempFiles =
+                  tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
+              if (tempFiles != null && tempFiles.length == 1) {
+                try {
+                  capturedTempFileBytes.set(Files.readAllBytes(tempDir.resolve(tempFiles[0])));
+                } catch (IOException e) {
+                  // 読み取れない場合は null のまま
+                }
+              }
+              firstWriteReceived.countDown();
+              try {
+                writeMayProceed.await();
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted", e);
+              }
+            }
+          }
+        };
+
+    // 別スレッドで execute() を走らせる
+    Thread executor =
+        new Thread(
+            () -> {
+              try {
+                FileBufferCommand.createEncrypted()
+                    .execute(new ByteArrayInputStream(input), interceptingOutput);
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            });
+    executor.start();
+
+    // 最初の write() が来るまで待ってからアンブロック
+    firstWriteReceived.await();
+    writeMayProceed.countDown();
+    executor.join();
+
+    byte[] fileBytes = capturedTempFileBytes.get();
+    assertNotNull(fileBytes, "Temp file bytes should have been captured mid-execution");
+    // ファイルサイズは IV(12B) + 暗号文 + GCMタグ(16B) なので plaintext より大きい
+    assertTrue(
+        fileBytes.length > input.length,
+        "Encrypted file ("
+            + fileBytes.length
+            + "B) must be larger than plaintext ("
+            + input.length
+            + "B): IV=12B + ciphertext + GCM tag=16B");
+    // 一時ファイルの内容が平文を含まないこと（暗号化されていること）
+    assertFalse(
+        containsSubsequence(fileBytes, input), "Temporary file must not contain plaintext bytes");
+  }
+
+  @Test
+  @DisplayName("Encrypted: temporary file is deleted after execution")
+  void testEncrypted_tempFileDeletedAfterExecution() throws IOException {
+    Path tempDir = Path.of(System.getProperty("java.io.tmpdir"));
+    String[] before = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
+    if (before == null) before = new String[0];
+
+    execute(FileBufferCommand.createEncrypted(), "secret".getBytes(StandardCharsets.UTF_8));
+
+    String[] after = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
+    if (after == null) after = new String[0];
+    assertEquals(
+        before.length, after.length, "Temporary file should be deleted after encrypted execution");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pipeline integration
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("Pipeline: cmd1 → FileBufferCommand → cmd2 produces correct output")
+  void testPipelineIntegration() throws IOException {
+    // cmd1: append " [stage1]"
+    // cmd2: append " [stage2]"
+    byte[] input = "input".getBytes(StandardCharsets.UTF_8);
+
+    StreamConverter converter =
+        StreamConverter.create(
+            (in, out) -> {
+              byte[] data = in.readAllBytes();
+              String text = new String(data, StandardCharsets.UTF_8) + " [stage1]";
+              out.write(text.getBytes(StandardCharsets.UTF_8));
+            },
+            FileBufferCommand.create(),
+            (in, out) -> {
+              byte[] data = in.readAllBytes();
+              String text = new String(data, StandardCharsets.UTF_8) + " [stage2]";
+              out.write(text.getBytes(StandardCharsets.UTF_8));
+            });
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    converter.run(new ByteArrayInputStream(input), output);
+
+    String result = output.toString(StandardCharsets.UTF_8);
+    assertEquals("input [stage1] [stage2]", result);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private byte[] execute(FileBufferCommand command, byte[] inputBytes) throws IOException {
+    ByteArrayInputStream in = new ByteArrayInputStream(inputBytes);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    command.execute(in, out);
+    return out.toByteArray();
+  }
+
+  /** Returns true if {@code haystack} contains {@code needle} as a contiguous subsequence. */
+  private boolean containsSubsequence(byte[] haystack, byte[] needle) {
+    if (needle.length == 0) return true;
+    outer:
+    for (int i = 0; i <= haystack.length - needle.length; i++) {
+      for (int j = 0; j < needle.length; j++) {
+        if (haystack[i + j] != needle[j]) continue outer;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private byte[] buildLargeInput(int size) {
+    byte[] data = new byte[size];
+    for (int i = 0; i < size; i++) {
+      data[i] = (byte) (i % 256);
+    }
+    return data;
+  }
+
+  /**
+   * Counts the number of registered shutdown hooks by inspecting the JVM's ApplicationShutdownHooks
+   * via reflection.
+   */
+  private int countShutdownHooks() {
+    try {
+      Class<?> clazz = Class.forName("java.lang.ApplicationShutdownHooks");
+      Field field = clazz.getDeclaredField("hooks");
+      field.setAccessible(true);
+      java.util.IdentityHashMap<?, ?> hooks = (java.util.IdentityHashMap<?, ?>) field.get(null);
+      return hooks.size();
+    } catch (Exception e) {
+      // If reflection fails (e.g., security manager), return -1 to skip assertion
+      return -1;
+    }
+  }
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/FileBufferCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/FileBufferCommandTest.java
@@ -13,9 +13,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 @DisplayName("FileBufferCommand Tests")
 class FileBufferCommandTest {
@@ -49,57 +51,54 @@ class FileBufferCommandTest {
 
   @Test
   @DisplayName("Plain: temporary file is deleted after execution")
-  void testPlain_tempFileDeletedAfterExecution() throws IOException {
-    // Track temp files before and after execution
-    Path tempDir = Path.of(System.getProperty("java.io.tmpdir"));
-    String[] before = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
-    if (before == null) before = new String[0];
-
-    byte[] input = "test data".getBytes(StandardCharsets.UTF_8);
-    execute(FileBufferCommand.create(), input);
-
-    String[] after = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
-    if (after == null) after = new String[0];
-
-    // No new streamconverter temp files should remain
-    assertEquals(before.length, after.length, "Temporary file should be deleted after execution");
+  void testPlain_tempFileDeletedAfterExecution(@TempDir Path tempDir) throws IOException {
+    System.setProperty("java.io.tmpdir", tempDir.toString());
+    try {
+      execute(FileBufferCommand.create(), "test data".getBytes(StandardCharsets.UTF_8));
+      String[] remaining = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
+      assertEquals(
+          0,
+          remaining == null ? 0 : remaining.length,
+          "Temporary file should be deleted after execution");
+    } finally {
+      System.clearProperty("java.io.tmpdir");
+    }
   }
 
   @Test
   @DisplayName("Plain: temporary file is deleted even when IOException is thrown mid-read")
-  void testPlain_tempFileDeletedOnException() {
-    Path tempDir = Path.of(System.getProperty("java.io.tmpdir"));
-    String[] before = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
-    if (before == null) before = new String[0];
-    final int beforeCount = before.length;
+  void testPlain_tempFileDeletedOnException(@TempDir Path tempDir) {
+    System.setProperty("java.io.tmpdir", tempDir.toString());
+    try {
+      InputStream failingStream =
+          new InputStream() {
+            private int count = 0;
 
-    InputStream failingStream =
-        new InputStream() {
-          private int count = 0;
+            @Override
+            public int read(byte[] buf, int off, int len) throws IOException {
+              if (count++ > 2) throw new IOException("Simulated read failure");
+              buf[off] = 'X';
+              return 1;
+            }
 
-          @Override
-          public int read(byte[] buf, int off, int len) throws IOException {
-            if (count++ > 2) throw new IOException("Simulated read failure");
-            buf[off] = 'X';
-            return 1;
-          }
+            @Override
+            public int read() throws IOException {
+              return 'X';
+            }
+          };
 
-          @Override
-          public int read() throws IOException {
-            return 'X';
-          }
-        };
+      assertThrows(
+          IOException.class,
+          () -> FileBufferCommand.create().execute(failingStream, new ByteArrayOutputStream()));
 
-    assertThrows(
-        IOException.class,
-        () -> {
-          ByteArrayOutputStream out = new ByteArrayOutputStream();
-          FileBufferCommand.create().execute(failingStream, out);
-        });
-
-    String[] after = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
-    if (after == null) after = new String[0];
-    assertEquals(beforeCount, after.length, "Temporary file should be deleted after exception");
+      String[] remaining = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
+      assertEquals(
+          0,
+          remaining == null ? 0 : remaining.length,
+          "Temporary file should be deleted after exception");
+    } finally {
+      System.clearProperty("java.io.tmpdir");
+    }
   }
 
   @Test
@@ -143,7 +142,14 @@ class FileBufferCommandTest {
   void testEncrypted_tempFileContainsEncryptedData() throws Exception {
     byte[] input = "Sensitive plaintext payload.".getBytes(StandardCharsets.UTF_8);
 
-    Path tempDir = Path.of(System.getProperty("java.io.tmpdir"));
+    // 実際の tmpdir をスキャン。execute() 開始直前のスナップショットとの差分で
+    // このテストが作成した一時ファイルを確実に特定する。
+    Path actualTmpDir = Path.of(System.getProperty("java.io.tmpdir"));
+    java.util.Set<String> before =
+        java.util.Arrays.stream(
+                actualTmpDir.toFile().list((d, n) -> n.startsWith("streamconverter-")))
+            .collect(java.util.stream.Collectors.toSet());
+
     AtomicReference<byte[]> capturedTempFileBytes = new AtomicReference<>();
     CountDownLatch firstWriteReceived = new CountDownLatch(1);
     CountDownLatch writeMayProceed = new CountDownLatch(1);
@@ -167,19 +173,26 @@ class FileBufferCommandTest {
           private void maybeIntercept() throws IOException {
             if (!intercepted) {
               intercepted = true;
-              // この時点で一時ファイルへの書き込みは完了している
-              String[] tempFiles =
-                  tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
-              if (tempFiles != null && tempFiles.length == 1) {
-                try {
-                  capturedTempFileBytes.set(Files.readAllBytes(tempDir.resolve(tempFiles[0])));
-                } catch (IOException e) {
-                  // 読み取れない場合は null のまま
+              // スナップショット差分でこのテストの一時ファイルを特定する
+              String[] current =
+                  actualTmpDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
+              if (current != null) {
+                for (String name : current) {
+                  if (!before.contains(name)) {
+                    try {
+                      capturedTempFileBytes.set(Files.readAllBytes(actualTmpDir.resolve(name)));
+                    } catch (IOException e) {
+                      // 読み取れない場合は null のまま
+                    }
+                    break;
+                  }
                 }
               }
               firstWriteReceived.countDown();
               try {
-                writeMayProceed.await();
+                if (!writeMayProceed.await(10, TimeUnit.SECONDS)) {
+                  throw new IOException("Timed out waiting for test to proceed");
+                }
               } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new IOException("Interrupted", e);
@@ -201,10 +214,13 @@ class FileBufferCommandTest {
             });
     executor.start();
 
-    // 最初の write() が来るまで待ってからアンブロック
-    firstWriteReceived.await();
+    // 最初の write() が来るまで待ってからアンブロック（タイムアウト付き）
+    assertTrue(
+        firstWriteReceived.await(10, TimeUnit.SECONDS),
+        "Timed out waiting for encrypted output to be written");
     writeMayProceed.countDown();
-    executor.join();
+    executor.join(10_000);
+    assertFalse(executor.isAlive(), "Executor thread did not finish in time");
 
     byte[] fileBytes = capturedTempFileBytes.get();
     assertNotNull(fileBytes, "Temp file bytes should have been captured mid-execution");
@@ -223,17 +239,18 @@ class FileBufferCommandTest {
 
   @Test
   @DisplayName("Encrypted: temporary file is deleted after execution")
-  void testEncrypted_tempFileDeletedAfterExecution() throws IOException {
-    Path tempDir = Path.of(System.getProperty("java.io.tmpdir"));
-    String[] before = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
-    if (before == null) before = new String[0];
-
-    execute(FileBufferCommand.createEncrypted(), "secret".getBytes(StandardCharsets.UTF_8));
-
-    String[] after = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
-    if (after == null) after = new String[0];
-    assertEquals(
-        before.length, after.length, "Temporary file should be deleted after encrypted execution");
+  void testEncrypted_tempFileDeletedAfterExecution(@TempDir Path tempDir) throws IOException {
+    System.setProperty("java.io.tmpdir", tempDir.toString());
+    try {
+      execute(FileBufferCommand.createEncrypted(), "secret".getBytes(StandardCharsets.UTF_8));
+      String[] remaining = tempDir.toFile().list((d, n) -> n.startsWith("streamconverter-"));
+      assertEquals(
+          0,
+          remaining == null ? 0 : remaining.length,
+          "Temporary file should be deleted after encrypted execution");
+    } finally {
+      System.clearProperty("java.io.tmpdir");
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -243,8 +260,6 @@ class FileBufferCommandTest {
   @Test
   @DisplayName("Pipeline: cmd1 → FileBufferCommand → cmd2 produces correct output")
   void testPipelineIntegration() throws IOException {
-    // cmd1: append " [stage1]"
-    // cmd2: append " [stage2]"
     byte[] input = "input".getBytes(StandardCharsets.UTF_8);
 
     StreamConverter converter =
@@ -264,8 +279,7 @@ class FileBufferCommandTest {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     converter.run(new ByteArrayInputStream(input), output);
 
-    String result = output.toString(StandardCharsets.UTF_8);
-    assertEquals("input [stage1] [stage2]", result);
+    assertEquals("input [stage1] [stage2]", output.toString(StandardCharsets.UTF_8));
   }
 
   // ---------------------------------------------------------------------------
@@ -312,7 +326,6 @@ class FileBufferCommandTest {
       java.util.IdentityHashMap<?, ?> hooks = (java.util.IdentityHashMap<?, ?>) field.get(null);
       return hooks.size();
     } catch (Exception e) {
-      // If reflection fails (e.g., security manager), return -1 to skip assertion
       return -1;
     }
   }


### PR DESCRIPTION
## 概要

`ConsumerCommand` + `TeeInputStream` パターンの問題（issue #545）を解決する。
バリデーション失敗時に不正データが出力ストリームへ全量書き込まれるケースに対し、
ステージ間を一時ファイルで分離する `FileBufferCommand` を追加する。

```java
StreamConverter.create(
    validateCmd,
    FileBufferCommand.create(),       // ← ここで一時ファイルにバッファ
    transformCmd
);
```

## 変更内容

### 追加ファイル

- `streamconverter-core/src/main/java/com/streamconverter/command/impl/FileBufferCommand.java`
- `streamconverter-core/src/test/java/com/streamconverter/command/impl/FileBufferCommandTest.java`

### 実装詳細

**`FileBufferCommand`**
- `create()` — 平文モード（一時ファイルにそのまま書き込み）
- `createEncrypted()` — AES-256-GCM 暗号化モード（機密データ向け）
- 一時ファイルは `execute()` 完了後に必ず削除（例外発生時も `finally` で保証）
- シャットダウン時のリーク防止に ShutdownHook を登録・解除
- 外部ライブラリ追加なし（`javax.crypto` 標準 API のみ使用）

**暗号化ファイルのバイトレイアウト**
```
[ IV (12 bytes) ][ AES-GCM 暗号文 + 認証タグ (可変長) ]
```

## テスト

12件のテストで以下を検証:

| テスト | 検証内容 |
|---|---|
| Plain round-trip (空/通常/128KB) | 入力と出力が完全一致 |
| 一時ファイル削除（正常/例外時） | 実行後にファイルが残らない |
| ShutdownHook 解除 | フック数が実行前後で同一 |
| Encrypted round-trip (空/通常/128KB) | 復号後に元データと一致 |
| **暗号化直接検証** | 実行中に一時ファイルを横取りし、平文を含まないことを確認 |
| Pipeline 統合 | `StreamConverter.create(cmd1, FileBufferCommand.create(), cmd2)` が正常動作 |

暗号化検証テストは `OutputStream` フックで `readDecrypted()` の最初の `write()` を捕捉し、
その時点の一時ファイルを直接読み取る方式で実装（間接検証ではなく直接検証）。

## テスト実行

```bash
./gradlew :streamconverter-core:test --tests "com.streamconverter.command.impl.FileBufferCommandTest"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)