### PR TITLE
docs: align user-facing docs with current API and Gradle tasks (#588)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import com.streamconverter.command.rule.impl.string.TrimRule;
 import com.streamconverter.path.CSVPath;
 
 StreamConverter converter = StreamConverter.create(
-    CsvNavigateCommand.create(CSVPath.fromHeaderName("name"), new TrimRule()));
+    CsvNavigateCommand.create(CSVPath.of("name"), new TrimRule()));
 
 converter.run(inputStream, outputStream);
 ```

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 Java 21 &nbsp;|&nbsp; [📚 完全なドキュメント一覧](docs/INDEX.md) &nbsp;|&nbsp; [📖 クイックスタート](docs/README.md) &nbsp;|&nbsp; [🔗 API Javadoc](https://3211133.github.io/StreamConverter/)
 
 大容量ファイルをストリームで処理するための Java ライブラリ/ツールキットです。パイプライン化された `IStreamCommand` を組み合わせて、
-文字コード変換・CSV/JSON/XML ナビゲーション・HTTP 連携・バリデーションなどをメモリ効率良く実行できます。
-
-> 💡 **Version**: See [build.gradle.kts](build.gradle.kts) or [VERSION_MANAGEMENT.md](docs/reference/VERSION_MANAGEMENT.md) for current version.
+文字コード変換・CSV/JSON/XML ナビゲーション・バリデーションなどをメモリ効率良く実行できます。
 
 ---
 
@@ -13,54 +11,37 @@ Java 21 &nbsp;|&nbsp; [📚 完全なドキュメント一覧](docs/INDEX.md) &n
 
 | モジュール | 役割 |
 | --- | --- |
-| `streamconverter-core` | パイプラインエンジンとコマンド実装、`StreamConverter` / `ExecutionContext` / ルール API | 
-| `streamconverter-web` | Spring Boot 製の REST API ラッパー。CSV/JSON 抽出や任意パイプライン実行エンドポイントを提供 | 
-| `streamconverter-examples` | サンプルコードと `runQuickStart` / `runMDC` などの実行タスク | 
-| `streamconverter-tools` | 実験・解析ユーティリティ（Gradle タスク経由で利用） |
+| `streamconverter-core` | パイプラインエンジンと主要コマンド実装（`StreamConverter` / `PipelineContext` / Rule API） |
+| `streamconverter-http` | HTTP 連携コマンド実装 |
+| `streamconverter-db` | DB ルール連携・拡張 |
+| `streamconverter-web` | Spring Boot 製の REST API ラッパー |
+| `streamconverter-examples` | サンプルコードと実行タスク |
+| `streamconverter-tools` | 実験・解析ユーティリティ |
 
 ## ✨ 主な機能
 
 ### 🔄 ストリーミングパイプライン
-- `StreamConverter` は入力ストリームをパイプ経由で渡し、各コマンドを並列最適化されたスレッドで実行します。
-- `CSVPath` / `TreePath` による型安全なパス指定と `IRule` 実装で、ナビゲーション＋変換を一度に表現できます。
+- `StreamConverter` は入力ストリームをパイプ経由で渡し、各コマンドを非同期実行します。
+- `StreamConverter.run(...)` は `void` を返し、結果は出力ストリームとログで確認します。
 
 ### 📊 観測性とコンテキスト伝播
-- `CommandResult` に各コマンドの成功可否・実行時間・入出力バイト数を集約。
-- `ExecutionContext` がリクエスト ID やユーザー情報を MDC に自動連携し、マルチスレッドでもログトレースを維持します。
-
-### 🧰 コマンドカタログ
-- CSV/JSON/XML ナビゲーション、ラインエンディング正規化、文字コード変換、HTTP 送信、スキーマ検証などを同梱。
-- `LowerCaseRule` や `ChainRule` などのルールを組み合わせてフィールド単位の変換を定義可能。
+- `PipelineContext` によるパイプライン内の共有値連携に対応。
+- `MdcPropagatingRule` と `PipelineContextTurboFilter` を組み合わせると、抽出値を MDC へ自動反映できます。
 
 ---
 
 ## 🚀 クイックスタート
 
-### パイプライン処理の例
 ```java
-import java.util.List;
-
-import com.streamconverter.CommandResult;
 import com.streamconverter.StreamConverter;
-import com.streamconverter.command.impl.json.JsonNavigateCommand;
-import com.streamconverter.command.impl.SendHttpCommand;
-import com.streamconverter.command.rule.PassThroughRule;
-import com.streamconverter.context.ExecutionContext;
-import com.streamconverter.path.TreePath;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.rule.impl.string.TrimRule;
+import com.streamconverter.path.CSVPath;
 
-ExecutionContext context = ExecutionContext.builder()
-    .globalContext("requestId", "REQ-12345")
-    .userContext("operator", "batch-service")
-    .build();
+StreamConverter converter = StreamConverter.create(
+    CsvNavigateCommand.create(CSVPath.fromHeaderName("name"), new TrimRule()));
 
-StreamConverter converter = StreamConverter.createWithContext(
-    context,
-    JsonNavigateCommand.create(TreePath.fromJson("$.result"), new PassThroughRule()),
-    new SendHttpCommand("https://api.example.com/ingest"));
-
-List<CommandResult> results = converter.run(inputStream, outputStream);
-results.forEach(result ->
-    LOG.info("{}: {} ms", result.getCommandName(), result.getExecutionTimeMillis()));
+converter.run(inputStream, outputStream);
 ```
 
 > 詳細なハンズオンは [docs/quickstart/basic-usage.md](docs/quickstart/basic-usage.md) を参照してください。
@@ -72,40 +53,15 @@ results.forEach(result ->
 | カテゴリ | クラス | 概要 |
 | --- | --- | --- |
 | CSV | `CsvNavigateCommand`, `CsvFilterCommand`, `CsvValidateCommand` | 列変換・行フィルタ・構造検証 |
-| JSON | `JsonNavigateCommand`, `JsonFilterCommand`, `JsonValidateCommand`, `JsonStreamingValidateCommand` | JSONPath 変換・フィルタ・スキーマ検証 |
+| JSON | `JsonNavigateCommand`, `JsonFilterCommand` | JSONPath 変換・フィルタ |
 | XML | `XmlNavigateCommand`, `XmlFilterCommand`, `ConvertCommand`, `ValidateCommand` | XPath ナビゲーションと XSD 検証 |
-| 文字列 | `LineEndingNormalizeCommand`, `CharacterConvertCommand`, `SampleStreamCommand` | 改行正規化・エンコーディング変換・テスト用テンプレート |
-| 通信 | `SendHttpCommand` | 外部 HTTP API へのストリーム送信（安全な URL チェック付き） |
-
----
-
-## 📚 ドキュメント
-- [INDEX.md](docs/INDEX.md): 対象者別の完全なドキュメント一覧
-- [docs/README.md](docs/README.md): ハイライトとナビゲーションガイド
-- [handbook/README.md](docs/handbook/README.md): What/Why/How ベースの機能ガイド
-- [handbook/logging.md](docs/handbook/logging.md): MDC と自動ロギング
-- [handbook/validation.md](docs/handbook/validation.md): CSV/JSON/XML 検証
-- [handbook/web-api.md](docs/handbook/web-api.md): REST API の利用手順
-- [reference/TESTING.md](docs/reference/TESTING.md): テスト戦略とカバレッジ
-
----
-
-## 💡 サンプルコード
-
-| 例 | 説明 |
-| --- | --- |
-| [QuickStart.java](streamconverter-examples/src/main/java/com/streamconverter/examples/QuickStart.java) | 最小限のパイプライン実装 |
-| [StreamConverterMDCDemo.java](streamconverter-examples/src/main/java/com/streamconverter/examples/StreamConverterMDCDemo.java) | MDC 連携とマルチスレッドデモ |
-| [ComplexPipelineExample.java](streamconverter-examples/src/main/java/com/streamconverter/examples/ComplexPipelineExample.java) | 多段変換パイプライン |
-| [ValidationExample.java](streamconverter-examples/src/main/java/com/streamconverter/examples/ValidationExample.java) | CSV/JSON/XML のバリデーション統合 |
-| [DatabaseRuleDemo.java](streamconverter-examples/src/main/java/com/streamconverter/examples/DatabaseRuleDemo.java) | ルールチェーンと外部依存デモ |
-| [PerformanceOptimizationExamples.java](streamconverter-examples/src/main/java/com/streamconverter/examples/PerformanceOptimizationExamples.java) | 大規模データでの最適化テクニック |
+| 文字列 | `LineEndingNormalizeCommand`, `CharacterConvertCommand` | 改行正規化・エンコーディング変換 |
 
 ---
 
 ## 🛠️ ビルド & 実行
 ```bash
