### PR TITLE
fix(core): make ConvertCommand constructor private, add factory method (#552)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/ConvertCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/ConvertCommand.java
@@ -34,15 +34,13 @@ public class ConvertCommand extends AbstractStreamCommand {
   private TreePath treePath;
 
   /**
-   * デフォルトコンストラクタ
+   * 内部利用のみ。インスタンス生成には {@link #create} を使うこと。
    *
    * @param rule 変換ルール
    * @param treePath 変換対象のTreePath
    */
   private ConvertCommand(IRule rule, TreePath treePath) {
     super();
-    Objects.requireNonNull(rule, "rule must not be null");
-    Objects.requireNonNull(treePath, "treePath must not be null");
     this.rule = rule;
     this.treePath = treePath;
   }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/ConvertCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/ConvertCommand.java
@@ -39,12 +39,26 @@ public class ConvertCommand extends AbstractStreamCommand {
    * @param rule 変換ルール
    * @param treePath 変換対象のTreePath
    */
-  public ConvertCommand(IRule rule, TreePath treePath) {
+  private ConvertCommand(IRule rule, TreePath treePath) {
     super();
     Objects.requireNonNull(rule, "rule must not be null");
     Objects.requireNonNull(treePath, "treePath must not be null");
     this.rule = rule;
     this.treePath = treePath;
+  }
+
+  /**
+   * Factory method for creating a ConvertCommand with explicit rule and TreePath.
+   *
+   * @param rule 変換ルール
+   * @param treePath 変換対象のTreePath
+   * @return a ConvertCommand instance
+   * @throws NullPointerException if rule or treePath is null
+   */
+  public static ConvertCommand create(IRule rule, TreePath treePath) {
+    Objects.requireNonNull(rule, "rule must not be null");
+    Objects.requireNonNull(treePath, "treePath must not be null");
+    return new ConvertCommand(rule, treePath);
   }
 
   /**

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ConvertCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ConvertCommandTest.java
@@ -29,7 +29,7 @@ public class ConvertCommandTest {
         """;
 
     TestRule rule = TestRule.contentTransformRule(); // replaces "original" with "transformed"
-    ConvertCommand command = new ConvertCommand(rule, TreePath.fromXml("root/target"));
+    ConvertCommand command = ConvertCommand.create(rule, TreePath.fromXml("root/target"));
 
     ByteArrayInputStream inputStream =
         new ByteArrayInputStream(inputXml.getBytes(StandardCharsets.UTF_8));
@@ -62,7 +62,8 @@ public class ConvertCommandTest {
         """;
 
     TestRule rule = TestRule.upperCaseRule(); // replaces "test" with "TEST"
-    ConvertCommand command = new ConvertCommand(rule, TreePath.fromXml("document/section/value"));
+    ConvertCommand command =
+        ConvertCommand.create(rule, TreePath.fromXml("document/section/value"));
 
     ByteArrayInputStream inputStream =
         new ByteArrayInputStream(inputXml.getBytes(StandardCharsets.UTF_8));
@@ -83,12 +84,12 @@ public class ConvertCommandTest {
 
     assertThrows(
         NullPointerException.class,
-        () -> new ConvertCommand(null, TreePath.fromXml("valid/path")),
+        () -> ConvertCommand.create(null, TreePath.fromXml("valid/path")),
         "Should throw exception for null rule");
 
     assertThrows(
         NullPointerException.class,
-        () -> new ConvertCommand(rule, null),
+        () -> ConvertCommand.create(rule, null),
         "Should throw exception for null path");
   }
 
@@ -98,7 +99,7 @@ public class ConvertCommandTest {
     String inputXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root></root>";
 
     TestRule rule = TestRule.contentTransformRule();
-    ConvertCommand command = new ConvertCommand(rule, TreePath.fromXml("root/nonexistent"));
+    ConvertCommand command = ConvertCommand.create(rule, TreePath.fromXml("root/nonexistent"));
 
     ByteArrayInputStream inputStream =
         new ByteArrayInputStream(inputXml.getBytes(StandardCharsets.UTF_8));
@@ -116,7 +117,7 @@ public class ConvertCommandTest {
     String invalidXml = "<invalid><unclosed>";
 
     TestRule rule = TestRule.contentTransformRule();
-    ConvertCommand command = new ConvertCommand(rule, TreePath.fromXml("invalid/element"));
+    ConvertCommand command = ConvertCommand.create(rule, TreePath.fromXml("invalid/element"));
 
     ByteArrayInputStream inputStream =
         new ByteArrayInputStream(invalidXml.getBytes(StandardCharsets.UTF_8));
@@ -146,7 +147,7 @@ public class ConvertCommandTest {
     xmlBuilder.append("</document>");
 
     TestRule rule = TestRule.upperCaseRule();
-    ConvertCommand command = new ConvertCommand(rule, TreePath.fromXml("document/item"));
+    ConvertCommand command = ConvertCommand.create(rule, TreePath.fromXml("document/item"));
 
     ByteArrayInputStream inputStream =
         new ByteArrayInputStream(xmlBuilder.toString().getBytes(StandardCharsets.UTF_8));
@@ -183,7 +184,7 @@ public class ConvertCommandTest {
 
     TestRule rule = TestRule.contentTransformRule(); // replaces "original" with "transformed"
     ConvertCommand command =
-        new ConvertCommand(rule, TreePath.fromXml("catalog/product/description"));
+        ConvertCommand.create(rule, TreePath.fromXml("catalog/product/description"));
 
     TrackingInputStream trackingInputStream =
         new TrackingInputStream(xmlData.getBytes(StandardCharsets.UTF_8));
@@ -245,7 +246,7 @@ public class ConvertCommandTest {
 
     TestRule rule = TestRule.contentTransformRule(); // replaces "original" with "transformed"
     ConvertCommand command =
-        new ConvertCommand(rule, TreePath.fromXml("library/book/content/chapter/text"));
+        ConvertCommand.create(rule, TreePath.fromXml("library/book/content/chapter/text"));
 
     TrackingInputStream trackingInputStream =
         new TrackingInputStream(xmlData.getBytes(StandardCharsets.UTF_8));

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ConvertCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ConvertCommandTest.java
@@ -78,7 +78,7 @@ public class ConvertCommandTest {
   }
 
   @Test
-  @DisplayName("Constructor validation")
+  @DisplayName("Factory method validation")
   public void testConstructorValidation() {
     TestRule rule = TestRule.contentTransformRule();
 


### PR DESCRIPTION
## Summary
- Make `ConvertCommand(IRule, TreePath)` constructor `private`
- Add `ConvertCommand.create(IRule, TreePath)` factory method with null checks
- Update all test usages to use `ConvertCommand.create(...)` instead of `new ConvertCommand(...)`

## Test plan
- [x] All 8 existing `ConvertCommandTest` tests pass with the factory method
- [x] Null validation tests updated to use `ConvertCommand.create(null, ...)`

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)