### PR TITLE
fix(core): replace java.util.logging with SLF4J in XML commands (#551)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
@@ -12,13 +12,14 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * XML Filter Command Class
@@ -32,7 +33,7 @@ import javax.xml.stream.events.XMLEvent;
  * path expressions including nested elements and attributes
  */
 public class XmlFilterCommand extends AbstractStreamCommand {
-  private static final Logger LOGGER = Logger.getLogger(XmlFilterCommand.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(XmlFilterCommand.class);
 
   private final IPath<List<String>> xpath;
 
@@ -96,7 +97,7 @@ public class XmlFilterCommand extends AbstractStreamCommand {
               eventWriter.add(event);
               eventWriter.close();
             } catch (XMLStreamException e) {
-              LOGGER.warning("Error writing start element: " + e.getMessage());
+              LOGGER.warn("Error writing start element: " + e.getMessage());
             }
           } else if (isCapturing && currentDepth > captureDepth) {
             // We're inside a matching element, continue capturing
@@ -105,7 +106,7 @@ public class XmlFilterCommand extends AbstractStreamCommand {
               eventWriter.add(event);
               eventWriter.close();
             } catch (XMLStreamException e) {
-              LOGGER.warning("Error writing nested start element: " + e.getMessage());
+              LOGGER.warn("Error writing nested start element: " + e.getMessage());
             }
           }
 
@@ -116,7 +117,7 @@ public class XmlFilterCommand extends AbstractStreamCommand {
               eventWriter.add(event);
               eventWriter.close();
             } catch (XMLStreamException e) {
-              LOGGER.warning("Error writing end element: " + e.getMessage());
+              LOGGER.warn("Error writing end element: " + e.getMessage());
             }
 
             // If we're closing the captured element
@@ -137,7 +138,7 @@ public class XmlFilterCommand extends AbstractStreamCommand {
             eventWriter.add(event);
             eventWriter.close();
           } catch (XMLStreamException e) {
-            LOGGER.warning("Error writing content: " + e.getMessage());
+            LOGGER.warn("Error writing content: " + e.getMessage());
           }
         }
       }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
@@ -97,7 +97,7 @@ public class XmlFilterCommand extends AbstractStreamCommand {
               eventWriter.add(event);
               eventWriter.close();
             } catch (XMLStreamException e) {
-              LOGGER.warn("Error writing start element: " + e.getMessage());
+              LOGGER.warn("Error writing start element", e);
             }
           } else if (isCapturing && currentDepth > captureDepth) {
             // We're inside a matching element, continue capturing
@@ -106,7 +106,7 @@ public class XmlFilterCommand extends AbstractStreamCommand {
               eventWriter.add(event);
               eventWriter.close();
             } catch (XMLStreamException e) {
-              LOGGER.warn("Error writing nested start element: " + e.getMessage());
+              LOGGER.warn("Error writing nested start element", e);
             }
           }
 
@@ -117,7 +117,7 @@ public class XmlFilterCommand extends AbstractStreamCommand {
               eventWriter.add(event);
               eventWriter.close();
             } catch (XMLStreamException e) {
-              LOGGER.warn("Error writing end element: " + e.getMessage());
+              LOGGER.warn("Error writing end element", e);
             }
 
             // If we're closing the captured element
@@ -138,7 +138,7 @@ public class XmlFilterCommand extends AbstractStreamCommand {
             eventWriter.add(event);
             eventWriter.close();
           } catch (XMLStreamException e) {
-            LOGGER.warn("Error writing content: " + e.getMessage());
+            LOGGER.warn("Error writing content", e);
           }
         }
       }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
@@ -12,7 +12,6 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLEventWriter;
@@ -20,6 +19,8 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * XML Navigate Command Class
@@ -29,7 +30,7 @@ import javax.xml.stream.events.XMLEvent;
  * while preserving the overall XML structure.
  */
 public class XmlNavigateCommand extends AbstractStreamCommand {
-  private static final Logger LOGGER = Logger.getLogger(XmlNavigateCommand.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(XmlNavigateCommand.class);
   private static final XMLEventFactory EVENT_FACTORY = XMLEventFactory.newInstance();
 
   private TreePath treePath;
@@ -175,14 +176,14 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
       try {
         eventReader.close();
       } catch (XMLStreamException e) {
-        LOGGER.warning("Failed to close XMLEventReader: " + e.getMessage());
+        LOGGER.warn("Failed to close XMLEventReader: " + e.getMessage());
       }
     }
     if (eventWriter != null) {
       try {
         eventWriter.close();
       } catch (XMLStreamException e) {
-        LOGGER.warning("Failed to close XMLEventWriter: " + e.getMessage());
+        LOGGER.warn("Failed to close XMLEventWriter: " + e.getMessage());
       }
     }
   }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
@@ -176,14 +176,14 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
       try {
         eventReader.close();
       } catch (XMLStreamException e) {
-        LOGGER.warn("Failed to close XMLEventReader: " + e.getMessage());
+        LOGGER.warn("Failed to close XMLEventReader", e);
       }
     }
     if (eventWriter != null) {
       try {
         eventWriter.close();
       } catch (XMLStreamException e) {
-        LOGGER.warn("Failed to close XMLEventWriter: " + e.getMessage());
+        LOGGER.warn("Failed to close XMLEventWriter", e);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Replace `java.util.logging.Logger` with SLF4J `Logger`/`LoggerFactory` in `XmlFilterCommand` and `XmlNavigateCommand`
- Change `LOGGER.warning(...)` to `LOGGER.warn(...)` per SLF4J API
- Consistent with SLF4J used in all other commands in the project

## Test plan
- [x] All existing XML command tests pass unchanged
- [x] No new tests needed (style-only change)

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)