-# 全モジュールのビルド（Spotless/テスト/静的解析込み）
+# 全モジュールのビルド
 ./gradlew build
 
 # コアモジュールのテストのみ
@@ -117,28 +73,23 @@ results.forEach(result ->
 # サンプルコードを実行
 ./gradlew :streamconverter-examples:runQuickStart
 ./gradlew :streamconverter-examples:runMDC
-
-# ドキュメント・ベンチマーク
-./gradlew javadocAll
-./gradlew benchmarkAll
 ```
 
 ---
 
-## 🧑‍💻 開発メモ
-- 推奨 JDK: 21（Gradle Toolchain 対応済み）
-- コードスタイル: Spotless + Google Java Format（`./gradlew spotlessApply`）
-- 詳細なセットアップ手順は [docs/development/CONFIGURATION.md](docs/development/CONFIGURATION.md) と [docs/guides/PRE_COMMIT_SETUP.md](docs/guides/PRE_COMMIT_SETUP.md) を参照してください。
+## 📚 ドキュメント
+- [INDEX.md](docs/INDEX.md): 対象者別の完全なドキュメント一覧
+- [docs/README.md](docs/README.md): ハイライトとナビゲーションガイド
+- [handbook/README.md](docs/handbook/README.md): What/Why/How ベースの機能ガイド
+- [handbook/logging.md](docs/handbook/logging.md): MDC と自動ロギング
+- [handbook/validation.md](docs/handbook/validation.md): CSV/XML バリデーション
+- [handbook/web-api.md](docs/handbook/web-api.md): REST API の利用手順
 
 ---
 
 ## 📄 ライセンス
 
 本プロジェクトはリポジトリ内の [LICENSE](LICENSE) に従います。
+
 - **[GitHub Issues](https://github.com/3211133/StreamConverter/issues)** - バグ報告・機能要求
 - **[セキュリティポリシー](SECURITY.md)** - 脆弱性報告
-- **[ドキュメントハブ](docs/README.md)** - 詳細な技術情報
-
----
-
-**StreamConverter v0.0.0** - 効率的なストリーム処理ライブラリ（開発中）

--- a/docs/AUTO_LOGGING.md
+++ b/docs/AUTO_LOGGING.md
@@ -1,313 +1,37 @@
-# Auto-Logging Infrastructure
+# AUTO_LOGGING
 
-## このドキュメントの基礎資料
-このドキュメントは以下の実装を基に作成されています：
-- [AbstractStreamCommand.java](../streamconverter-core/src/main/java/com/streamconverter/command/AbstractStreamCommand.java) - 自動ログ機能の実装
-
-> 💡 **クイック概要**: まず [Logging Handbook](handbook/logging.md) で What/Why/How を理解することをお勧めします。
-
-StreamConverterは包括的な自動ログ出力機能を提供し、大容量ファイル処理時のトラブルシューティングとモニタリングを支援します。
+本ドキュメントは現行実装（`PipelineContext` + `MdcPropagatingRule` + `PipelineContextTurboFilter`）に基づく自動ロギングの要点をまとめます。
 
 ## 概要
 
-すべての標準コマンドは `AbstractStreamCommand` を継承しており、以下のログ機能が自動的に提供されます：
+- `PipelineContext` はパイプライン全体で共有されるコンテキストです。
+- `MdcPropagatingRule` は抽出した値を `PipelineContext` と現在スレッドの MDC に設定します。
+- `PipelineContextTurboFilter` はログ出力直前に `PipelineContext` の値を MDC へ同期します。
 
-- **実行時間測定**: コマンドの開始から終了までの時間
-- **データサイズ測定**: 入力・出力バイト数
-- **メモリ使用量測定**: コマンド実行前後のメモリ差分
-- **パフォーマンス警告**: 5秒以上の実行時に自動警告
-- **実際のクラス名表示**: 各コマンドが自身のクラス名でログ出力
-- **MDC自動同期**: ExecutionContextの共有コンテキストがログ出力時に自動的にMDCに同期（2025年1月追加、TurboFilter使用）
-- **ソースロケーション情報**: メソッド名と行番号の自動出力（logback設定による）
-
-> ℹ️ **Note**: The `LoggingDecorator` class has been removed as AbstractStreamCommand provides comprehensive built-in logging. All standard commands automatically output logs with execution time, data sizes, memory usage, and performance warnings.
-
-## 基本的な使用方法
-
-### パイプライン作成例（自動ログ）
+## 基本例
 
 ```java
 import com.streamconverter.StreamConverter;
-import com.streamconverter.command.IStreamCommand;
-import com.streamconverter.command.impl.csv.CsvNavigateCommand;
-import com.streamconverter.command.impl.SendHttpCommand;
 import com.streamconverter.command.impl.json.JsonNavigateCommand;
-import com.streamconverter.path.CSVPath;
+import com.streamconverter.command.rule.MdcPropagatingRule;
 import com.streamconverter.path.TreePath;
-import com.streamconverter.command.rule.PassThroughRule;
 
-// 各コマンドを作成（ログ機能は自動的に含まれる）
-IStreamCommand csvCommand = new CsvNavigateCommand(new CSVPath("productName"), new PassThroughRule());
-IStreamCommand httpCommand = new SendHttpCommand("http://api.example.com");
-IStreamCommand jsonCommand = new JsonNavigateCommand(TreePath.fromJson("$.result"), new PassThroughRule());
+StreamConverter converter = StreamConverter.create(
+    JsonNavigateCommand.create(TreePath.fromJson("$.user.id"), MdcPropagatingRule.create("userId"))
+);
 
-// パイプラインを作成（各コマンドが自動的にログ出力）
-IStreamCommand[] pipeline = {csvCommand, httpCommand, jsonCommand};
-StreamConverter converter = StreamConverter.create(pipeline);
-List<CommandResult> results = converter.run(inputStream, outputStream);
+converter.run(inputStream, outputStream);
 ```
 
-## 出力されるログ情報
-
-### 必須ログ項目
-
-- **実行開始**: コマンド名、開始時刻
-- **実行終了**: コマンド名、終了時刻、実行時間
-- **例外発生**: 例外の種類、メッセージ、スタックトレース
-- **パフォーマンス**: 実行時間、処理データサイズ
-
-### 詳細ログ項目（DEBUGレベル）
-
-- **入力データ情報**: データサイズ、形式、エンコーディング
-- **出力データ情報**: データサイズ、変換結果サマリー
-- **リソース使用量**: メモリ使用量、処理スループット
-- **設定情報**: コマンド固有の設定値
-
-## 実際のログ出力例
-
-### ExecutionContext付きマルチスレッド実行
-
-```
-2025-11-02 10:09:27.063 INFO  com.streamconverter.StreamConverter.run:204 [execId:EXEC-45916851, seq:0] - Starting StreamConverter with 3 commands (executionId: EXEC-45916851)
-2025-11-02 10:09:27.099 INFO  com.streamconverter.StreamConverter.lambda$executeMultipleCommandsWithMDC$0:256 [execId:EXEC-45916851, seq:1] - Setting up command 1 of 3: CsvNavigateCommand (sequence: 1)
-2025-11-02 10:09:27.100 INFO  c.s.command.impl.csv.CsvNavigateCommand.execute:50 [execId:EXEC-45916851, seq:1] - Starting command execution: CsvNavigateCommand
-2025-11-02 10:09:27.102 INFO  c.s.command.impl.csv.CsvNavigateCommand.execute:74 [execId:EXEC-45916851, seq:1] - Command execution completed: CsvNavigateCommand (2ms, input: 98890bytes, output: 98890bytes, memory: 1MB)
-2025-11-02 10:09:27.103 INFO  com.streamconverter.StreamConverter.lambda$executeMultipleCommandsWithMDC$0:280 [execId:EXEC-45916851, seq:1] - Completed command: CsvNavigateCommand (sequence: 1)
-2025-11-02 10:09:27.105 INFO  com.streamconverter.StreamConverter.executeMultipleCommandsWithMDC:349 [execId:EXEC-45916851, seq:0] - All commands completed successfully (executionId: EXEC-45916851)
-```
-
-### エラー発生時のログ
-
-```
-2025-11-02 10:09:27.150 ERROR c.s.command.impl.SendHttpCommand.execute:92 [execId:EXEC-123, seq:2] - Command execution failed: SendHttpCommand (1523ms, input: 89012bytes, output: 0bytes, memory: 3MB) - Connection timeout
-java.net.SocketTimeoutException: Connect timed out
-    at com.streamconverter.command.impl.SendHttpCommand.executeInternal(SendHttpCommand.java:145)
-    ...
-```
-
-## ExecutionContext対応のログ機能
-
-ExecutionContextの基本的な使用方法は [Basic Usage - Context and Metrics](quickstart/basic-usage.md#3-context-and-metrics) を参照してください。
-
-以下は、ExecutionContextとロギング機能を組み合わせた例です：
-
-```java
-// ExecutionContext作成（詳細は上記リンク参照）
-ExecutionContext context = ExecutionContext.builder()
-    .globalContext("requestId", "REQ-12345")
-    .globalContext("userId", "user789")
-    .build();
-
-// ロギングが自動的に有効化される
-StreamConverter converter = StreamConverter.createWithContext(context, commands);
-List<CommandResult> results = converter.run(inputStream, outputStream);
-
-// ログにはrequestIdとuserIdが自動的に含まれる
-```
-
-### MDCコンテキスト伝播の確認
-
-MDC（Mapped Diagnostic Context）により、以下の情報が自動的にログに含まれます：
-
-- `executionId` - StreamConverter実行ごとの一意ID
-- `commandSequence` - パイプライン内でのコマンド実行順序
-- `stage` - 実行ステージ名（setStage()で設定した場合）
-- `threadName` - 実行スレッド名
-- `startTime` - 実行開始時刻
-- カスタムコンテキスト - ExecutionContext.builder().globalContext()で追加した任意のキー・バリュー
-
-logback設定例：
-```xml
-<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36}.%method:%line [execId:%X{executionId:-}, seq:%X{commandSequence:-}, stage:%X{stage:-}] - %msg%n</pattern>
-```
-
-これにより、マルチスレッド環境でも各ログ行がどの実行に属するか追跡可能です。
-
-## パフォーマンス考慮事項
-
-### ログレベルの選択
-
-- **PRODUCTION**: `INFO`または`WARN` - 必要最小限のログ
-- **DEVELOPMENT**: `DEBUG` - 詳細な診断情報
-- **TROUBLESHOOTING**: `TRACE` - 最大詳細度（パフォーマンス影響あり）
-
-### メモリ使用量
-
-```java
-// 大容量ファイル処理時の設定例
-CommandConfig config = new CommandConfig()
-    .enableLogging(true)
-    .setLogLevel("INFO")                    // DEBUGは避ける
-    .enablePerformanceMetrics(false)        // 高頻度測定を無効化
-    .setLogBufferSize(1024);                // ログバッファサイズ制限
-```
-
-## ログ設定のカスタマイズ
-
-### logback.xmlでの設定
+## Logback 設定例
 
 ```xml
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <!-- ソースロケーション情報（%method:%line）とMDC情報（%X{...}）を含む推奨パターン -->
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36}.%method:%line [execId:%X{executionId:-}, seq:%X{commandSequence:-}, stage:%X{stage:-}] - %msg%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/streamconverter.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/streamconverter.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxHistory>30</maxHistory>
-            <maxFileSize>10MB</maxFileSize>
-            <totalSizeCap>1GB</totalSizeCap>
-        </rollingPolicy>
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36}.%method:%line [execId:%X{executionId:-}, seq:%X{commandSequence:-}, stage:%X{stage:-}] - %msg%n</pattern>
-        </encoder>
-    </appender>
-
-    <logger name="com.streamconverter" level="INFO" additivity="false">
-        <appender-ref ref="STDOUT" />
-        <appender-ref ref="FILE" />
-    </logger>
+  <turboFilter class="com.streamconverter.logging.PipelineContextTurboFilter"/>
 </configuration>
 ```
 
-パターンの各要素：
-- `%method:%line` - メソッド名と行番号（ソースロケーション情報）
-- `%X{executionId:-}` - ExecutionContextの実行ID（MDC）
-- `%X{commandSequence:-}` - コマンド実行順序（MDC）
-- `%X{stage:-}` - 実行ステージ名（MDC）
-- `:-` - MDC値が設定されていない場合のデフォルト値（空文字列）
+## 注意点
 
-### プログラムでのロガー設定
-
-```java
-import org.slf4j.LoggerFactory;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.Level;
-
-// 実行時にログレベルを変更
-Logger logger = (Logger) LoggerFactory.getLogger("com.streamConverter");
-logger.setLevel(Level.DEBUG);
-```
-
-## ベストプラクティス
-
-### 1. 適切なログレベルの使用
-
-```java
-// 本番環境
-CommandConfig prodConfig = new CommandConfig()
-    .enableLogging(true)
-    .setLogLevel("WARN");    // エラーと警告のみ
-
-// 開発環境  
-CommandConfig devConfig = new CommandConfig()
-    .enableLogging(true)
-    .setLogLevel("DEBUG");   // 詳細な診断情報
-```
-
-### 2. 大容量ファイル処理時の設定
-
-```java
-// 10GB+のファイル処理
-CommandConfig largeFileConfig = new CommandConfig()
-    .enableLogging(true)
-    .setLogLevel("INFO")
-    .enablePerformanceMetrics(true)     // 処理進捗の把握
-    .setMetricsInterval(10000);         // 10,000レコードごとに出力
-```
-
-### 3. パイプライン全体のログ統合
-
-```java
-// ExecutionContext作成でログ統合を実現
-ExecutionContext context = ExecutionContext.builder()
-    .globalContext("environment", "production")
-    .globalContext("pipeline", "csv-http-json")
-    .build();
-
-IStreamCommand[] pipeline = {
-    new CsvNavigateCommand("input"),
-    new SendHttpCommand("http://api.example.com"),
-    new JsonNavigateCommand("$.result")
-};
-
-StreamConverter converter = StreamConverter.createWithContext(context, pipeline);
-```
-
-### 4. MDC自動同期（2025年1月追加）
-
-ExecutionContextの共有コンテキストは、ログ出力時に自動的にMDCに同期されます。
-
-```java
-// ExecutionContext作成
-ExecutionContext context = ExecutionContext.create();
-
-// XMLからuserIdを抽出してMDCに自動設定
-XmlNavigateCommand extractUserId = new XmlNavigateCommand(
-    TreePath.fromXml("request/userId"),
-    new MdcSetupRule(context, "userId")
-);
-
-// 後続のコマンドは自動的にMDCでuserIdを参照可能
-SampleStreamCommand processor = new SampleStreamCommand("processor");
-
-// パイプライン実行
-StreamConverter.createWithContext(context, extractUserId, processor)
-    .run(inputStream, outputStream);
-```
-
-**動作の仕組み**:
-1. `MdcSetupRule`が抽出した値を`ExecutionContext`の共有コンテキストに保存
-2. `AbstractStreamCommand`が`ExecutionContextHolder`にコンテキストを設定
-3. ログ出力時に`ExecutionContextTurboFilter`が共有コンテキストをMDCに自動同期
-4. logback.xmlのパターン`[userId:%X{userId:-}]`が正しく展開される
-
-**ログ出力例**:
-```
-2025-01-06 14:00:01.123 INFO  [execId:EXEC-123, seq:1, userId:USER12345] - Starting command execution: XmlNavigateCommand
-2025-01-06 14:00:01.125 INFO  [execId:EXEC-123, seq:2, userId:USER12345] - Starting command execution: SampleStreamCommand
-2025-01-06 14:00:01.127 INFO  [execId:EXEC-123, seq:2, userId:USER12345] - Processing data for user
-```
-
-**利点**:
-- アプリケーションコードがMDCを意識する必要がない
-- マルチスレッド環境でも自動的に伝播
-- パフォーマンス最適化（変更がある場合のみMDC操作）
-
-## トラブルシューティング
-
-### 一般的な問題と解決策
-
-1. **ログが出力されない**
-   ```java
-   // logback.xmlでのレベル設定を確認
-   // CommandConfigでのログ有効化を確認
-   config.enableLogging(true);
-   ```
-
-2. **パフォーマンスが低下する**
-   ```java
-   // ログレベルをINFO以上に設定
-   config.setLogLevel("INFO");
-   // パフォーマンス測定を無効化
-   config.enablePerformanceMetrics(false);
-   ```
-
-3. **メモリ使用量が増加する**
-   ```java
-   // ログバッファサイズを制限
-   config.setLogBufferSize(512);
-   // 詳細ログを無効化
-   config.enableMemoryTracking(false);
-   ```
-
-## 関連ドキュメント
-
-- [Command Architecture](archived/COMMAND_ARCHITECTURE.md) - コマンドパターンの詳細
-- [Testing Strategy](reference/TESTING.md) - パフォーマンス最適化とベンチマーク
-- [Documentation Index](INDEX.md) - その他のドキュメント
+- `StreamConverter.run(...)` は `void` を返します。
+- 旧 API（`ExecutionContext` / `createWithContext(...)` / `CommandResult`）は現行の公開 API ではありません。

--- a/docs/WEB_API.md
+++ b/docs/WEB_API.md
@@ -1,128 +1,42 @@
 # StreamConverter Web API
 
-## このドキュメントの基礎資料
-このドキュメントは以下の実装を基に作成されています：
-- [StreamProcessingController.java](../streamconverter-web/src/main/java/com/streamconverter/web/StreamProcessingController.java) - REST APIエンドポイントの実装
-
-> 💡 **クイック概要**: まず [Web API Handbook](handbook/web-api.md) で What/Why/How を理解することをお勧めします。
-
-StreamConverterの既存機能をWebAPIとして提供するRESTfulサービスです。
+StreamConverter の処理を HTTP 経由で利用するための Spring Boot WebFlux モジュールです。
 
 ## 🚀 起動方法
 
 ```bash
