### PR TITLE
docs(core): document TeeInputStream partial-write risk in ConsumerCommand (#543, #545)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/ConsumerCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/ConsumerCommand.java
@@ -28,8 +28,8 @@ public abstract class ConsumerCommand extends AbstractStreamCommand {
    * Executes the command on the provided input stream and writes the result to the output stream.
    *
    * <p><strong>Note on data integrity:</strong> This method uses {@link TeeInputStream} to copy
-   * input bytes to {@code outputStream} concurrently with {@link #consume(InputStream)}. If {@code
-   * consume()} throws an exception, partial data may already have been written to {@code
+   * input bytes to {@code outputStream} as they are read by {@link #consume(InputStream)}. If
+   * {@code consume()} throws an exception, partial data may already have been written to {@code
    * outputStream}. To prevent this, place a {@link
    * com.streamconverter.command.impl.FileBufferCommand} immediately before this command in the
    * pipeline:
@@ -38,7 +38,7 @@ public abstract class ConsumerCommand extends AbstractStreamCommand {
    * StreamConverter.create(
    *     new MyValidateCommand(),
    *     FileBufferCommand.create(),
-   *     nextStageCommand
+   *     new MyConsumerCommand()  // ConsumerCommand subclass
    * );
    * }</pre>
    *

--- a/streamconverter-core/src/main/java/com/streamconverter/command/ConsumerCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/ConsumerCommand.java
@@ -27,6 +27,21 @@ public abstract class ConsumerCommand extends AbstractStreamCommand {
   /**
    * Executes the command on the provided input stream and writes the result to the output stream.
    *
+   * <p><strong>Note on data integrity:</strong> This method uses {@link TeeInputStream} to copy
+   * input bytes to {@code outputStream} concurrently with {@link #consume(InputStream)}. If {@code
+   * consume()} throws an exception, partial data may already have been written to {@code
+   * outputStream}. To prevent this, place a {@link
+   * com.streamconverter.command.impl.FileBufferCommand} immediately before this command in the
+   * pipeline:
+   *
+   * <pre>{@code
+   * StreamConverter.create(
+   *     new MyValidateCommand(),
+   *     FileBufferCommand.create(),
+   *     nextStageCommand
+   * );
+   * }</pre>
+   *
    * @param inputStream The input stream to read data from.
    * @param outputStream The output stream to write data to.
    * @throws IOException If an I/O error occurs during the execution of the command.


### PR DESCRIPTION
## Summary
- Add Javadoc to `ConsumerCommand.execute()` explaining that `TeeInputStream` copies bytes concurrently with `consume()`, meaning partial data may be written to `outputStream` if `consume()` throws
- Document the recommended mitigation: insert `FileBufferCommand` before the `ConsumerCommand` in the pipeline
- Resolves both issues now that `FileBufferCommand` is implemented (commit `5574f6fd`)

## Test plan
- [x] All existing tests pass (documentation-only change)
- [x] Javadoc compiles cleanly

Closes #543
Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)