### PR TITLE
fix(security): プロジェクト全体コードレビューで発見されたCritical Issuesの修正

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonNavigateCommand.java
@@ -10,7 +10,6 @@ import com.streamconverter.path.TreePath;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -77,8 +76,6 @@ public class JsonNavigateCommand extends AbstractStreamCommand {
       processJsonStreamWithPath(parser, generator);
 
       generator.flush();
-    } catch (com.fasterxml.jackson.core.JsonParseException e) {
-      handleJsonParseException(outputStream, e);
     }
   }
 
@@ -152,12 +149,5 @@ public class JsonNavigateCommand extends AbstractStreamCommand {
     // Use matchesIgnoringArraySyntax so that paths like $.orders[*].product_code
     // correctly match the streaming currentPath ["orders", "product_code"].
     return treePath.matchesIgnoringArraySyntax(currentPath);
-  }
-
-  /** Handle JSON parsing exceptions */
-  private void handleJsonParseException(OutputStream outputStream, Exception e) throws IOException {
-    String errorMessage = String.format("JSON parsing error: %s", e.getMessage());
-    outputStream.write(errorMessage.getBytes(StandardCharsets.UTF_8));
-    outputStream.flush();
   }
 }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/ValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/ValidateCommand.java
@@ -156,20 +156,14 @@ public class ValidateCommand extends ConsumerCommand {
    *
    * @param validator 設定対象のValidator
    */
-  private void configureSecureValidator(Validator validator) {
-    try {
-      // XXE攻撃防止設定
-      validator.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+  private void configureSecureValidator(Validator validator) throws SAXException {
+    // XXE攻撃防止設定（設定失敗はXXE脆弱性のまま継続するため例外をスロー）
+    validator.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 
-      // 外部リソースアクセスを無効化
-      validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-      validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    // 外部リソースアクセスを無効化
+    validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 
-      logger.debug("Secure XML processing features configured for Validator");
-
-    } catch (Exception e) {
-      logger.warn("Could not configure all security features for Validator: {}", e.getMessage());
-      // 警告レベルで記録し、処理は継続
-    }
+    logger.debug("Secure XML processing features configured for Validator");
   }
 }

--- a/streamconverter-core/src/main/java/com/streamconverter/security/SecureXmlConfiguration.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/security/SecureXmlConfiguration.java
@@ -57,7 +57,13 @@ public class SecureXmlConfiguration {
     factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
     // 外部パラメータエンティティを無効化
     factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    // 外部DTDロードを無効化
+    factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
     securityLogger.debug("External entities disabled");
+
+    // JAXP標準の外部リソースアクセス制限
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 
     // 追加のセキュリティ設定
     factory.setNamespaceAware(true);

--- a/streamconverter-core/src/main/java/com/streamconverter/security/SecureXmlConfiguration.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/security/SecureXmlConfiguration.java
@@ -48,24 +48,16 @@ public class SecureXmlConfiguration {
       throws ParserConfigurationException {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
-    // XXE攻撃防止設定
-    try {
-      // DOCTYPE宣言を無効化
-      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-      securityLogger.debug("DOCTYPE declarations disabled");
-    } catch (ParserConfigurationException e) {
-      logger.warn("Failed to disable DOCTYPE declarations", e);
-    }
+    // XXE攻撃防止設定（設定失敗はXXE脆弱性のまま継続するため例外をスロー）
+    // DOCTYPE宣言を無効化
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    securityLogger.debug("DOCTYPE declarations disabled");
 
-    try {
-      // 外部一般エンティティを無効化
-      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-      // 外部パラメータエンティティを無効化
-      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-      securityLogger.debug("External entities disabled");
-    } catch (ParserConfigurationException e) {
-      logger.warn("Failed to disable external entities", e);
-    }
+    // 外部一般エンティティを無効化
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    // 外部パラメータエンティティを無効化
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    securityLogger.debug("External entities disabled");
 
     // 追加のセキュリティ設定
     factory.setNamespaceAware(true);

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonNavigateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonNavigateCommandTest.java
@@ -2,6 +2,7 @@ package com.streamconverter.command.impl.json;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.streamconverter.command.rule.PassThroughRule;
@@ -81,16 +82,13 @@ class JsonNavigateCommandTest {
 
   @Test
   void testInvalidJsonInput() throws IOException {
-    // JsonNavigateCommand writes a descriptive error message to the output stream
-    // rather than throwing an exception (tolerant processing design).
+    // JsonNavigateCommand propagates JsonParseException as IOException for invalid input.
     String invalidJson = "{invalid json}";
     InputStream inputStream =
         new ByteArrayInputStream(invalidJson.getBytes(StandardCharsets.UTF_8));
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-    assertDoesNotThrow(() -> command.execute(inputStream, outputStream));
-    String result = outputStream.toString(StandardCharsets.UTF_8);
-    assertTrue(result.contains("JSON parsing error"), "Invalid input should produce error message");
+    assertThrows(IOException.class, () -> command.execute(inputStream, outputStream));
   }
 
   @Test

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
@@ -1,5 +1,6 @@
 package com.streamconverter.command.rule;
 
+import com.streamconverter.StreamProcessingException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -247,7 +248,8 @@ public class DatabaseFetchRule implements IRule {
       }
     } catch (SQLException e) {
       logger.error("データベース操作中にエラーが発生しました: {}", e.getMessage(), e);
-      return "ERROR: " + e.getMessage();
+      throw new StreamProcessingException(
+          "データベースフェッチに失敗しました: " + e.getMessage(), e);
     }
   }
 }

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
@@ -1,5 +1,6 @@
 package com.streamconverter.command.rule;
 
+import com.streamconverter.StreamProcessingException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -220,7 +221,8 @@ public class PooledDatabaseFetchRule implements IRule {
 
     } catch (SQLException e) {
       logger.error("プール接続でのデータベース操作中にエラーが発生しました: {}", e.getMessage(), e);
-      return "ERROR: " + e.getMessage();
+      throw new StreamProcessingException(
+          "データベースフェッチに失敗しました: " + e.getMessage(), e);
     } finally {
       // リソースのクローズ（接続は自動的にプールに返却される）
       closeResources(resultSet, statement, connection);

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseFetchRuleTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseFetchRuleTest.java
@@ -1,9 +1,12 @@
 package com.streamconverter.command.rule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import com.streamconverter.StreamProcessingException;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -202,11 +205,11 @@ public class DatabaseFetchRuleTest {
       // テスト対象のインスタンスを作成
       DatabaseFetchRule rule = new DatabaseFetchRule(databaseUrl, query);
 
-      // テスト実行
-      String result = rule.apply(input);
-
-      // 結果の検証
-      assertEquals("ERROR: " + errorMessage, result, "SQLエラーが発生した場合はエラーメッセージが返されること");
+      // SQLエラーは StreamProcessingException としてスローされることを検証
+      assertThrows(
+          StreamProcessingException.class,
+          () -> rule.apply(input),
+          "SQLエラーが発生した場合は StreamProcessingException がスローされること");
     }
   }
 

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/PooledDatabaseFetchRuleIntegrationTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/PooledDatabaseFetchRuleIntegrationTest.java
@@ -1,7 +1,10 @@
 package com.streamconverter.command.rule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.streamconverter.StreamProcessingException;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -277,8 +280,10 @@ public class PooledDatabaseFetchRuleIntegrationTest {
     // プールをシャットダウン
     testPool.close();
 
-    // シャットダウン後はエラーになることを確認
-    result = rule.apply("2");
-    assertTrue(result.startsWith("ERROR"), "Should return error after pool shutdown");
+    // シャットダウン後は StreamProcessingException がスローされることを確認
+    assertThrows(
+        StreamProcessingException.class,
+        () -> rule.apply("2"),
+        "Should throw StreamProcessingException after pool shutdown");
   }
 }

--- a/streamconverter-tools/src/main/java/com/streamconverter/analysis/PmdReportConverter.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/analysis/PmdReportConverter.java
@@ -88,8 +88,16 @@ public class PmdReportConverter {
   }
 
   private List<PmdViolation> parseXmlReport(Path xmlPath) throws Exception {
-    DocumentBuilder builder = SecureXmlConfiguration.createSecureDocumentBuilder();
-    Document doc = builder.parse(xmlPath.toFile());
+    try (java.io.InputStream xmlStream = Files.newInputStream(xmlPath)) {
+      return parseXmlReportFromStream(xmlStream);
+    }
+  }
+
+  private List<PmdViolation> parseXmlReportFromStream(java.io.InputStream xmlStream)
+      throws Exception {
+    DocumentBuilder builder =
+        SecureXmlConfiguration.createSecureDocumentBuilderForStream(xmlStream);
+    Document doc = builder.parse(xmlStream);
 
     NodeList fileNodes = doc.getElementsByTagName("file");
     List<PmdViolation> violations = new ArrayList<>();

--- a/streamconverter-tools/src/main/java/com/streamconverter/analysis/PmdReportConverter.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/analysis/PmdReportConverter.java
@@ -1,5 +1,6 @@
 package com.streamconverter.analysis;
 
+import com.streamconverter.security.SecureXmlConfiguration;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -7,7 +8,6 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -88,7 +88,7 @@ public class PmdReportConverter {
   }
 
   private List<PmdViolation> parseXmlReport(Path xmlPath) throws Exception {
-    DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+    DocumentBuilder builder = SecureXmlConfiguration.createSecureDocumentBuilder();
     Document doc = builder.parse(xmlPath.toFile());
 
     NodeList fileNodes = doc.getElementsByTagName("file");

--- a/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToCsvCommand.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToCsvCommand.java
@@ -81,7 +81,10 @@ public class PmdXmlToCsvCommand extends AbstractStreamCommand {
    * @throws Exception XML解析エラーの場合
    */
   private List<PmdViolation> parseXmlStream(InputStream input) throws Exception {
-    DocumentBuilder builder = SecureXmlConfiguration.createSecureDocumentBuilder();
+    if (input == null) {
+      throw new IllegalArgumentException("PMD XML input stream must not be null");
+    }
+    DocumentBuilder builder = SecureXmlConfiguration.createSecureDocumentBuilderForStream(input);
     Document doc = builder.parse(input);
 
     NodeList fileNodes = doc.getElementsByTagName("file");

--- a/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToCsvCommand.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToCsvCommand.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.streamconverter.command.AbstractStreamCommand;
 import com.streamconverter.command.impl.analysis.PmdXmlToMarkdownCommand.PmdViolation;
+import com.streamconverter.security.SecureXmlConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.*;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -81,7 +81,7 @@ public class PmdXmlToCsvCommand extends AbstractStreamCommand {
    * @throws Exception XML解析エラーの場合
    */
   private List<PmdViolation> parseXmlStream(InputStream input) throws Exception {
-    DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+    DocumentBuilder builder = SecureXmlConfiguration.createSecureDocumentBuilder();
     Document doc = builder.parse(input);
 
     NodeList fileNodes = doc.getElementsByTagName("file");

--- a/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToJsonCommand.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToJsonCommand.java
@@ -113,7 +113,7 @@ public class PmdXmlToJsonCommand extends AbstractStreamCommand {
 
   /** PMD XML ストリームからバイオレーション情報を解析 */
   private List<PmdViolation> parseXmlStream(InputStream input) throws Exception {
-    DocumentBuilder builder = SecureXmlConfiguration.createSecureDocumentBuilder();
+    DocumentBuilder builder = SecureXmlConfiguration.createSecureDocumentBuilderForStream(input);
     Document doc = builder.parse(input);
 
     NodeList fileNodes = doc.getElementsByTagName("file");

--- a/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToJsonCommand.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToJsonCommand.java
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.streamconverter.command.AbstractStreamCommand;
 import com.streamconverter.command.impl.analysis.PmdXmlToMarkdownCommand.PmdViolation;
+import com.streamconverter.security.SecureXmlConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.time.Instant;
 import java.util.*;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -113,7 +113,7 @@ public class PmdXmlToJsonCommand extends AbstractStreamCommand {
 
   /** PMD XML ストリームからバイオレーション情報を解析 */
   private List<PmdViolation> parseXmlStream(InputStream input) throws Exception {
-    DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+    DocumentBuilder builder = SecureXmlConfiguration.createSecureDocumentBuilder();
     Document doc = builder.parse(input);
 
     NodeList fileNodes = doc.getElementsByTagName("file");

--- a/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToMarkdownCommand.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToMarkdownCommand.java
@@ -70,7 +70,7 @@ public class PmdXmlToMarkdownCommand extends AbstractStreamCommand {
    * @throws Exception XML解析エラーの場合
    */
   private List<PmdViolation> parseXmlStream(InputStream input) throws Exception {
-    DocumentBuilder builder = SecureXmlConfiguration.createSecureDocumentBuilder();
+    DocumentBuilder builder = SecureXmlConfiguration.createSecureDocumentBuilderForStream(input);
     Document doc = builder.parse(input);
 
     NodeList fileNodes = doc.getElementsByTagName("file");

--- a/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToMarkdownCommand.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/command/impl/analysis/PmdXmlToMarkdownCommand.java
@@ -1,6 +1,7 @@
 package com.streamconverter.command.impl.analysis;
 
 import com.streamconverter.command.AbstractStreamCommand;
+import com.streamconverter.security.SecureXmlConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -8,7 +9,6 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -70,7 +70,7 @@ public class PmdXmlToMarkdownCommand extends AbstractStreamCommand {
    * @throws Exception XML解析エラーの場合
    */
   private List<PmdViolation> parseXmlStream(InputStream input) throws Exception {
-    DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+    DocumentBuilder builder = SecureXmlConfiguration.createSecureDocumentBuilder();
     Document doc = builder.parse(input);
 
     NodeList fileNodes = doc.getElementsByTagName("file");


### PR DESCRIPTION
## 解決した課題

プロジェクト全体のコードレビューにより発見されたセキュリティ上のCritical Issuesを修正します。

### 背景と問題の概要

今回の修正は、以下の2種類のセキュリティリスクに対応するものです。

#### 1. エラー文字列のデータ汚染（Data Contamination）

`DatabaseFetchRule` および `PooledDatabaseFetchRule` は、SQLエラー発生時に `"ERROR: ..."` という文字列をストリームの出力として返却していました。このパターンでは、エラー文字列が後続のコマンドにデータとして混入し、意図しない処理が行われる危険性がありました。

同様に、`JsonNavigateCommand` でも無効なJSONが入力された際に、エラーメッセージを `outputStream` に書き込む処理が存在しており、不正なデータが後続パイプラインに流れ込む可能性がありました。

#### 2. XXE（XML External Entity）攻撃防止設定の実質的な無効化

`SecureXmlConfiguration` および `ValidateCommand` において、XXE防止のための設定処理が `try-catch` ブロックで囲まれ、設定失敗時に例外が握りつぶされていました。これにより、XXE攻撃防止設定が失敗しても処理が続行され、XXE攻撃に対して脆弱な状態でXML処理が行われる可能性がありました。

また、`PmdXmlToMarkdownCommand`、`PmdXmlToCsvCommand`、`PmdXmlToJsonCommand`、`PmdReportConverter` では `DocumentBuilderFactory.newInstance()` を直接呼び出しており、既存の `SecureXmlConfiguration.createSecureDocumentBuilder()` が提供するXXE対策が適用されていませんでした。

---

## 解決方法

### 1. エラー文字列返却 → 例外スローへの変更

**対象ファイル:**
- `streamconverter-core/.../rule/DatabaseFetchRule.java`
- `streamconverter-core/.../rule/PooledDatabaseFetchRule.java`

SQLエラー発生時に `"ERROR: ..."` 文字列を返却する処理を削除し、`StreamProcessingException` をスローするように変更しました。これにより、エラーが明示的に伝播し、後続パイプラインへのデータ汚染を防ぎます。

**対象ファイル:**
- `streamconverter-core/.../impl/json/JsonNavigateCommand.java`

無効なJSONをエラーメッセージとして `outputStream` に書き込む処理を削除し、`JsonParseException` を `IOException` としてそのまま伝播させるように変更しました。

### 2. XXE防止設定の確実な適用

**対象ファイル:**
- `streamconverter-core/.../security/SecureXmlConfiguration.java`
- `streamconverter-core/.../impl/xml/ValidateCommand.java`

XXE防止設定処理を囲む `try-catch` を削除し、設定失敗時は例外をスローして処理を中断するように変更しました。「設定が失敗した場合は安全側に倒す（fail-safe）」という設計原則に従います。

**対象ファイル:**
- `streamconverter-tools/.../analysis/PmdXmlToMarkdownCommand.java`
- `streamconverter-tools/.../analysis/PmdXmlToCsvCommand.java`
- `streamconverter-tools/.../analysis/PmdXmlToJsonCommand.java`
- `streamconverter-tools/.../analysis/PmdReportConverter.java`

`DocumentBuilderFactory.newInstance()` の直接呼び出しを `SecureXmlConfiguration.createSecureDocumentBuilder()` に置換し、既存のXXE対策を確実に適用するように変更しました。

### トレードオフの考慮

エラー時に例外をスローする変更は、既存の挙動（エラー文字列の返却）からの破壊的変更を伴います。しかし、エラー状態を無音で継続することはセキュリティ上のリスクが高く、明示的なエラーハンドリングを優先する判断をしました。

---

## テスト

全テストを実行し、`BUILD SUCCESSFUL` を確認済みです。

### 変更したテストファイル

- `JsonNavigateCommandTest.java` — `JsonParseException` が `IOException` として伝播することを検証するように修正
- `DatabaseFetchRuleTest.java` — `StreamProcessingException` がスローされることを検証するように修正
- `PooledDatabaseFetchRuleIntegrationTest.java` — 同上

---

## その他

### 破壊的変更

- `DatabaseFetchRule` および `PooledDatabaseFetchRule` のエラー時の戻り値がなくなり、`StreamProcessingException` がスローされます。呼び出し元でのエラーハンドリングが必要です。
- `JsonNavigateCommand` で無効なJSONを入力した場合、エラー文字列の代わりに `IOException` がスローされます。

### 関連するセキュリティガイドライン

本修正は `docs/reference/SECURITY_ANALYSIS.md` に記載されたXXE防止設計および入力サニタイズ方針に準拠しています。

---

## レビュー依頼

@codex この解決方法は、課題に対してクリティカルな解法でしょうか？

特に以下の点についてご確認をお願いいたします：

1. **データ汚染防止**: エラー文字列をストリームに流さず例外をスローするアプローチは、この問題に対して最も効果的な対処法でしょうか？
2. **XXE防止のfail-safe設計**: `try-catch` を削除して設定失敗時に例外をスローする方針は、セキュリティの観点から適切でしょうか？
3. **`DocumentBuilderFactory` の置換**: 既存の `SecureXmlConfiguration.createSecureDocumentBuilder()` を再利用するアプローチは、XXE対策として十分でしょうか？

ご確認のほど、よろしくお願いいたします。