-# Web APIサーバーとして起動
-./gradlew bootRun
+# Web モジュールを起動
+./gradlew :streamconverter-web:bootRun
 
-# または、Jarファイルから起動
-./gradlew bootJar
-java -jar build/libs/StreamConverter-*.jar
+# Fat Jar を作成
+./gradlew :streamconverter-web:bootJar
 ```
 
-サーバーは `http://localhost:8080` で起動します。
+デフォルトは `http://localhost:8080` で起動します。
 
 ## 📡 API エンドポイント
 
-### 1. ヘルスチェック
-```bash
-GET /api/v1/stream/health
-```
+### ヘルスチェック
+`GET /api/v1/stream/health`
 
-### 2. CSV列抽出
-```bash
-POST /api/v1/stream/csv/extract?columnName=name
-Content-Type: application/octet-stream
+### CSV 抽出
+`POST /api/v1/stream/csv/extract?columnName=name`
 
-# 例: CSVファイルから特定の列を抽出
-curl -X POST \
-  -H "Content-Type: application/octet-stream" \
-  --data-binary @input.csv \
-  "http://localhost:8080/api/v1/stream/csv/extract?columnName=name"
-```
+### JSON 抽出
+`POST /api/v1/stream/json/extract?jsonPath=$.user.name`
 
