### PR TITLE
docs: clarify silent error handling and add missing Javadoc across core modules

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
@@ -218,7 +218,10 @@ public class StreamConverter {
                       try {
                         commandOutput.close();
                       } catch (IOException ignored) {
-                        // ignored
+                        // PipedOutputStream.close() may fail if the reader side has already closed
+                        // (or the pipe is broken for other reasons — see isPipedStreamIOException).
+                        // The command has already finished (exceptionally), so this secondary
+                        // failure is safe to ignore.
                       }
                     }
                     // Already a StreamProcessingException — re-throw as-is to avoid double-wrapping
@@ -228,7 +231,10 @@ public class StreamConverter {
                       try {
                         commandOutput.close();
                       } catch (IOException ignored) {
-                        // ignored
+                        // PipedOutputStream.close() may fail if the reader side has already closed
+                        // (or the pipe is broken for other reasons — see isPipedStreamIOException).
+                        // The command has already finished (exceptionally), so this secondary
+                        // failure is safe to ignore.
                       }
                     }
                     throw new StreamProcessingException(
@@ -238,7 +244,10 @@ public class StreamConverter {
                       try {
                         commandOutput.close();
                       } catch (IOException ignored) {
-                        // ignored
+                        // PipedOutputStream.close() may fail if the reader side has already closed
+                        // (or the pipe is broken for other reasons — see isPipedStreamIOException).
+                        // The command has already finished (exceptionally), so this secondary
+                        // failure is safe to ignore.
                       }
                     }
                     throw e;

--- a/streamconverter-core/src/main/java/com/streamconverter/logging/InheritableMDCAdapter.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/logging/InheritableMDCAdapter.java
@@ -17,6 +17,12 @@ import org.slf4j.spi.MDCAdapter;
  *
  * <p>Use {@link MDCInitializer#initialize()} at application startup (before the first log call) to
  * install this adapter.
+ *
+ * <p><b>Thread safety:</b> Each thread holds its own independent copy of the context map via {@link
+ * InheritableThreadLocal}. Child threads receive a shallow copy (snapshot) of the parent's map at
+ * creation time; subsequent changes in the parent are not reflected in already-running children,
+ * and vice versa. Individual per-thread maps are not synchronized, which is safe as long as each
+ * map is accessed only by its owning thread — which is the normal MDC usage pattern.
  */
 public class InheritableMDCAdapter implements MDCAdapter {
 
@@ -44,6 +50,16 @@ public class InheritableMDCAdapter implements MDCAdapter {
         }
       };
 
+  /**
+   * 現在のスレッドのMDCコンテキストにキーと値を設定する。
+   *
+   * <p>このメソッド呼び出し後に起動された子スレッドは、このエントリを自動継承する （{@link InheritableThreadLocal}
+   * による）。ただし、既に起動済みの子スレッドには反映されない。
+   *
+   * @param key MDCキー名。nullの場合は {@link IllegalArgumentException} をスロー
+   * @param val 設定する値
+   * @throws IllegalArgumentException keyがnullの場合
+   */
   @Override
   public void put(String key, String val) {
     if (key == null) throw new IllegalArgumentException("key cannot be null");
@@ -55,12 +71,26 @@ public class InheritableMDCAdapter implements MDCAdapter {
     map.put(key, val);
   }
 
+  /**
+   * 現在のスレッドのMDCコンテキストから指定キーの値を取得する。
+   *
+   * @param key MDCキー名
+   * @return 設定されている値。キーが存在しないかkeyがnullの場合はnull
+   */
   @Override
   public String get(String key) {
     Map<String, String> map = tlm.get();
     return (map != null && key != null) ? map.get(key) : null;
   }
 
+  /**
+   * 現在のスレッドのMDCコンテキストから指定キーを削除する。
+   *
+   * <p>削除後にコンテキストが空になった場合は {@link InheritableThreadLocal} 自体を解放する。 Dequeスタック（{@link
+   * #pushByKey}/{@link #popByKey}）には影響しない。 Dequeを含む全エントリのクリアには {@link #clear()} を使用すること。
+   *
+   * @param key 削除するMDCキー名
+   */
   @Override
   public void remove(String key) {
     Map<String, String> map = tlm.get();
@@ -72,18 +102,38 @@ public class InheritableMDCAdapter implements MDCAdapter {
     }
   }
 
+  /**
+   * 現在のスレッドのMDCコンテキスト（マップおよびDeque）をすべてクリアする。
+   *
+   * <p>{@link InheritableThreadLocal} のエントリを解放するため、このメソッド呼び出し後に 生成される子スレッドにはコンテキストが継承されない。
+   * なお、既に起動済みの子スレッドが保持するコピーには影響しない。
+   */
   @Override
   public void clear() {
     tlm.remove();
     tlmDeque.remove();
   }
 
+  /**
+   * 現在のスレッドのMDCコンテキストのコピーを返す。
+   *
+   * <p>返されたマップはスナップショットであり、以降の変更は反映されない。
+   *
+   * @return MDCコンテキストのコピー。コンテキストが未設定の場合はnull
+   */
   @Override
   public Map<String, String> getCopyOfContextMap() {
     Map<String, String> map = tlm.get();
     return (map != null) ? new HashMap<>(map) : null;
   }
 
+  /**
+   * 現在のスレッドのMDCコンテキストを指定されたマップで置き換える。
+   *
+   * <p>nullを渡すとコンテキストをクリアする。子スレッドへの継承も更新後の内容になる。
+   *
+   * @param contextMap 新しいMDCコンテキスト。nullの場合はクリア
+   */
   @Override
   public void setContextMap(Map<String, String> contextMap) {
     if (contextMap == null) {
@@ -93,6 +143,14 @@ public class InheritableMDCAdapter implements MDCAdapter {
     }
   }
 
+  /**
+   * 指定キーのDequeスタックに値をプッシュする。
+   *
+   * <p>keyがnullの場合は何もしない。
+   *
+   * @param key Dequeのキー名
+   * @param value プッシュする値
+   */
   @Override
   public void pushByKey(String key, String value) {
     if (key == null) return;
@@ -104,6 +162,14 @@ public class InheritableMDCAdapter implements MDCAdapter {
     map.computeIfAbsent(key, k -> new ArrayDeque<>()).push(value);
   }
 
+  /**
+   * 指定キーのDequeスタックから先頭の値をポップして返す。
+   *
+   * <p>keyがnullまたはDequeが存在しない場合はnullを返す。
+   *
+   * @param key Dequeのキー名
+   * @return ポップした値。キーが存在しないかkeyがnullの場合はnull
+   */
   @Override
   public String popByKey(String key) {
     if (key == null) return null;
@@ -113,6 +179,14 @@ public class InheritableMDCAdapter implements MDCAdapter {
     return (deque != null) ? deque.pop() : null;
   }
 
+  /**
+   * 指定キーのDequeのコピーを返す。
+   *
+   * <p>返されたDequeはスナップショットであり、以降の変更は反映されない。
+   *
+   * @param key Dequeのキー名
+   * @return Dequeのコピー。キーが存在しない場合はnull
+   */
   @Override
   public Deque<String> getCopyOfDequeByKey(String key) {
     Map<String, Deque<String>> map = tlmDeque.get();
@@ -121,6 +195,13 @@ public class InheritableMDCAdapter implements MDCAdapter {
     return (deque != null) ? new ArrayDeque<>(deque) : null;
   }
 
+  /**
+   * 指定キーのDequeの全要素をクリアする。
+   *
+   * <p>keyがnullまたはDequeが存在しない場合は何もしない。
+   *
+   * @param key クリアするDequeのキー名
+   */
   @Override
   public void clearDequeByKey(String key) {
     if (key == null) return;

--- a/streamconverter-core/src/main/java/com/streamconverter/logging/PipelineContextTurboFilter.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/logging/PipelineContextTurboFilter.java
@@ -21,6 +21,23 @@ import org.slf4j.Marker;
  */
 public class PipelineContextTurboFilter extends TurboFilter {
 
+  /**
+   * ログイベント発生直前に {@link PipelineContext#syncToMDC()} を呼び出し、 パイプライン共有値を呼び出しスレッドのMDCへ反映する。
+   *
+   * <p>フィルタリングは行わず、常に {@link FilterReply#NEUTRAL} を返す。
+   *
+   * <p>このフィルタはログを発生させたスレッドと同一スレッドで実行されるため、 {@link PipelineContext#syncToMDC()}
+   * によりそのスレッドのMDCのみが更新される。 これは {@link PipelineContext} が {@link ThreadLocal} ベースであるための前提条件であり、
+   * TurboFilter の仕様（ログ発生スレッドでの同期実行）により保証されている。
+   *
+   * @param marker ログマーカー（未使用）
+   * @param logger ログ出力元ロガー（未使用）
+   * @param level ログレベル（未使用）
+   * @param format メッセージフォーマット（未使用）
+   * @param params メッセージパラメータ（未使用）
+   * @param t 例外（未使用）
+   * @return 常に {@link FilterReply#NEUTRAL}
+   */
   @Override
   public FilterReply decide(
       Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t) {

--- a/streamconverter-core/src/main/java/com/streamconverter/path/CSVPath.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/path/CSVPath.java
@@ -69,11 +69,31 @@ public class CSVPath extends AbstractPath<Integer> {
     return new CSVPath(selectorList);
   }
 
+  /**
+   * 検証・正規化処理のフック。
+   *
+   * <p>{@link AbstractPath#AbstractPath(String)} コンストラクタから呼び出されるが、 CSVPathでは検証をファクトリメソッド（{@link
+   * #of(String)} / {@code create}）側で行うため、 コンストラクタ内スロー（CT_CONSTRUCTOR_THROW）を避けるためにここでは何もしない。
+   *
+   * @param rawSelector 生のセレクター文字列（未使用）
+   */
   @Override
   protected void validateAndNormalize(String rawSelector) {
     // Validation is performed in factory methods (of/create) to avoid CT_CONSTRUCTOR_THROW
   }
 
+  /**
+   * 指定された列インデックスがこのパスにマッチするかどうかを判定する（OR条件）。
+   *
+   * <p>いずれかのセレクターがインデックスに一致すれば {@code true} を返す。
+   *
+   * <p><b>注意:</b> このメソッドは数値インデックス指定セレクター（例: {@code "0"}, {@code "1:3"}）に対してのみ 機能する。列名指定セレクター（例:
+   * {@code "name"}, {@code "userId"}）は常に {@code false} を返す。 列名での一致判定には {@link #matches(String[],
+   * int)} を使用すること。
+   *
+   * @param columnIndex 判定対象の列インデックス（0始まり）。nullまたは負値の場合はfalse
+   * @return いずれかのセレクターが一致する場合true
+   */
   @Override
   public boolean matches(Integer columnIndex) {
     if (columnIndex == null || columnIndex < 0) {
@@ -181,6 +201,13 @@ public class CSVPath extends AbstractPath<Integer> {
     }
   }
 
+  /**
+   * このパスの文字列表現を返す。
+   *
+   * <p>セレクターが1つの場合はその値をそのまま返し、複数の場合はカンマ区切りで結合する。
+   *
+   * @return セレクターの文字列表現
+   */
   @Override
   public String toString() {
     if (selectors.size() == 1) {

--- a/streamconverter-core/src/main/java/com/streamconverter/path/CSVPath.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/path/CSVPath.java
@@ -72,14 +72,15 @@ public class CSVPath extends AbstractPath<Integer> {
   /**
    * 検証・正規化処理のフック。
    *
-   * <p>{@link AbstractPath#AbstractPath(String)} コンストラクタから呼び出されるが、 CSVPathでは検証をファクトリメソッド（{@link
-   * #of(String)} / {@code create}）側で行うため、 コンストラクタ内スロー（CT_CONSTRUCTOR_THROW）を避けるためにここでは何もしない。
+   * <p>{@link AbstractPath#AbstractPath(String)} コンストラクタから呼び出されるが、CSVPathでは検証を ファクトリメソッド（{@link
+   * #of(String)} / {@link #of(java.util.List)}）側で行うため、
+   * コンストラクタ内スロー（CT_CONSTRUCTOR_THROW）を避けるためにここでは何もしない。
    *
    * @param rawSelector 生のセレクター文字列（未使用）
    */
   @Override
   protected void validateAndNormalize(String rawSelector) {
-    // Validation is performed in factory methods (of/create) to avoid CT_CONSTRUCTOR_THROW
+    // Validation is performed in factory methods (of(...)) to avoid CT_CONSTRUCTOR_THROW
   }
 
   /**

--- a/streamconverter-core/src/main/java/com/streamconverter/path/TreePath.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/path/TreePath.java
@@ -112,6 +112,15 @@ public class TreePath implements IPath<List<String>> {
     return originalPath;
   }
 
+  /**
+   * 2つのTreePathが等しいかどうかをセグメントリストで比較する。
+   *
+   * <p>注意: 元のパス文字列（{@link #toString()} の値）が異なっていても、 セグメントに展開した結果が同じであれば等しいとみなす。 例えば {@code
+   * "$.user.name"} と {@code "user.name"} がパース後に同じセグメントになる場合、 等しいと判定される。
+   *
+   * @param obj 比較対象のオブジェクト
+   * @return セグメントリストが等しい場合true
+   */
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
@@ -120,6 +129,11 @@ public class TreePath implements IPath<List<String>> {
     return segments.equals(treePath.segments);
   }
 
+  /**
+   * セグメントリストに基づくハッシュコードを返す。
+   *
+   * @return ハッシュコード
+   */
   @Override
   public int hashCode() {
     return segments.hashCode();

--- a/streamconverter-core/src/main/java/com/streamconverter/path/TreePath.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/path/TreePath.java
@@ -115,8 +115,8 @@ public class TreePath implements IPath<List<String>> {
   /**
    * 2つのTreePathが等しいかどうかをセグメントリストで比較する。
    *
-   * <p>注意: 元のパス文字列（{@link #toString()} の値）が異なっていても、 セグメントに展開した結果が同じであれば等しいとみなす。 例えば {@code
-   * "$.user.name"} と {@code "user.name"} がパース後に同じセグメントになる場合、 等しいと判定される。
+   * <p>注意: 元のパス文字列（{@link #toString()} の値）が異なっていても、セグメントに展開した結果が同じであれば等しいとみなす。 例えば JSONスタイルの {@code
+   * "$.user.name"} と XMLスタイルの {@code "user/name"} がパース後に同じセグメントになる場合、 等しいと判定される。
    *
    * @param obj 比較対象のオブジェクト
    * @return セグメントリストが等しい場合true

--- a/streamconverter-core/src/main/java/com/streamconverter/security/SecureXmlConfiguration.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/security/SecureXmlConfiguration.java
@@ -216,9 +216,9 @@ class SecurityAwareErrorHandler implements org.xml.sax.ErrorHandler {
   /**
    * XML解析の警告を処理する。
    *
-   * <p>セキュリティ上の理由から詳細は抑制し、DEBUGレベルでのみ記録する。
+   * <p>セキュリティ上の理由から詳細は抑制し、内部ロガーにはDEBUGレベルで一般的なメッセージのみを記録する。 セキュリティロガーにはWARNレベルで警告発生を記録する。
    *
-   * @param exception 発生した警告の詳細
+   * @param exception 発生した警告の詳細（ログには詳細情報を含めない）
    */
   @Override
   public void warning(org.xml.sax.SAXParseException exception) {

--- a/streamconverter-core/src/main/java/com/streamconverter/security/SecureXmlConfiguration.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/security/SecureXmlConfiguration.java
@@ -171,11 +171,15 @@ public class SecureXmlConfiguration {
   }
 
   /**
-   * InputStreamからのXML読み込みを安全に行います
+   * ストリーム処理用に安全なDocumentBuilderを作成します。
    *
-   * @param inputStream 読み込み対象のInputStream
-   * @return 安全に解析されたDocumentBuilder
+   * <p>引数の {@code inputStream} はnullチェックにのみ使用され、実際のXML解析はこのメソッド内では行いません。 返された {@code
+   * DocumentBuilder} を使って呼び出し元が解析を行います。
+   *
+   * @param inputStream nullチェック対象のInputStream（nullの場合は {@link IllegalArgumentException} をスロー）
+   * @return ストリーム処理用に安全に設定されたDocumentBuilder
    * @throws ParserConfigurationException XML設定エラーが発生した場合
+   * @throws IllegalArgumentException inputStreamがnullの場合
    */
   public static DocumentBuilder createSecureDocumentBuilderForStream(InputStream inputStream)
       throws ParserConfigurationException {
@@ -195,22 +199,43 @@ public class SecureXmlConfiguration {
   }
 }
 
-/** セキュリティを考慮したXMLエラーハンドラー 詳細なエラー情報の漏洩を防ぐため、一般的なエラーメッセージのみを提供 */
+/**
+ * セキュリティを考慮したXMLエラーハンドラー。
+ *
+ * <p>詳細なエラー情報の外部漏洩を防ぐため、外部向けメッセージには一般的な内容のみを使用する。 内部ログには行・列情報を記録し、デバッグを可能にする。
+ *
+ * <p>このクラスは {@link
+ * SecureXmlConfiguration#createSecureDocumentBuilderForStream(java.io.InputStream)}
+ * 内部での使用を想定してpackage-privateとしており、外部から直接インスタンス化されることを想定していない。
+ */
 class SecurityAwareErrorHandler implements org.xml.sax.ErrorHandler {
   private static final Logger logger = LoggerFactory.getLogger(SecurityAwareErrorHandler.class);
   private static final Logger securityLogger =
       LoggerFactory.getLogger("com.streamConverter.security");
 
+  /**
+   * XML解析の警告を処理する。
+   *
+   * <p>セキュリティ上の理由から詳細は抑制し、DEBUGレベルでのみ記録する。
+   *
+   * @param exception 発生した警告の詳細
+   */
   @Override
   public void warning(org.xml.sax.SAXParseException exception) {
     logger.debug("XML parsing warning (details suppressed for security)");
     securityLogger.warn("XML parsing warning detected during secure processing");
   }
 
+  /**
+   * XML解析の回復可能エラーを処理する。
+   *
+   * <p>セキュリティコンテキストでは回復可能エラーも失敗として扱う（不正XMLを後続処理に渡さない）。 内部ログには行・列情報を記録するが、外部エラーメッセージには詳細を含めない。
+   *
+   * @param exception 発生したエラーの詳細
+   * @throws org.xml.sax.SAXException 常にスローし、XML処理を中断する
+   */
   @Override
   public void error(org.xml.sax.SAXParseException exception) throws org.xml.sax.SAXException {
-    // セキュリティコンテキストでは回復可能エラーも失敗として扱う（不正XMLを後続処理に渡さない）
-    // 内部ログには行・列情報を記録するが、外部エラーメッセージには詳細を含めない
     logger.warn(
         "XML parsing error at line {}, column {}",
         exception.getLineNumber(),
@@ -219,6 +244,14 @@ class SecurityAwareErrorHandler implements org.xml.sax.ErrorHandler {
     throw new org.xml.sax.SAXException("XML processing failed: parsing error detected", exception);
   }
 
+  /**
+   * XML解析の致命的エラーを処理する。
+   *
+   * <p>セキュリティ制約違反とみなし、詳細情報を外部に漏らさずに処理を中断する。
+   *
+   * @param exception 発生した致命的エラーの詳細
+   * @throws org.xml.sax.SAXException 常にスローし、XML処理を中断する
+   */
   @Override
   public void fatalError(org.xml.sax.SAXParseException exception) throws org.xml.sax.SAXException {
     securityLogger.error("Fatal XML parsing error detected during secure processing");

--- a/streamconverter-tools/src/main/java/com/streamconverter/benchmark/LargeDataGenerator.java
+++ b/streamconverter-tools/src/main/java/com/streamconverter/benchmark/LargeDataGenerator.java
@@ -411,6 +411,7 @@ public class LargeDataGenerator {
         buffer = chunkBytes;
         bytesGenerated += chunkBytes.length;
       } catch (Exception e) {
+        LOG.warn("Unexpected error while encoding chunk to bytes; treating as end of document", e);
         buffer = new byte[0];
         isDocumentComplete = true;
       }


### PR DESCRIPTION
## Summary

- **StreamConverter**: `// ignored` コメントを `isPipedStreamIOException` 参照付きの説明コメントに置き換え（3箇所）
- **LargeDataGenerator**: 無音の `catch (Exception e)` ブロックに `LOG.warn` を追加
- **InheritableMDCAdapter**: 全 `@Override` メソッド（10件）に Javadoc 追加、スレッド安全性セクション追加、継承セマンティクス（子スレッド生成時スナップショット、遡及伝搬なし）を明確化
- **PipelineContextTurboFilter**: `decide()` がログ発生スレッドと同スレッドで実行される前提を Javadoc に記載
- **CSVPath**: `validateAndNormalize`/`matches(Integer)`/`toString` に Javadoc 追加、名前指定セレクターが常に false を返す制約を明記
- **TreePath**: `equals()` がセグメントのみで比較し元のパス文字列を考慮しないことを記載
- **SecureXmlConfiguration**: `createSecureDocumentBuilderForStream` の誤解を招く `@return` を修正、`SecurityAwareErrorHandler` に package-private 理由を追記

## Test plan

- [ ] `./gradlew :streamconverter-core:compileJava` がエラーなしで通ること
- [ ] `./gradlew :streamconverter-core:test` が全パスすること
- [ ] 動作変更なし（Javadoc・コメント・ログ追加のみの変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
