### PR TITLE
refactor(core,db): remove unused interface and deduplicate SQL utils

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
@@ -166,11 +166,6 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
     throw new IOException("Invalid XML format", e);
   }
 
-  @FunctionalInterface
-  private interface CharacterDataProcessor {
-    String process(XMLEvent event, String data);
-  }
-
   private void closeResources(XMLEventReader eventReader, XMLEventWriter eventWriter) {
     if (eventReader != null) {
       try {

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
@@ -197,6 +197,12 @@ public class DatabaseFetchRule implements IRule {
       }
     } catch (SQLException e) {
       logger.error("データベース操作中にエラーが発生しました: {}", e.getMessage(), e);
+      Throwable[] suppressed = e.getSuppressed();
+      if (suppressed != null) {
+        for (Throwable s : suppressed) {
+          logger.error("クローズ中に追加のエラーが発生しました: {}", s.getMessage(), s);
+        }
+      }
       throw new StreamProcessingException(
           "データベースフェッチに失敗しました: " + e.getMessage(), e);
     }

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
@@ -44,12 +44,6 @@ import org.slf4j.LoggerFactory;
 public class DatabaseFetchRule implements IRule {
   private static final Logger logger = LoggerFactory.getLogger(DatabaseFetchRule.class);
 
-  /** SQLインジェクション攻撃を検出するパターン（SELECT以外の危険なSQL文） */
-  private static final Pattern SQL_INJECTION_PATTERN =
-      Pattern.compile(
-          "(?i).*(union|insert|update|delete|drop|create|alter|exec|execute|sp_|xp_).*",
-          Pattern.CASE_INSENSITIVE);
-
   /** 許可されるデータベースURLスキーマ（テスト用のmockも含む） */
   private static final Pattern ALLOWED_DB_SCHEME_PATTERN =
       Pattern.compile(
@@ -120,56 +114,11 @@ public class DatabaseFetchRule implements IRule {
    * @throws SecurityException SQLインジェクションが検出された場合
    */
   private String validateQuery(String queryString) {
-    if (queryString.isEmpty()) {
-      throw new IllegalArgumentException("Query cannot be empty");
-    }
-
-    // SELECTクエリのみ許可
-    if (!queryString.trim().toLowerCase().startsWith("select")) {
-      throw new SecurityException("Only SELECT queries are allowed: " + queryString);
-    }
-
-    // SQLインジェクション攻撃の検出（パターンマッチング使用）
-    if (SQL_INJECTION_PATTERN.matcher(queryString).matches()) {
-      throw new SecurityException(
-          "Query contains potentially dangerous SQL commands: " + queryString);
-    }
-
-    // セミコロンによる複数文の実行を防止
-    if (queryString.contains(";") && !queryString.trim().endsWith(";")) {
-      throw new SecurityException("Multiple SQL statements are not allowed: " + queryString);
-    }
-
-    logger.debug("Query validation passed, length: {}", queryString.length());
-    return queryString;
+    return SqlQueryUtils.validateQuery(queryString, logger);
   }
 
-  /**
-   * 入力パラメータをサニタイズします
-   *
-   * @param input サニタイズ対象の入力
-   * @return サニタイズされた入力
-   */
   private String sanitizeInput(String input) {
-    if (input == null) {
-      throw new IllegalArgumentException("Input parameter cannot be null");
-    }
-
-    // 危険な文字の除去/エスケープ
-    String sanitized =
-        input
-            .replace("'", "''") // シングルクォートのエスケープ
-            .replace("--", "") // SQLコメントの除去
-            .replace("/*", "") // ブロックコメント開始の除去
-            .replace("*/", ""); // ブロックコメント終了の除去
-
-    // 極端に長い入力の制限
-    if (sanitized.length() > 1000) {
-      logger.warn("Input parameter is extremely long, truncating: length={}", sanitized.length());
-      sanitized = sanitized.substring(0, 1000);
-    }
-
-    return sanitized;
+    return SqlQueryUtils.sanitizeInput(input, logger);
   }
 
   /**

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
@@ -7,7 +7,6 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Objects;
-import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,12 +49,6 @@ import org.slf4j.LoggerFactory;
 public class PooledDatabaseFetchRule implements IRule {
   private static final Logger logger = LoggerFactory.getLogger(PooledDatabaseFetchRule.class);
 
-  /** SQLインジェクション攻撃を検出するパターン（SELECT以外の危険なSQL文） */
-  private static final Pattern SQL_INJECTION_PATTERN =
-      Pattern.compile(
-          "(?i).*(union|insert|update|delete|drop|create|alter|exec|execute|sp_|xp_).*",
-          Pattern.CASE_INSENSITIVE);
-
   private final HikariConnectionPoolConfig connectionPool;
   private final String query;
 
@@ -88,57 +81,11 @@ public class PooledDatabaseFetchRule implements IRule {
    * @throws SecurityException SQLインジェクションが検出された場合
    */
   private String validateQuery(String queryString) {
-    if (queryString.isEmpty()) {
-      throw new IllegalArgumentException("Query cannot be empty");
-    }
-
-    // SELECTクエリのみ許可
-    if (!queryString.trim().toLowerCase().startsWith("select")) {
-      throw new SecurityException("Only SELECT queries are allowed: " + queryString);
-    }
-
-    // SQLインジェクション攻撃の検出
-    if (SQL_INJECTION_PATTERN.matcher(queryString).matches()) {
-      throw new SecurityException(
-          "Query contains potentially dangerous SQL commands: " + queryString);
-    }
-
-    // セミコロンによる複数文の実行を防止
-    if (queryString.contains(";") && !queryString.trim().endsWith(";")) {
-      throw new SecurityException("Multiple SQL statements are not allowed: " + queryString);
-    }
-
-    logger.debug("Query validation passed, length: {}", queryString.length());
-    return queryString;
+    return SqlQueryUtils.validateQuery(queryString, logger);
   }
 
-  /**
-   * 入力パラメータをサニタイズします
-   *
-   * @param input サニタイズ対象の入力
-   * @return サニタイズされた入力（非null）
-   * @throws IllegalArgumentException inputがnullの場合
-   */
   private String sanitizeInput(String input) {
-    if (input == null) {
-      throw new IllegalArgumentException("Input parameter cannot be null");
-    }
-
-    // 危険な文字の除去/エスケープ
-    String sanitized =
-        input
-            .replace("'", "''") // シングルクォートのエスケープ
-            .replace("--", "") // SQLコメントの除去
-            .replace("/*", "") // ブロックコメント開始の除去
-            .replace("*/", ""); // ブロックコメント終了の除去
-
-    // 極端に長い入力の制限
-    if (sanitized.length() > 1000) {
-      logger.warn("Input parameter is extremely long, truncating: length={}", sanitized.length());
-      sanitized = sanitized.substring(0, 1000);
-    }
-
-    return sanitized;
+    return SqlQueryUtils.sanitizeInput(input, logger);
   }
 
   /**
@@ -153,17 +100,9 @@ public class PooledDatabaseFetchRule implements IRule {
    */
   @Override
   public String apply(String input) {
-    Connection connection = null;
-    PreparedStatement statement = null;
-    ResultSet resultSet = null;
-
-    try {
-      // プールから接続を取得
-      logger.debug("Getting connection from pool: {}", connectionPool.getPoolStats());
-      connection = connectionPool.getConnection();
-
-      // クエリの準備
-      statement = connection.prepareStatement(query);
+    logger.debug("Getting connection from pool: {}", connectionPool.getPoolStats());
+    try (Connection connection = connectionPool.getConnection();
+        PreparedStatement statement = connection.prepareStatement(query)) {
 
       // 入力文字列をパラメータとして設定（クエリに「?」プレースホルダーがある場合）
       if (query.contains("?") && input != null && !input.isEmpty()) {
@@ -181,88 +120,51 @@ public class PooledDatabaseFetchRule implements IRule {
 
       // クエリ実行
       logger.debug("Executing query with pooled connection: {}", query);
-      resultSet = statement.executeQuery();
+      try (ResultSet resultSet = statement.executeQuery()) {
+        // 結果の検証と処理
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        int columnCount = metaData.getColumnCount();
 
-      // 結果の検証と処理
-      ResultSetMetaData metaData = resultSet.getMetaData();
-      int columnCount = metaData.getColumnCount();
+        // 結果がない場合
+        if (!resultSet.next()) {
+          logger.warn("クエリ結果が空です。");
+          return "";
+        }
 
-      // 結果がない場合
-      if (!resultSet.next()) {
-        logger.warn("クエリ結果が空です。");
-        return "";
+        // 列数の検証
+        if (columnCount != 1) {
+          logger.warn("クエリ結果が一列ではありません。列数: {}。先頭列の値を使用します。", columnCount);
+        }
+
+        // 先頭行の先頭列の値を取得
+        String value = resultSet.getString(1);
+
+        // 追加の行があるかチェック
+        boolean hasMoreRows = resultSet.next();
+        if (hasMoreRows) {
+          logger.warn("クエリ結果が複数行あります。先頭行の値を使用します。");
+        }
+
+        // nullチェック
+        if (value == null) {
+          logger.info("クエリ結果の先頭値がNULLです。");
+          return "";
+        }
+
+        // 結果が理想的（1行1列）かどうかをログに記録
+        if (columnCount == 1 && !hasMoreRows) {
+          logger.debug("データベースから単一値を取得しました（プール使用）: {}", value);
+        } else {
+          logger.debug("データベースから先頭値を取得しました（プール使用）: {}", value);
+        }
+
+        return value;
       }
-
-      // 列数の検証
-      if (columnCount != 1) {
-        logger.warn("クエリ結果が一列ではありません。列数: {}。先頭列の値を使用します。", columnCount);
-      }
-
-      // 先頭行の先頭列の値を取得
-      String value = resultSet.getString(1);
-
-      // 追加の行があるかチェック
-      boolean hasMoreRows = resultSet.next();
-      if (hasMoreRows) {
-        logger.warn("クエリ結果が複数行あります。先頭行の値を使用します。");
-      }
-
-      // nullチェック
-      if (value == null) {
-        logger.info("クエリ結果の先頭値がNULLです。");
-        return "";
-      }
-
-      // 結果が理想的（1行1列）かどうかをログに記録
-      if (columnCount == 1 && !hasMoreRows) {
-        logger.debug("データベースから単一値を取得しました（プール使用）: {}", value);
-      } else {
-        logger.debug("データベースから先頭値を取得しました（プール使用）: {}", value);
-      }
-
-      return value;
 
     } catch (SQLException e) {
       logger.error("プール接続でのデータベース操作中にエラーが発生しました: {}", e.getMessage(), e);
       throw new StreamProcessingException(
           "データベースフェッチに失敗しました: " + e.getMessage(), e);
-    } finally {
-      // リソースのクローズ（接続は自動的にプールに返却される）
-      closeResources(resultSet, statement, connection);
-    }
-  }
-
-  /**
-   * データベースリソースを安全にクローズします。 接続はプールに自動的に返却されます。
-   *
-   * @param resultSet 結果セット
-   * @param statement プリペアドステートメント
-   * @param connection データベース接続（プールに返却される）
-   */
-  private void closeResources(
-      ResultSet resultSet, PreparedStatement statement, Connection connection) {
-    if (resultSet != null) {
-      try {
-        resultSet.close();
-      } catch (SQLException e) {
-        logger.warn("ResultSetのクローズ中にエラーが発生しました: {}", e.getMessage());
-      }
-    }
-
-    if (statement != null) {
-      try {
-        statement.close();
-      } catch (SQLException e) {
-        logger.warn("PreparedStatementのクローズ中にエラーが発生しました: {}", e.getMessage());
-      }
-    }
-
-    if (connection != null) {
-      try {
-        connection.close(); // プールに返却される
-      } catch (SQLException e) {
-        logger.warn("Connection（プール返却）中にエラーが発生しました: {}", e.getMessage());
-      }
     }
   }
 

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
@@ -163,6 +163,12 @@ public class PooledDatabaseFetchRule implements IRule {
 
     } catch (SQLException e) {
       logger.error("プール接続でのデータベース操作中にエラーが発生しました: {}", e.getMessage(), e);
+      Throwable[] suppressed = e.getSuppressed();
+      if (suppressed != null) {
+        for (Throwable s : suppressed) {
+          logger.error("クローズ中に追加のエラーが発生しました: {}", s.getMessage(), s);
+        }
+      }
       throw new StreamProcessingException(
           "データベースフェッチに失敗しました: " + e.getMessage(), e);
     }

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/SqlQueryUtils.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/SqlQueryUtils.java
@@ -12,9 +12,9 @@ import org.slf4j.Logger;
 final class SqlQueryUtils {
 
   /** SQLインジェクション攻撃を検出するパターン（SELECT以外の危険なSQL文） */
-  static final Pattern SQL_INJECTION_PATTERN =
+  private static final Pattern SQL_INJECTION_PATTERN =
       Pattern.compile(
-          "(?i).*(union|insert|update|delete|drop|create|alter|exec|execute|sp_|xp_).*",
+          ".*(union|insert|update|delete|drop|create|alter|exec|execute|sp_|xp_).*",
           Pattern.CASE_INSENSITIVE);
 
   private SqlQueryUtils() {}
@@ -44,8 +44,10 @@ final class SqlQueryUtils {
           "Query contains potentially dangerous SQL commands: " + queryString);
     }
 
-    // セミコロンによる複数文の実行を防止
-    if (queryString.contains(";") && !queryString.trim().endsWith(";")) {
+    // セミコロンによる複数文の実行を防止（末尾の1個のみ許可）
+    String stripped = queryString.trim();
+    String withoutTrailingSemicolon = stripped.endsWith(";") ? stripped.substring(0, stripped.length() - 1) : stripped;
+    if (withoutTrailingSemicolon.contains(";")) {
       throw new SecurityException("Multiple SQL statements are not allowed: " + queryString);
     }
 
@@ -66,10 +68,10 @@ final class SqlQueryUtils {
       throw new IllegalArgumentException("Input parameter cannot be null");
     }
 
-    // 危険な文字の除去/エスケープ
+    // PreparedStatement がパラメータバインディングを担うため、シングルクォートエスケープは行わない。
+    // ここでは PreparedStatement を通じないコンテキスト向けに残存する危険パターンのみ除去する。
     String sanitized =
         input
-            .replace("'", "''") // シングルクォートのエスケープ
             .replace("--", "") // SQLコメントの除去
             .replace("/*", "") // ブロックコメント開始の除去
             .replace("*/", ""); // ブロックコメント終了の除去

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/SqlQueryUtils.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/SqlQueryUtils.java
@@ -1,5 +1,6 @@
 package com.streamconverter.command.rule;
 
+import java.util.Locale;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 
@@ -34,7 +35,7 @@ final class SqlQueryUtils {
     }
 
     // SELECTクエリのみ許可
-    if (!queryString.trim().toLowerCase().startsWith("select")) {
+    if (!queryString.trim().toLowerCase(Locale.ROOT).startsWith("select")) {
       throw new SecurityException("Only SELECT queries are allowed: " + queryString);
     }
 

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/SqlQueryUtils.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/SqlQueryUtils.java
@@ -1,0 +1,85 @@
+package com.streamconverter.command.rule;
+
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+
+/**
+ * SQLクエリの検証・サニタイズユーティリティ。
+ *
+ * <p>{@link DatabaseFetchRule} と {@link PooledDatabaseFetchRule} で共有される
+ * ロジックを提供します。
+ */
+final class SqlQueryUtils {
+
+  /** SQLインジェクション攻撃を検出するパターン（SELECT以外の危険なSQL文） */
+  static final Pattern SQL_INJECTION_PATTERN =
+      Pattern.compile(
+          "(?i).*(union|insert|update|delete|drop|create|alter|exec|execute|sp_|xp_).*",
+          Pattern.CASE_INSENSITIVE);
+
+  private SqlQueryUtils() {}
+
+  /**
+   * SELECTクエリの妥当性を検証します。
+   *
+   * @param queryString 検証対象のクエリ
+   * @param logger ロガー
+   * @return 検証済みクエリ
+   * @throws IllegalArgumentException クエリが空の場合
+   * @throws SecurityException 危険なクエリパターンが検出された場合
+   */
+  static String validateQuery(String queryString, Logger logger) {
+    if (queryString.isEmpty()) {
+      throw new IllegalArgumentException("Query cannot be empty");
+    }
+
+    // SELECTクエリのみ許可
+    if (!queryString.trim().toLowerCase().startsWith("select")) {
+      throw new SecurityException("Only SELECT queries are allowed: " + queryString);
+    }
+
+    // SQLインジェクション攻撃の検出（パターンマッチング使用）
+    if (SQL_INJECTION_PATTERN.matcher(queryString).matches()) {
+      throw new SecurityException(
+          "Query contains potentially dangerous SQL commands: " + queryString);
+    }
+
+    // セミコロンによる複数文の実行を防止
+    if (queryString.contains(";") && !queryString.trim().endsWith(";")) {
+      throw new SecurityException("Multiple SQL statements are not allowed: " + queryString);
+    }
+
+    logger.debug("Query validation passed, length: {}", queryString.length());
+    return queryString;
+  }
+
+  /**
+   * 入力パラメータをサニタイズします。
+   *
+   * @param input サニタイズ対象の入力
+   * @param logger ロガー
+   * @return サニタイズされた入力（非null）
+   * @throws IllegalArgumentException inputがnullの場合
+   */
+  static String sanitizeInput(String input, Logger logger) {
+    if (input == null) {
+      throw new IllegalArgumentException("Input parameter cannot be null");
+    }
+
+    // 危険な文字の除去/エスケープ
+    String sanitized =
+        input
+            .replace("'", "''") // シングルクォートのエスケープ
+            .replace("--", "") // SQLコメントの除去
+            .replace("/*", "") // ブロックコメント開始の除去
+            .replace("*/", ""); // ブロックコメント終了の除去
+
+    // 極端に長い入力の制限
+    if (sanitized.length() > 1000) {
+      logger.warn("Input parameter is extremely long, truncating: length={}", sanitized.length());
+      sanitized = sanitized.substring(0, 1000);
+    }
+
+    return sanitized;
+  }
+}


### PR DESCRIPTION
## 対応した課題

プロジェクト全体コードレビューで発見された **Suggestion #7・#8・#9** をまとめて対処します。

## 変更内容

### Suggestion #7: `XmlNavigateCommand` の未使用インターフェース削除

`CharacterDataProcessor` は定義のみで使用箇所が皆無だったため削除しました。

### Suggestion #8: `DatabaseFetchRule` / `PooledDatabaseFetchRule` のコード重複解消

`validateQuery()` と `sanitizeInput()` が2クラスで完全に重複していました。
`SqlQueryUtils`（package-private）に抽出し、両クラスから委譲するよう変更しました（約60行削減）。

### Suggestion #9: `PooledDatabaseFetchRule.closeResources()` の try-with-resources 化

手動 null チェック + `finally` ブロック + `closeResources()` メソッドを
`Connection`・`PreparedStatement`・`ResultSet` の try-with-resources に置き換えました。
リソースは宣言の逆順に自動クローズされ、クローズ失敗の例外も適切に処理されます。

## テスト

- 既存の全テスト: PASS

## 破壊的変更

なし。