-### 3. JSON パス抽出
-```bash
-POST /api/v1/stream/json/extract?jsonPath=$.user.name
-Content-Type: application/octet-stream
+### パイプライン処理
+`POST /api/v1/stream/process`
 
-# 例: JSONからパス指定で値を抽出
-curl -X POST \
-  -H "Content-Type: application/octet-stream" \
-  --data-binary @input.json \
-  "http://localhost:8080/api/v1/stream/json/extract?jsonPath=name"
-```
+- `X-Pipeline-Config` ヘッダーで実行チェーンを指定
+- 例: `csv:name,json:$.user.id`
 
-### 4. パイプライン処理
-```bash
-POST /api/v1/stream/process
-Content-Type: application/octet-stream
-X-Pipeline-Config: csv:name,process:validator,json:$.result
-
-# 例: 複数のコマンドをパイプライン実行
-curl -X POST \
-  -H "Content-Type: application/octet-stream" \
-  -H "X-Pipeline-Config: csv:name,process:validator" \
-  --data-binary @input.csv \
-  "http://localhost:8080/api/v1/stream/process"
-```
-
-## 🔧 パイプライン設定
-
-`X-Pipeline-Config` ヘッダーでコマンドチェーンを指定できます：
-
-- `csv:columnName` - CSV列抽出
-- `json:jsonPath` - JSONパス抽出  
-- `process:processorName` - カスタム処理
-
-複数のコマンドはカンマで区切ります。
-
-## 📝 使用例
-
-### CSV処理の例
-```bash
-# input.csv
-name,age,city
-John,30,NYC
-Jane,25,LA
-
-# name列を抽出
-curl -X POST \
-  -H "Content-Type: application/octet-stream" \
-  --data-binary @input.csv \
-  "http://localhost:8080/api/v1/stream/csv/extract?columnName=name"
-```
-
-### JSON処理の例
-```bash
-# input.json
-{"user":{"name":"John","age":30},"city":"NYC"}
-
-# user.name を抽出
-curl -X POST \
-  -H "Content-Type: application/octet-stream" \
-  --data-binary @input.json \
-  "http://localhost:8080/api/v1/stream/json/extract?jsonPath=user.name"
-```
-
-## 🏗️ アーキテクチャ
-
-- **Spring Boot WebFlux**: 非同期・ノンブロッキング処理
-- **既存StreamConverter統合**: 既存のコマンドパイプラインをそのまま活用
-- **InputStream/OutputStream対応**: バイナリストリーミング処理
-- **メモリ効率**: 大容量データも少ないメモリで処理
-
-## 🧪 テスト実行
+## 🧪 テスト
 
 ```bash
-# Web APIテストを実行
-./gradlew test --tests "*StreamProcessingControllerTest*"
+# Web モジュールのテスト
+./gradlew :streamconverter-web:test
 
-# 全テストを実行
-./gradlew test
+# 特定テストクラス
+./gradlew :streamconverter-web:test --tests "*StreamProcessingControllerTest*"
 ```
-
-## 📊 監視・ログ
-
-- **ログレベル**: `application.yml`で設定可能
-- **ヘルスチェック**: `/api/v1/stream/health`
-- **Spring Boot Actuator**: 運用監視機能（必要に応じて有効化）

--- a/docs/WEB_API.md
+++ b/docs/WEB_API.md
@@ -19,11 +19,15 @@ StreamConverter の処理を HTTP 経由で利用するための Spring Boot Web
 ### ヘルスチェック
 `GET /api/v1/stream/health`
 
-### CSV 抽出
+### CSV ナビゲーション（構造保持）
 `POST /api/v1/stream/csv/extract?columnName=name`
 
-### JSON 抽出
+指定列に `PassThroughRule` を適用しながら CSV 構造全体を出力します（列のみを抽出するのではありません）。
+
+### JSON ナビゲーション（構造保持）
 `POST /api/v1/stream/json/extract?jsonPath=$.user.name`
+
+指定パスに `PassThroughRule` を適用しながら JSON 構造全体を出力します（パスの値のみを抽出するのではありません）。
 
 ### パイプライン処理
 `POST /api/v1/stream/process`

--- a/docs/handbook/web-api.md
+++ b/docs/handbook/web-api.md
@@ -1,24 +1,19 @@
 # Web API
 
-## このドキュメントの基礎資料
-このドキュメントは以下の資料を基に作成されています：
-- [WEB_API.md](../WEB_API.md) - Web API の詳細仕様とエンドポイント
-
 ## What
-The Web API exposes StreamConverter capabilities over HTTP using Spring Boot.
+Web API は StreamConverter を HTTP から呼び出すための Spring Boot WebFlux インターフェースです。
 
 ## Why
-It allows remote systems to process streams without embedding the library, enabling integration with other services.
+ライブラリを直接組み込まなくても、外部システムからストリーム変換を利用できます。
 
 ## How
-1. Start the server with `./gradlew bootRun`.
-2. Use endpoints such as `/api/v1/stream/csv/extract` or `/api/v1/stream/json/extract`.
-3. Chain multiple commands by supplying an `X-Pipeline-Config` header.
+1. `./gradlew :streamconverter-web:bootRun` で起動します。
+2. `/api/v1/stream/csv/extract` や `/api/v1/stream/json/extract` を呼び出します。
+3. `X-Pipeline-Config` ヘッダーで複数コマンドを連結できます。
 
 ## See also
+- [Web API 詳細ガイド](../WEB_API.md)
 - [Architecture](architecture.md)
 - [Logging](logging.md)
 - [Validation](validation.md)
 - [Handbook index](README.md)
-
-Further endpoint examples are in the [original Web API guide](../WEB_API.md).

--- a/docs/reference/CLAUDE_ARCHITECTURE.md
+++ b/docs/reference/CLAUDE_ARCHITECTURE.md
@@ -1,76 +1,20 @@
-# StreamConverter Architecture Guide for AI Assistants
+# CLAUDE Architecture Notes
 
-## このドキュメントの基礎資料
-このドキュメントは以下の資料を基に作成されています：
-- [CLAUDE.md](../../CLAUDE.md) - AI アシスタント向けメインガイドから詳細部分を外部化
+## Core API
+- `StreamConverter.create(IStreamCommand...)`
+- `StreamConverter.create(List<IStreamCommand>)`
+- `void StreamConverter.run(InputStream, OutputStream)`
 
-This document provides detailed architectural information for AI assistants working with the StreamConverter codebase.
+## Context & Logging
+- Shared context: `PipelineContext`
+- MDC propagation rule: `MdcPropagatingRule`
+- Log sync filter: `PipelineContextTurboFilter`
 
-## 3-Layer Architecture
+## Available built-in commands (core)
+- CSV: `CsvNavigateCommand`, `CsvFilterCommand`, `CsvValidateCommand`
+- JSON: `JsonNavigateCommand`, `JsonFilterCommand`
+- XML: `XmlNavigateCommand`, `XmlFilterCommand`, `ConvertCommand`, `ValidateCommand`
+- Text: `LineEndingNormalizeCommand`, `CharacterConvertCommand`
 
-```
-Core Layer         → StreamConverter, ExecutionContext, CommandResult
-Command Layer      → IStreamCommand implementations, AbstractStreamCommand
-Foundation Layer   → Path handlers, utilities, security components
-```
-
-## Key Design Patterns
-
-- **Command Pattern**: All processing units inherit from `IStreamCommand`
-- **Pipeline Pattern**: Commands chained via `StreamConverter.create(commands[])`
-- **Factory Pattern**: `EnhancedCommandFactory` with configuration and caching
-- **Strategy Pattern**: `IRule` implementations for data transformation rules
-- **Built-in Logging**: Automatic logging via `AbstractStreamCommand` base class
-
-## Core Processing Flow
-
-1. **Input Stream** → Wrapped in `MeasuredInputStream` for metrics
-2. **Command Pipeline** → Sequential or concurrent command execution
-3. **Rule Application** → Data transformation via `IRule` implementations
-4. **Output Stream** → Wrapped in `MeasuredOutputStream` for metrics
-5. **Context Propagation** → MDC context maintained across threads
-
-## Command Types by Category
-
-### Data Extraction
-- `CsvNavigateCommand` - Extract data from CSV files
-- `JsonNavigateCommand` - Extract data from JSON documents
-- `XmlNavigateCommand` - Extract data from XML documents
-
-### Data Transformation
-- `CharacterConvertCommand` - Character encoding conversion
-- `LineEndingNormalizeCommand` - Normalize line endings
-- `xml.ConvertCommand` - XSLT transformation
-
-### Communication
-- `SendHttpCommand` - HTTP requests with Spring WebClient
-
-### Validation
-- `JsonValidateCommand` - JSON schema validation
-- `JsonStreamingValidateCommand` - Streaming JSON validation
-- `CsvValidateCommand` - CSV structure validation
-- `ValidateCommand` - XML validation
-
-### Filtering
-- `CsvFilterCommand` - Filter CSV rows
-- `JsonFilterCommand` - Filter JSON elements
-- `XmlFilterCommand` - Filter XML nodes
-
-### Pipeline Control
-- `FileBufferCommand` - Buffer data through a temporary file between pipeline stages
-  - `FileBufferCommand.create()` — 平文モード
-  - `FileBufferCommand.createEncrypted()` — AES-256-GCM 暗号化モード（機密データ向け）
-  - バリデーション失敗時に不正データが下流へ流れる問題（`ConsumerCommand` + `TeeInputStream` パターンの issue #545）を解決する
-
-## Testing Patterns
-
-- **Unit Tests**: Standard JUnit 5 with Mockito
-- **Integration Tests**: End-to-end pipeline testing
-- **Network Tests**: Conditional execution via `@DisabledIfSystemProperty`
-- **Benchmark Tests**: Tagged with `@Tag("benchmark")`, excluded from normal test runs
-- **Memory Tests**: Special handling for GC-sensitive memory assertions
-
-## Related Documentation
-
-- [ARCHITECTURE.md](../ARCHITECTURE.md) - Comprehensive architecture documentation
-- [handbook/architecture.md](../handbook/architecture.md) - Architecture handbook
+## Important
+旧 API (`ExecutionContext`, `createWithContext`, `CommandResult`, `JsonValidateCommand`, `JsonStreamingValidateCommand`, `SampleStreamCommand`) を前提にした実装は現行コードと一致しません。

--- a/docs/reference/CLAUDE_EXAMPLES.md
+++ b/docs/reference/CLAUDE_EXAMPLES.md
@@ -4,7 +4,7 @@
 
 ```java
 StreamConverter converter = StreamConverter.create(
-    CsvNavigateCommand.create(CSVPath.fromHeaderName("name"), new TrimRule())
+    CsvNavigateCommand.create(CSVPath.of("name"), new TrimRule())
 );
 converter.run(inputStream, outputStream);
 ```
@@ -22,8 +22,8 @@ converter.run(inputStream, outputStream);
 
 ```java
 StreamConverter converter = StreamConverter.create(
-    LineEndingNormalizeCommand.create(LineEndingType.LF),
-    CharacterConvertCommand.create(Charset.forName("UTF-8"), Charset.forName("Shift_JIS"))
+    new LineEndingNormalizeCommand(LineEndingType.UNIX),
+    CharacterConvertCommand.create("UTF-8", "Shift_JIS")
 );
 converter.run(inputStream, outputStream);
 ```

--- a/docs/reference/CLAUDE_EXAMPLES.md
+++ b/docs/reference/CLAUDE_EXAMPLES.md
@@ -1,113 +1,29 @@
-# StreamConverter Code Examples for AI Assistants
+# CLAUDE Examples
 
-## このドキュメントの基礎資料
-このドキュメントは以下の資料を基に作成されています：
-- [CLAUDE.md](../../CLAUDE.md) - AI アシスタント向けメインガイドから詳細部分を外部化
-
-This document provides code examples and common usage patterns for AI assistants working with the StreamConverter codebase.
-
-## Common Usage Patterns
-
-### Basic Pipeline: CSV → HTTP API → JSON
+## Minimal pipeline
 
 ```java
-// Extract from CSV, send to API, extract from response
-IStreamCommand[] pipeline = {
-    new CsvNavigateCommand("productName"),      // Extract from CSV
-    new SendHttpCommand("http://api.example.com"), // Send to API
-    new JsonNavigateCommand("$.result")         // Extract from response
-};
-
-StreamConverter converter = StreamConverter.create(pipeline);
-List<CommandResult> results = converter.run(inputStream, outputStream);
-```
-
-### Context-Aware Processing (Recommended)
-
-```java
-// Build execution context with correlation IDs
-ExecutionContext context = ExecutionContext.builder()
-    .globalContext("requestId", "REQ-12345")
-    .globalContext("userId", "user789")
-    .build();
-
-// Create converter with context
-StreamConverter converter = StreamConverter.createWithContext(context, pipeline);
-List<CommandResult> results = converter.run(inputStream, outputStream);
-```
-
-### MDC Auto-Sync with Shared Context (Since 2025-01)
-
-```java
-// Create execution context
-ExecutionContext context = ExecutionContext.create();
-
-// Extract userId from XML and auto-sync to MDC
-XmlNavigateCommand extractUserId = new XmlNavigateCommand(
-    TreePath.fromXml("request/userId"),
-    new MdcSetupRule(context, "userId")  // Stores in shared context
-);
-
-// Downstream commands automatically get userId in MDC
-SampleStreamCommand processor = new SampleStreamCommand("processor");
-
-// Pipeline execution - TurboFilter auto-syncs to MDC
-StreamConverter.createWithContext(context, extractUserId, processor)
-    .run(inputStream, outputStream);
-
-// All logs will show [userId:USER12345] automatically
-```
-
-**Key Points**:
-- `MdcSetupRule` stores extracted values in shared context
-- `ExecutionContextTurboFilter` auto-syncs to MDC on every log output
-- Downstream commands are MDC-agnostic
-- Works correctly in multi-threaded environments
-
-### Validate-then-Transform with FileBufferCommand
-
-バリデーションが失敗した場合でも不正データが下流コマンドへ流れないようにしたい場合、`FileBufferCommand` をステージ間に挟む。
-
-```java
-// バリデーション失敗時に不正データが transformCmd へ到達しないことを保証する
 StreamConverter converter = StreamConverter.create(
-    validateCmd,
-    FileBufferCommand.create(),   // ← 一時ファイルでステージを分離
-    transformCmd
+    CsvNavigateCommand.create(CSVPath.fromHeaderName("name"), new TrimRule())
 );
 converter.run(inputStream, outputStream);
 ```
 
-機密データを扱う場合は暗号化モードを使用する：
+## Pipeline with MDC propagation
 
 ```java
 StreamConverter converter = StreamConverter.create(
-    validateCmd,
-    FileBufferCommand.createEncrypted(),  // AES-256-GCM で一時ファイルを暗号化
-    transformCmd
+    JsonNavigateCommand.create(TreePath.fromJson("$.user.id"), MdcPropagatingRule.create("userId"))
 );
+converter.run(inputStream, outputStream);
 ```
 
-**一時ファイルのライフサイクル**:
-- `execute()` 開始時に `Files.createTempFile("streamconverter-", ".tmp")` で作成
-- 正常終了・例外発生を問わず `finally` で削除
-- JVM 異常終了に備えて ShutdownHook も登録（正常終了時は解除）
-
-### Testing Network-Dependent Code
+## Multi command chain
 
 ```java
-@DisabledIfSystemProperty(
-    named = "skipNetworkTests",
-    matches = "true",
-    disabledReason = "Network-dependent test disabled"
-)
-@Test
-void testWithNetworkAccess() {
-    // Test code that requires network
-}
+StreamConverter converter = StreamConverter.create(
+    LineEndingNormalizeCommand.create(LineEndingType.LF),
+    CharacterConvertCommand.create(Charset.forName("UTF-8"), Charset.forName("Shift_JIS"))
+);
+converter.run(inputStream, outputStream);
 ```
-
-## Related Documentation
-
-- [quickstart/basic-usage.md](../quickstart/basic-usage.md) - Basic usage guide
-- [handbook/](../handbook/) - Feature-specific handbooks with examples

--- a/docs/reference/CLAUDE_IMPLEMENTATION.md
+++ b/docs/reference/CLAUDE_IMPLEMENTATION.md
@@ -1,95 +1,15 @@
-# StreamConverter Implementation Details for AI Assistants
+# CLAUDE Implementation Notes
 
-## このドキュメントの基礎資料
-このドキュメントは以下の資料を基に作成されています：
-- [CLAUDE.md](../../CLAUDE.md) - AI アシスタント向けメインガイドから詳細部分を外部化
+## API baseline
+- `StreamConverter.run(...)` is `void`.
+- Build pipelines with `StreamConverter.create(...)`.
 
-This document provides important implementation constraints and guidelines for AI assistants working with the StreamConverter codebase.
+## Context model
+- Use `PipelineContext` for shared per-run state.
+- Use `MdcPropagatingRule` to write extracted values into context/MDC.
+- Use `PipelineContextTurboFilter` in Logback for automatic MDC synchronization.
 
-## Stream Processing Constraints
-
-### Critical Rules
-- **Never read entire InputStream into memory** - Always use streaming approaches
-- **Commands must support streaming** - Process data as it flows through
-- **Memory-efficient operations** - Use `MeasuredInputStream`/`MeasuredOutputStream` for monitoring
-
-### Example: Incorrect vs Correct
-
-```java
-// ❌ INCORRECT: Reads entire stream into memory
-byte[] allData = inputStream.readAllBytes();
-String content = new String(allData);
-
-// ✅ CORRECT: Stream processing
-try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
-    String line;
-    while ((line = reader.readLine()) != null) {
-        // Process line by line
-    }
-}
-```
-
-## Security Considerations
-
-### SQL Injection Protection
-- Use prepared statements in `DatabaseFetchRule`
-- Never concatenate user input into SQL queries
-
-### XML External Entity (XXE) Prevention
-- Disable external entity processing in XML parsers
-- Use secure factory configurations
-
-### URL Scheme Validation
-- Validate URL schemes in HTTP commands
-- Only allow http/https protocols
-
-### Input Sanitization
-- Validate and sanitize all user inputs
-- Apply appropriate encoding/escaping
-
-## Context Management
-
-### MDC Integration
-- MDC (Mapped Diagnostic Context) for distributed tracing
-- Automatic context propagation across threads
-
-### ExecutionContext Usage
-- Use for request correlation
-- Track performance metrics
-- Thread-safe context propagation in concurrent processing
-
-### Example: Context Propagation
-
-```java
-ExecutionContext context = ExecutionContext.builder()
-    .globalContext("traceId", UUID.randomUUID().toString())
-    .build();
-
-// Context is automatically propagated to all commands
-StreamConverter converter = StreamConverter.createWithContext(context, pipeline);
-```
-
-## Performance Guidelines
-
-### Benchmark Considerations
-- Benchmark tests are isolated with memory configuration (`-Xmx3g` for 5GB tests)
-- Memory measurements can be unreliable due to GC timing - use cautiously
-- Prefer functional verification over performance-based assertions
-
-### Known Behavior
-- Spring WebClient uses sequential processing, not parallel
-- Verified via `InputStreamCloseTimingVerification`
-- Thread pool configuration affects concurrent pipeline execution
-
-## Personal Insights (Lessons Learned)
-
-- Do not read the entire InputStream at once
-- It has been verified that Spring WebClient performs sequential, not parallel, processing
-- Memory efficiency tests may be unreliable due to the effects of GC timing
-- Do not use `@SuppressWarnings` annotation
-
-## Related Documentation
-
-- [reference/TESTING.md](TESTING.md) - Testing strategy
-- [reference/SECURITY_ANALYSIS.md](SECURITY_ANALYSIS.md) - Security measures
-- [guides/BENCHMARK_IMPLEMENTATION.md](../guides/BENCHMARK_IMPLEMENTATION.md) - Performance benchmarks
+## Implementation guidance
+- Prefer streaming commands and avoid loading full input into memory.
+- Keep command execution side-effect minimal and deterministic.
+- Validate all external inputs (headers, path expressions, schema paths).

--- a/docs/reference/COMMAND_EXAMPLES.md
+++ b/docs/reference/COMMAND_EXAMPLES.md
@@ -1,314 +1,59 @@
-# Command Examples Reference
+# Command Examples
 
-StreamConverter で使用できるコマンドの基本的な使用例を示します。
+現行 API（`StreamConverter.create(...)` + `void run(...)`）のサンプルです。
 
-> ✅ **検証済みコード**: このドキュメントのコード例は [BasicUsageExamples.java](../../streamconverter-examples/src/main/java/com/streamconverter/examples/docs/BasicUsageExamples.java) で実際にコンパイル・実行可能な形で管理されています。
-
-## CSV Commands
-
-### CsvNavigateCommand - CSV列変換
+## CSV 列抽出
 
 ```java
-import com.streamconverter.command.impl.csv.CsvNavigateCommand;
-import com.streamconverter.path.CSVPath;
-import com.streamconverter.command.rule.PassThroughRule;
-import com.streamconverter.command.IStreamCommand;
 import com.streamconverter.StreamConverter;
-import com.streamconverter.CommandResult;
-import java.util.List;
-
-// 特定の列に変換ルールを適用（CSV構造全体を保持）
-IStreamCommand csvCommand = new CsvNavigateCommand(
-    new CSVPath("productName"),
-    new PassThroughRule()
-);
-```
-
-### CsvFilterCommand - CSV列抽出
-
-```java
-import com.streamconverter.command.impl.csv.CsvFilterCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.rule.impl.string.TrimRule;
 import com.streamconverter.path.CSVPath;
 
-// 特定の列のみ抽出（指定した列だけを出力、ヘッダーありと仮定）
-IStreamCommand filterCommand = CsvFilterCommand.create(new CSVPath("price"));
-
-// ヘッダーの有無を明示的に指定
-IStreamCommand filterCommand2 = new CsvFilterCommand(new CSVPath("name"), true);
-```
-
-### CsvValidateCommand - CSV検証
-
-```java
-import com.streamconverter.command.impl.csv.CsvValidateCommand;
-
-// CSVファイルの構造を検証（必須カラムを指定）
-IStreamCommand validateCommand = new CsvValidateCommand("id", "name", "price");
-
-// 詳細設定を指定
-IStreamCommand validateCommand2 = new CsvValidateCommand(
-    true,  // hasHeader
-    10,    // maxErrorsToReport
-    "id", "name", "price"  // requiredColumns
+StreamConverter converter = StreamConverter.create(
+    CsvNavigateCommand.create(CSVPath.fromHeaderName("name"), new TrimRule())
 );
+converter.run(inputStream, outputStream);
 ```
 
-## JSON Commands
-
-### JsonNavigateCommand - JSON要素変換
+## JSON フィルタ
 
 ```java
-import com.streamconverter.command.impl.json.JsonNavigateCommand;
-import com.streamconverter.path.TreePath;
-import com.streamconverter.command.rule.PassThroughRule;
-
-// 特定の要素に変換ルールを適用（JSON構造全体を保持）
-IStreamCommand jsonCommand = new JsonNavigateCommand(
-    new TreePath("user", "name"),
-    new PassThroughRule()
-);
-```
-
-### JsonFilterCommand - JSON要素抽出
-
-```java
+import com.streamconverter.StreamConverter;
 import com.streamconverter.command.impl.json.JsonFilterCommand;
-import com.streamconverter.path.TreePath;
-
-// TreePathを使用してJSON要素を抽出（指定した要素のみを出力）
-IStreamCommand filterCommand = new JsonFilterCommand(
-    new TreePath("items", "0", "price")
-);
-```
-
-### JsonValidateCommand - JSON Schema検証
-
-```java
-import com.streamconverter.command.impl.json.JsonValidateCommand;
-
-// JSONスキーマで検証（静的ファクトリメソッドを使用）
-IStreamCommand validateCommand = JsonValidateCommand.create("schemas/user-schema.json");
-```
-
-## XML Commands
-
-### XmlNavigateCommand - XML要素変換
-
-```java
-import com.streamconverter.command.impl.xml.XmlNavigateCommand;
-import com.streamconverter.path.TreePath;
 import com.streamconverter.command.rule.PassThroughRule;
-
-// 特定の要素に変換ルールを適用（XML構造全体を保持）
-IStreamCommand xmlCommand = new XmlNavigateCommand(
-    new TreePath("root", "user", "name"),
-    new PassThroughRule()
-);
-```
-
-### XmlFilterCommand - XML要素抽出
-
-```java
-import com.streamconverter.command.impl.xml.XmlFilterCommand;
 import com.streamconverter.path.TreePath;
 
-// TreePathを使用してXML要素を抽出（指定した要素のみを出力）
-IStreamCommand filterCommand = new XmlFilterCommand(
-    new TreePath("root", "item")
+StreamConverter converter = StreamConverter.create(
+    JsonFilterCommand.create(TreePath.fromJson("$.user.active"), new PassThroughRule())
 );
+converter.run(inputStream, outputStream);
 ```
 
-### ValidateCommand - XML検証
+## XML 変換 + 検証
 
 ```java
+import com.streamconverter.StreamConverter;
+import com.streamconverter.command.impl.xml.ConvertCommand;
 import com.streamconverter.command.impl.xml.ValidateCommand;
 
-// XMLスキーマで検証（スキーマパスを指定）
-IStreamCommand validateCommand = new ValidateCommand("schemas/document.xsd");
+StreamConverter converter = StreamConverter.create(
+    ConvertCommand.create("transform.xslt"),
+    ValidateCommand.create("schema.xsd")
+);
+converter.run(inputStream, outputStream);
 ```
 
-## HTTP Communication
-
-### SendHttpCommand - HTTP リクエスト送信
+## MDC 伝播
 
 ```java
-import com.streamconverter.command.impl.SendHttpCommand;
-import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.StreamConverter;
 import com.streamconverter.command.impl.json.JsonNavigateCommand;
-import com.streamconverter.path.CSVPath;
+import com.streamconverter.command.rule.MdcPropagatingRule;
 import com.streamconverter.path.TreePath;
-import com.streamconverter.command.rule.PassThroughRule;
 
-// HTTP POSTリクエストを送信
-IStreamCommand httpCommand = new SendHttpCommand("https://api.example.com/process");
-
-// パイプライン例: CSV → HTTP API → JSON
-IStreamCommand[] pipeline = {
-    new CsvNavigateCommand(new CSVPath("productName"), new PassThroughRule()),
-    new SendHttpCommand("https://api.example.com/lookup"),
-    new JsonNavigateCommand(new TreePath("result"), new PassThroughRule())
-};
+StreamConverter converter = StreamConverter.create(
+    JsonNavigateCommand.create(TreePath.fromJson("$.userId"), MdcPropagatingRule.create("userId"))
+);
+converter.run(inputStream, outputStream);
 ```
-
-## Data Transformation
-
-### CharacterConvertCommand - 文字コード変換
-
-```java
-import com.streamconverter.command.impl.charcode.CharacterConvertCommand;
-
-// Shift_JIS から UTF-8 に変換（String パラメータを使用）
-IStreamCommand convertCommand = new CharacterConvertCommand("Shift_JIS", "UTF-8");
-```
-
-### LineEndingNormalizeCommand - 改行コード正規化
-
-```java
-import com.streamconverter.command.impl.LineEndingNormalizeCommand;
-import com.streamconverter.command.impl.LineEndingNormalizeCommand.LineEndingType;
-
-// 改行コードをLFに統一（列挙型を使用）
-IStreamCommand normalizeCommand = new LineEndingNormalizeCommand(LineEndingType.UNIX);
-
-// Windowsスタイル (CRLF)
-IStreamCommand windowsCommand = new LineEndingNormalizeCommand(LineEndingType.WINDOWS);
-
-// システムデフォルト
-IStreamCommand systemCommand = new LineEndingNormalizeCommand(LineEndingType.SYSTEM_DEFAULT);
-```
-
-## Pipeline Patterns
-
-### 単純なパイプライン
-
-```java
-import com.streamconverter.StreamConverter;
-import com.streamconverter.CommandResult;
-import com.streamconverter.command.IStreamCommand;
-import com.streamconverter.command.impl.csv.CsvNavigateCommand;
-import com.streamconverter.command.impl.charcode.CharacterConvertCommand;
-import com.streamconverter.path.CSVPath;
-import com.streamconverter.command.rule.PassThroughRule;
-import java.util.List;
-import java.io.InputStream;
-import java.io.OutputStream;
-
-// CSV → 変換 → 出力
-IStreamCommand[] pipeline = {
-    new CsvNavigateCommand(new CSVPath("name"), new PassThroughRule()),
-    new CharacterConvertCommand("Shift_JIS", "UTF-8")
-};
-
-StreamConverter converter = StreamConverter.create(pipeline);
-List<CommandResult> results = converter.run(inputStream, outputStream);
-```
-
-### ExecutionContext を使用したパイプライン
-
-ExecutionContext の詳細な使用方法は [Basic Usage - Context and Metrics](../quickstart/basic-usage.md#3-context-and-metrics) を参照してください。
-
-```java
-import com.streamconverter.ExecutionContext;
-import com.streamconverter.StreamConverter;
-import com.streamconverter.CommandResult;
-import java.util.List;
-
-// コンテキスト作成
-ExecutionContext context = ExecutionContext.builder()
-    .globalContext("requestId", "REQ-12345")
-    .globalContext("userId", "user789")
-    .build();
-
-// コンテキスト付きパイプライン実行
-StreamConverter converter = StreamConverter.createWithContext(context, pipeline);
-List<CommandResult> results = converter.run(inputStream, outputStream);
-```
-
-### 複雑なパイプライン例
-
-```java
-import com.streamconverter.ExecutionContext;
-import com.streamconverter.StreamConverter;
-import com.streamconverter.command.IStreamCommand;
-import com.streamconverter.command.impl.csv.CsvNavigateCommand;
-import com.streamconverter.command.impl.SendHttpCommand;
-import com.streamconverter.command.impl.json.JsonNavigateCommand;
-import com.streamconverter.command.impl.json.JsonValidateCommand;
-import com.streamconverter.path.CSVPath;
-import com.streamconverter.path.TreePath;
-import com.streamconverter.command.rule.PassThroughRule;
-import java.util.UUID;
-
-// CSV → HTTP API → JSON → 検証 → 出力
-IStreamCommand[] complexPipeline = {
-    new CsvNavigateCommand(new CSVPath("productId"), new PassThroughRule()),
-    new SendHttpCommand("https://api.example.com/products"),
-    new JsonNavigateCommand(new TreePath("product", "details"), new PassThroughRule()),
-    JsonValidateCommand.create("schemas/product-schema.json")
-};
-
-ExecutionContext context = ExecutionContext.builder()
-    .globalContext("traceId", UUID.randomUUID().toString())
-    .build();
-
-StreamConverter converter = StreamConverter.createWithContext(context, complexPipeline);
-```
-
-## エラーハンドリング
-
-### CommandResult を使用した結果確認
-
-```java
-import com.streamconverter.CommandResult;
-import java.util.List;
-
-List<CommandResult> results = converter.run(inputStream, outputStream);
-
-for (CommandResult result : results) {
-    if (!result.isSuccessful()) {
-        System.err.println("Command failed: " + result.getCommandName());
-        System.err.println("Error: " + result.getErrorMessage());
-    } else {
-        System.out.println("Success: " + result.getCommandName() +
-                         " (duration: " + result.getExecutionTimeMs() + "ms)");
-    }
-}
-```
-
-### try-with-resources パターン
-
-```java
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.IOException;
-import com.streamconverter.StreamConverter;
-import com.streamconverter.CommandResult;
-import com.streamconverter.command.IStreamCommand;
-import java.util.List;
-
-try (InputStream input = new FileInputStream("input.csv");
-     OutputStream output = new FileOutputStream("output.txt")) {
-
-    StreamConverter converter = StreamConverter.create(pipeline);
-    List<CommandResult> results = converter.run(input, output);
-
-    // 結果を確認
-    boolean allSuccessful = results.stream().allMatch(CommandResult::isSuccessful);
-    if (!allSuccessful) {
-        throw new RuntimeException("Pipeline execution failed");
-    }
-
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-## 関連ドキュメント
-
-- [Basic Usage](../quickstart/basic-usage.md) - 初心者向けチュートリアル
-- [ARCHITECTURE.md](../ARCHITECTURE.md) - アーキテクチャ詳細
-- [VALIDATION.md](../features/VALIDATION.md) - バリデーション機能の詳細
-- [AUTO_LOGGING.md](../AUTO_LOGGING.md) - ロギング機能
-- [COMMAND_REFERENCE.md](COMMAND_REFERENCE.md) - Gradle コマンドリファレンス

--- a/docs/reference/COMMAND_EXAMPLES.md
+++ b/docs/reference/COMMAND_EXAMPLES.md
@@ -2,7 +2,7 @@
 
 現行 API（`StreamConverter.create(...)` + `void run(...)`）のサンプルです。
 
-## CSV 列抽出
+## CSV 列変換/ナビゲーション
 
 ```java
 import com.streamconverter.StreamConverter;

--- a/docs/reference/COMMAND_EXAMPLES.md
+++ b/docs/reference/COMMAND_EXAMPLES.md
@@ -11,7 +11,7 @@ import com.streamconverter.command.rule.impl.string.TrimRule;
 import com.streamconverter.path.CSVPath;
 
 StreamConverter converter = StreamConverter.create(
-    CsvNavigateCommand.create(CSVPath.fromHeaderName("name"), new TrimRule())
+    CsvNavigateCommand.create(CSVPath.of("name"), new TrimRule())
 );
 converter.run(inputStream, outputStream);
 ```

--- a/docs/reference/COMMAND_EXAMPLES.md
+++ b/docs/reference/COMMAND_EXAMPLES.md
@@ -21,11 +21,10 @@ converter.run(inputStream, outputStream);
 ```java
 import com.streamconverter.StreamConverter;
 import com.streamconverter.command.impl.json.JsonFilterCommand;
-import com.streamconverter.command.rule.PassThroughRule;
 import com.streamconverter.path.TreePath;
 
 StreamConverter converter = StreamConverter.create(
-    JsonFilterCommand.create(TreePath.fromJson("$.user.active"), new PassThroughRule())
+    JsonFilterCommand.create(TreePath.fromJson("$.user.active"))
 );
 converter.run(inputStream, outputStream);
 ```
@@ -36,9 +35,11 @@ converter.run(inputStream, outputStream);
 import com.streamconverter.StreamConverter;
 import com.streamconverter.command.impl.xml.ConvertCommand;
 import com.streamconverter.command.impl.xml.ValidateCommand;
+import com.streamconverter.command.rule.impl.string.TrimRule;
+import com.streamconverter.path.TreePath;
 
 StreamConverter converter = StreamConverter.create(
-    ConvertCommand.create("transform.xslt"),
+    ConvertCommand.create(new TrimRule(), TreePath.fromXml("root/element")),
     ValidateCommand.create("schema.xsd")
 );
 converter.run(inputStream, outputStream);

--- a/docs/reference/COMMAND_REFERENCE.md
+++ b/docs/reference/COMMAND_REFERENCE.md
@@ -94,7 +94,7 @@ SpotBugs 静的解析を実行します。
 ## Web Module Commands
 
 ### `./gradlew :streamconverter-web:bootRun`
-Spring Boot アプリケーションを起動します。
+Web モジュールの Spring Boot アプリケーションを起動します。
 
 デフォルトポート: `http://localhost:8080`
 
@@ -102,13 +102,12 @@ Spring Boot アプリケーションを起動します。
 
 ```bash
 # 基本的な使用例を実行
-./gradlew runQuickStart
-./gradlew runAutoLoggingDemo
-./gradlew runContextDemo
-./gradlew runMDC
-./gradlew runDataProcessing
-./gradlew runDirectApiDemo
-./gradlew runDemo
+./gradlew :streamconverter-examples:runQuickStart
+./gradlew :streamconverter-examples:runMDC
+./gradlew :streamconverter-examples:runComplexPipeline
+./gradlew :streamconverter-examples:runValidationExample
+./gradlew :streamconverter-examples:runDatabaseRuleDemo
+./gradlew :streamconverter-examples:runBasicUsageExamples
 ```
 
 ## Git Commands


### PR DESCRIPTION
### Motivation
- Several public docs and AI-assistant reference files described removed or renamed APIs (`ExecutionContext`, `createWithContext`, `CommandResult`) and non-existent commands, creating a large mismatch with the current codebase.
- Web API and examples referenced non-module-qualified Gradle commands and example tasks that no longer match the multi-module Gradle layout.
- AI-assistant guidance (`CLAUDE_*`) and handbook content could mislead contributors and automated workflows if left pointing at obsolete APIs or missing commands.
- Code examples in `COMMAND_EXAMPLES.md` used non-existent factory signatures (`ConvertCommand.create(String)`, `JsonFilterCommand.create(IPath, IRule)`) and the Web API docs described endpoints as "抽出（extraction）" when the implementation preserves the full input structure.

### Description
- Updated `README.md` to reflect the actual module layout and to show the current usage pattern `StreamConverter.create(...)` + `void run(...)`.
- Rewrote `docs/WEB_API.md`, `docs/handbook/web-api.md`, and `docs/reference/COMMAND_REFERENCE.md` to use module-qualified Gradle commands (e.g. `:streamconverter-web:bootRun`) and to list only existing endpoints and test/run tasks.
- Replaced outdated auto-logging and command example content (`docs/AUTO_LOGGING.md`, `docs/reference/COMMAND_EXAMPLES.md`, and `docs/reference/CLAUDE_*`) to document the current `PipelineContext` / `MdcPropagatingRule` / `PipelineContextTurboFilter` model and removed references to missing commands/classes.
- Adjusted example Gradle task listings to those actually provided by `streamconverter-examples` and made small editorial cleanups across the referenced docs.
- Fixed `docs/reference/COMMAND_EXAMPLES.md` XML example to use the correct `ConvertCommand.create(IRule, TreePath)` signature (`ConvertCommand.create(new TrimRule(), TreePath.fromXml("root/element"))`) instead of the non-existent `ConvertCommand.create(String)`.
- Fixed `docs/reference/COMMAND_EXAMPLES.md` JSON filter example to use `JsonFilterCommand.create(TreePath.fromJson("..."))` (path-only factory) and removed the invalid `PassThroughRule` argument.
- Updated `docs/WEB_API.md` CSV and JSON endpoint headings from "抽出" to "ナビゲーション（構造保持）" with clarifying descriptions matching the actual `CsvNavigateCommand`/`JsonNavigateCommand` + `PassThroughRule` behaviour.

### Testing
- Ran `./gradlew :streamconverter-examples:tasks --all` and verified the documented example tasks (`runQuickStart`, `runMDC`, `runComplexPipeline`, `runValidationExample`, `runDatabaseRuleDemo`, `runBasicUsageExamples`) are present (succeeded).