### PR TITLE
[codex] test(core): add streaming contract coverage for commands

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -35,6 +35,7 @@
 
 ## 🧪 Quality & Testing
 - **[reference/TESTING.md](reference/TESTING.md)**: テスト戦略と実行方法
+  ストリーミング契約テストの目的、判定分類、実行コマンドを含む
 - **[reference/TEST_INVENTORY.md](reference/TEST_INVENTORY.md)**: テストケース一覧
 - **[reference/MEMORY_EFFICIENCY_TEST_STRATEGY.md](reference/MEMORY_EFFICIENCY_TEST_STRATEGY.md)**: 大容量データ検証
 - **[reference/CROSS_PLATFORM_TEST_CONSIDERATIONS.md](reference/CROSS_PLATFORM_TEST_CONSIDERATIONS.md)**: マルチプラットフォーム対応

--- a/docs/reference/TESTING.md
+++ b/docs/reference/TESTING.md
@@ -56,6 +56,23 @@ StreamConverterプロジェクトでは、以下の包括的なテストアプ�
 - **Mockito**: モックオブジェクトによる依存関係の分離
 - **Awaitility**: 非同期処理のテスト支援
 
+#### 6. **ストリーミング契約テスト (Streaming Contract Tests)**
+- **対象**: トップレベルの `IStreamCommand` / `AbstractStreamCommand` / `ConsumerCommand` 実装
+- **目的**: コマンドが「入力完了前に出力を開始するか」を機械的に確認し、非ストリーミング実装の混入を防ぐ
+- **検証方法**:
+  - 入力ストリームは最初のチャンクだけ返し、その後はブロックする
+  - 出力ストリームは最初の `write()` を検知する
+  - 入力がまだ止まっている間に出力が始まれば `STREAMING_COMPLIANT`
+  - 仕様上許可された全量バッファリングは `ALLOWED_FULL_BUFFERING`
+  - 実行して非準拠だったものは `KNOWN_STREAMING_VIOLATION`
+- **重要**:
+  - `KNOWN_STREAMING_VIOLATION` は「未確認」ではなく「実測済みの既知違反」
+  - このテストはメモリ安全性や性能全体を証明するものではなく、「出力開始タイミング」の契約を見ている
+- **実装場所**:
+  - `streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractTest.java`
+  - `streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandImplementationDiscovery.java`
+  - `streamconverter-core/src/test/java/com/streamconverter/command/contract/StreamingExpectation.java`
+
 ## 📁 テスト構造
 
 ### ディレクトリ構成
@@ -142,6 +159,10 @@ src/test/resources/
 
 # 並行テスト実行（パフォーマンス向上）
 ./gradlew test --parallel --max-workers=4
+
+# ストリーミング契約テスト
+./gradlew :streamconverter-core:test --tests com.streamconverter.command.contract.CommandStreamingContractTest
+./gradlew :streamconverter-core:test --tests com.streamconverter.command.contract.CommandImplementationDiscoveryTest
 ```
 
 ### 継続的インテグレーション

--- a/streamconverter-core/build.gradle.kts
+++ b/streamconverter-core/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
 
     // JUnit 5 の依存関係（テスト用）
     testImplementation(platform("org.junit:junit-bom:6.0.3"))
+    testImplementation(platform("org.springframework.boot:spring-boot-dependencies:4.0.3"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.pitest:pitest-junit5-plugin:1.2.3")
@@ -62,9 +63,13 @@ dependencies {
     // Mockito の依存関係（テスト用）
     testImplementation("org.mockito:mockito-core:5.23.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.23.0")
+    testImplementation("org.springframework:spring-webflux")
+    testImplementation("org.springframework:spring-test")
 
     // In-memory filesystem for cross-platform file system tests
     testImplementation("com.google.jimfs:jimfs:1.3.1")
+    testImplementation(project(":streamconverter-http"))
+    testImplementation(project(":streamconverter-tools"))
 }
 
 // Spotless configuration for code formatting
@@ -217,4 +222,3 @@ tasks.spotbugsTest {
 tasks.named("check") {
     dependsOn("spotlessApply")
 }
-

--- a/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandImplementationDiscovery.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandImplementationDiscovery.java
@@ -1,0 +1,74 @@
+package com.streamconverter.command.contract;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+final class CommandImplementationDiscovery {
+  private static final Pattern PACKAGE_PATTERN =
+      Pattern.compile("(?m)^\\s*package\\s+([\\w.]+)\\s*;");
+  private static final Pattern STREAM_COMMAND_CLASS_PATTERN =
+      Pattern.compile(
+          "(?ms)^(?:public\\s+)?(?:final\\s+)?(?:abstract\\s+)?class\\s+(\\w+)\\b"
+              + "(?:(?!\\{).|\\R)*?"
+              + "(?:extends\\s+(AbstractStreamCommand|ConsumerCommand)\\b|implements\\s+IStreamCommand\\b)");
+
+  private CommandImplementationDiscovery() {}
+
+  static List<DiscoveredCommand> discover(Path repositoryRoot) throws IOException {
+    try (Stream<Path> pathStream = Files.walk(repositoryRoot)) {
+      return pathStream
+          .filter(Files::isRegularFile)
+          .filter(CommandImplementationDiscovery::isMainJavaSource)
+          .sorted(Comparator.naturalOrder())
+          .map(CommandImplementationDiscovery::parseDiscoveredCommand)
+          .filter(commandClass -> commandClass != null)
+          .toList();
+    }
+  }
+
+  private static boolean isMainJavaSource(Path sourceFile) {
+    String normalizedPath = sourceFile.normalize().toString().replace('\\', '/');
+    return normalizedPath.contains("/src/main/java/") && normalizedPath.endsWith(".java");
+  }
+
+  private static DiscoveredCommand parseDiscoveredCommand(Path sourceFile) {
+    try {
+      String source = Files.readString(sourceFile);
+      if (looksAbstract(source)) {
+        return null;
+      }
+
+      String packageName = extractPackageName(source);
+      String simpleName = extractTopLevelCommandClassName(source);
+      if (packageName == null || simpleName == null) {
+        return null;
+      }
+
+      return new DiscoveredCommand(packageName + "." + simpleName, simpleName);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read command source " + sourceFile, e);
+    }
+  }
+
+  private static boolean looksAbstract(String source) {
+    return source.matches("(?s).*\\babstract\\s+class\\b.*");
+  }
+
+  private static String extractPackageName(String source) {
+    Matcher matcher = PACKAGE_PATTERN.matcher(source);
+    return matcher.find() ? matcher.group(1) : null;
+  }
+
+  private static String extractTopLevelCommandClassName(String source) {
+    Matcher matcher = STREAM_COMMAND_CLASS_PATTERN.matcher(source);
+    return matcher.find() ? matcher.group(1) : null;
+  }
+
+  record DiscoveredCommand(String fqcn, String simpleName) {}
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandImplementationDiscovery.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandImplementationDiscovery.java
@@ -5,18 +5,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 final class CommandImplementationDiscovery {
   private static final Pattern PACKAGE_PATTERN =
       Pattern.compile("(?m)^\\s*package\\s+([\\w.]+)\\s*;");
-  private static final Pattern STREAM_COMMAND_CLASS_PATTERN =
+  private static final Pattern TOP_LEVEL_CLASS_PATTERN =
       Pattern.compile(
-          "(?ms)^(?:public\\s+)?(?:final\\s+)?(?:abstract\\s+)?class\\s+(\\w+)\\b"
-              + "(?:(?!\\{).|\\R)*?"
-              + "(?:extends\\s+(AbstractStreamCommand|ConsumerCommand)\\b|implements\\s+IStreamCommand\\b)");
+          "(?m)^\\s*(?:public\\s+)?(?:final\\s+)?(?:abstract\\s+)?class\\s+(\\w+)\\b([^\\{]*)\\{");
 
   private CommandImplementationDiscovery() {}
 
@@ -40,10 +37,6 @@ final class CommandImplementationDiscovery {
   private static DiscoveredCommand parseDiscoveredCommand(Path sourceFile) {
     try {
       String source = Files.readString(sourceFile);
-      if (looksAbstract(source)) {
-        return null;
-      }
-
       String packageName = extractPackageName(source);
       String simpleName = extractTopLevelCommandClassName(source);
       if (packageName == null || simpleName == null) {
@@ -56,18 +49,37 @@ final class CommandImplementationDiscovery {
     }
   }
 
-  private static boolean looksAbstract(String source) {
-    return source.matches("(?s).*\\babstract\\s+class\\b.*");
-  }
-
   private static String extractPackageName(String source) {
-    Matcher matcher = PACKAGE_PATTERN.matcher(source);
+    java.util.regex.Matcher matcher = PACKAGE_PATTERN.matcher(source);
     return matcher.find() ? matcher.group(1) : null;
   }
 
   private static String extractTopLevelCommandClassName(String source) {
-    Matcher matcher = STREAM_COMMAND_CLASS_PATTERN.matcher(source);
-    return matcher.find() ? matcher.group(1) : null;
+    java.util.regex.Matcher matcher = TOP_LEVEL_CLASS_PATTERN.matcher(source);
+    if (!matcher.find()) {
+      return null;
+    }
+
+    String className = matcher.group(1);
+    String classHeaderTail = matcher.group(2);
+    String classDeclaration = matcher.group(0);
+
+    if (classDeclaration.contains("abstract class")) {
+      return null;
+    }
+
+    if (!isStreamCommandDeclaration(classHeaderTail)) {
+      return null;
+    }
+
+    return className;
+  }
+
+  private static boolean isStreamCommandDeclaration(String classHeaderTail) {
+    return classHeaderTail.contains("extends AbstractStreamCommand")
+        || classHeaderTail.contains("extends ConsumerCommand")
+        || classHeaderTail.contains("implements IStreamCommand")
+        || classHeaderTail.contains(", IStreamCommand");
   }
 
   record DiscoveredCommand(String fqcn, String simpleName) {}

--- a/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandImplementationDiscoveryTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandImplementationDiscoveryTest.java
@@ -1,0 +1,57 @@
+package com.streamconverter.command.contract;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CommandImplementationDiscoveryTest {
+
+  private static final Path REPOSITORY_ROOT = Path.of("..").normalize();
+
+  @Test
+  void discoversTopLevelStreamCommandsAcrossModules() throws IOException {
+    List<String> discovered =
+        CommandImplementationDiscovery.discover(REPOSITORY_ROOT).stream()
+            .map(CommandImplementationDiscovery.DiscoveredCommand::fqcn)
+            .toList();
+
+    assertAll(
+        () ->
+            assertTrue(
+                discovered.contains("com.streamconverter.command.impl.SendHttpCommand"),
+                "streamconverter-http の command 実装を検出できる必要がある"),
+        () ->
+            assertTrue(
+                discovered.contains("com.streamconverter.pmd.command.PmdXmlToMarkdownCommand"),
+                "streamconverter-tools の PMD command 実装を検出できる必要がある"),
+        () ->
+            assertTrue(
+                discovered.contains("com.streamconverter.sloc.command.SlocAggregateCommand"),
+                "streamconverter-tools の SLOC command 実装を検出できる必要がある"));
+  }
+
+  @Test
+  void ignoresNonTopLevelAndAbstractCommandShapes() throws IOException {
+    List<String> discovered =
+        CommandImplementationDiscovery.discover(REPOSITORY_ROOT).stream()
+            .map(CommandImplementationDiscovery.DiscoveredCommand::fqcn)
+            .toList();
+
+    assertAll(
+        () ->
+            assertFalse(
+                discovered.contains("com.streamconverter.examples.PipelineBasicsExample"),
+                "example 内の内部クラスをトップレベル command として誤検出してはいけない"),
+        () ->
+            assertFalse(
+                discovered.contains("com.streamconverter.command.AbstractStreamCommand"),
+                "抽象基底クラスを command 実装として扱ってはいけない"),
+        () ->
+            assertFalse(
+                discovered.contains("com.streamconverter.command.ConsumerCommand"),
+                "抽象 consumer 基底クラスを command 実装として扱ってはいけない"));
+  }
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractProvider.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractProvider.java
@@ -1,0 +1,19 @@
+package com.streamconverter.command.contract;
+
+import com.streamconverter.command.IStreamCommand;
+
+/** Provides the command instance and probe input used by the streaming contract tests. */
+interface CommandStreamingContractProvider {
+
+  IStreamCommand createCommand();
+
+  byte[] sampleInput();
+
+  int firstChunkSize();
+
+  StreamingExpectation expectation();
+
+  default String exemptionReason() {
+    return "";
+  }
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractProvider.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractProvider.java
@@ -2,7 +2,20 @@ package com.streamconverter.command.contract;
 
 import com.streamconverter.command.IStreamCommand;
 
-/** Provides the command instance and probe input used by the streaming contract tests. */
+/**
+ * Provides the command instance and probe input used by the streaming contract tests.
+ *
+ * <p>The probe intentionally blocks the input stream after an initial chunk and observes whether
+ * the command starts writing output before the remaining input is released. Providers therefore
+ * need to supply:
+ *
+ * <ul>
+ *   <li>a real command instance
+ *   <li>sample input large enough to exercise the command beyond its first read
+ *   <li>a first-chunk size that leaves meaningful unread input behind for the probe
+ *   <li>a classification that reflects confirmed behavior, not assumptions
+ * </ul>
+ */
 interface CommandStreamingContractProvider {
 
   IStreamCommand createCommand();
@@ -13,7 +26,18 @@ interface CommandStreamingContractProvider {
 
   StreamingExpectation expectation();
 
+  /** Required for every non-compliant classification so future readers know why it is not green. */
   default String exemptionReason() {
+    return "";
+  }
+
+  /** Rare escape hatch for commands that cannot be executed by this in-process probe. */
+  default boolean supportsProbeExecution() {
+    return true;
+  }
+
+  /** Required when {@link #supportsProbeExecution()} is false. */
+  default String probeSkipReason() {
     return "";
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractProviders.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractProviders.java
@@ -1,0 +1,354 @@
+package com.streamconverter.command.contract;
+
+import com.streamconverter.command.IStreamCommand;
+import com.streamconverter.command.impl.FileBufferCommand;
+import com.streamconverter.command.impl.LineEndingNormalizeCommand;
+import com.streamconverter.command.impl.LineEndingNormalizeCommand.LineEndingType;
+import com.streamconverter.command.impl.charcode.CharacterConvertCommand;
+import com.streamconverter.command.impl.csv.CsvFilterCommand;
+import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.csv.CsvValidateCommand;
+import com.streamconverter.command.impl.json.JsonFilterCommand;
+import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.xml.ConvertCommand;
+import com.streamconverter.command.impl.xml.ValidateCommand;
+import com.streamconverter.command.impl.xml.XmlFilterCommand;
+import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.command.rule.TestRule;
+import com.streamconverter.path.CSVPath;
+import com.streamconverter.path.TreePath;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+final class CommandStreamingContractProviders {
+  private CommandStreamingContractProviders() {}
+
+  static byte[] utf8(String value) {
+    return value.getBytes(StandardCharsets.UTF_8);
+  }
+
+  static byte[] resourceBytes(String resourceName) {
+    try (InputStream inputStream =
+        CommandStreamingContractProviders.class
+            .getClassLoader()
+            .getResourceAsStream(resourceName)) {
+      if (inputStream == null) {
+        throw new IllegalStateException("Missing test resource: " + resourceName);
+      }
+      return inputStream.readAllBytes();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read test resource: " + resourceName, e);
+    }
+  }
+}
+
+final class CharacterConvertCommandStreamingContractProvider
+    implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return CharacterConvertCommand.create("UTF-8", "UTF-8");
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    return CommandStreamingContractProviders.utf8(
+        "alpha,original,one\nbeta,original,two\ngamma,original,three\n");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 24;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+  }
+}
+
+final class LineEndingNormalizeCommandStreamingContractProvider
+    implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return new LineEndingNormalizeCommand(LineEndingType.UNIX);
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    String largeBlock = "line-content-".repeat(1200);
+    return CommandStreamingContractProviders.utf8(
+        largeBlock + "\r\n" + largeBlock + "\r\n" + "tail-line\r\n");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 12_000;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+  }
+}
+
+final class CsvFilterCommandStreamingContractProvider implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return CsvFilterCommand.create(CSVPath.of("1"), false);
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    String largeCell = "selected-value-".repeat(900);
+    return CommandStreamingContractProviders.utf8("1," + largeCell + ",30\n2,tail,40\n3,tail,50\n");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 12_000;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.EXEMPT_FROM_STREAMING_CONTRACT;
+  }
+
+  @Override
+  public String exemptionReason() {
+    return "Current implementation does not emit raw output before input completion under the strict streaming probe.";
+  }
+}
+
+final class CsvNavigateCommandStreamingContractProvider
+    implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return CsvNavigateCommand.create(CSVPath.of("1"), new TestRule("original", "transformed"));
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    String largeHeader = "header-name-".repeat(900);
+    return CommandStreamingContractProviders.utf8(
+        "id," + largeHeader + ",age\n1,original,30\n2,Bob,40\n3,Carol,50\n");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 12_000;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+  }
+}
+
+final class CsvValidateCommandStreamingContractProvider
+    implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return CsvValidateCommand.create(true, 5, "id", "name");
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    return CommandStreamingContractProviders.utf8(
+        "id,name,email\n1,Alice,a@example.com\n2,Bob,b@example.com\n3,Carol,c@example.com\n");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 20;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+  }
+}
+
+final class JsonNavigateCommandStreamingContractProvider
+    implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return JsonNavigateCommand.create(
+        TreePath.fromJson("$.user.name"), new TestRule("original", "transformed"));
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    String largeValue = "original".repeat(1400);
+    return CommandStreamingContractProviders.utf8(
+        "{\"user\":{\"name\":\"" + largeValue + "\",\"role\":\"admin\"},\"tail\":\"value\"}");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 12_500;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+  }
+}
+
+final class JsonFilterCommandStreamingContractProvider implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return JsonFilterCommand.create(TreePath.fromJson("$.user.name"));
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    String largeValue = "AliceValue".repeat(1400);
+    return CommandStreamingContractProviders.utf8(
+        "{\"user\":{\"name\":\"" + largeValue + "\",\"role\":\"admin\"},\"tail\":\"value\"}");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 12_500;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.EXEMPT_FROM_STREAMING_CONTRACT;
+  }
+
+  @Override
+  public String exemptionReason() {
+    return "Current implementation does not emit raw output before input completion under the strict streaming probe.";
+  }
+}
+
+final class ConvertCommandStreamingContractProvider implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return ConvertCommand.create(
+        new TestRule("original", "transformed"), TreePath.fromXml("root/item"));
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    String largeText = "original".repeat(1600);
+    return CommandStreamingContractProviders.utf8(
+        "<root><item>" + largeText + "</item><item>second</item><tail>z</tail></root>");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 13_000;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+  }
+}
+
+final class ValidateCommandStreamingContractProvider implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return ValidateCommand.create("test-schema.xsd");
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    return CommandStreamingContractProviders.resourceBytes("valid-test.xml");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 64;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+  }
+}
+
+final class XmlFilterCommandStreamingContractProvider implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return XmlFilterCommand.create(TreePath.fromXml("root/item"));
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    return CommandStreamingContractProviders.utf8(
+        "<root><item>first</item><item>second</item><tail>done</tail></root>");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 24;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.EXEMPT_FROM_STREAMING_CONTRACT;
+  }
+
+  @Override
+  public String exemptionReason() {
+    return "Current implementation accumulates extracted XML fragments before writing them.";
+  }
+}
+
+final class XmlNavigateCommandStreamingContractProvider
+    implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return XmlNavigateCommand.create(
+        TreePath.fromXml("root/item"), new TestRule("original", "transformed"));
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    String largeText = "original".repeat(1600);
+    return CommandStreamingContractProviders.utf8(
+        "<root><item>" + largeText + "</item><item>second</item><tail>done</tail></root>");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 13_000;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+  }
+}
+
+final class FileBufferCommandStreamingContractProvider implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return FileBufferCommand.create();
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    return CommandStreamingContractProviders.utf8(
+        "buffered-1\nbuffered-2\nbuffered-3\nbuffered-4\nbuffered-5\n");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 20;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.EXEMPT_FROM_STREAMING_CONTRACT;
+  }
+
+  @Override
+  public String exemptionReason() {
+    return "FileBufferCommand intentionally writes the entire input to a temp file before emitting output.";
+  }
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractProviders.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractProviders.java
@@ -4,6 +4,7 @@ import com.streamconverter.command.IStreamCommand;
 import com.streamconverter.command.impl.FileBufferCommand;
 import com.streamconverter.command.impl.LineEndingNormalizeCommand;
 import com.streamconverter.command.impl.LineEndingNormalizeCommand.LineEndingType;
+import com.streamconverter.command.impl.SendHttpCommand;
 import com.streamconverter.command.impl.charcode.CharacterConvertCommand;
 import com.streamconverter.command.impl.csv.CsvFilterCommand;
 import com.streamconverter.command.impl.csv.CsvNavigateCommand;
@@ -17,9 +18,37 @@ import com.streamconverter.command.impl.xml.XmlNavigateCommand;
 import com.streamconverter.command.rule.TestRule;
 import com.streamconverter.path.CSVPath;
 import com.streamconverter.path.TreePath;
+import com.streamconverter.pmd.PmdViolation;
+import com.streamconverter.pmd.command.PmdXmlToMarkdownCommand;
+import com.streamconverter.pmd.command.PmdXmlToViolationsCommand;
+import com.streamconverter.sloc.ModuleSloc;
+import com.streamconverter.sloc.command.JacocoXmlToModuleSlocCommand;
+import com.streamconverter.sloc.command.ModuleXmlConcatCommand;
+import com.streamconverter.sloc.command.SlocAggregateCommand;
+import com.streamconverter.sloc.command.SlocReportFormatCommand;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectOutputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.client.reactive.MockClientHttpRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 final class CommandStreamingContractProviders {
   private CommandStreamingContractProviders() {}
@@ -40,6 +69,71 @@ final class CommandStreamingContractProviders {
     } catch (IOException e) {
       throw new IllegalStateException("Failed to read test resource: " + resourceName, e);
     }
+  }
+
+  static byte[] serializeObjects(List<?> objects) {
+    try {
+      ByteArrayOutputStream output = new ByteArrayOutputStream();
+      try (ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+        for (Object object : objects) {
+          objectOutput.writeObject(object);
+        }
+      }
+      return output.toByteArray();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to serialize contract test input", e);
+    }
+  }
+
+  static Path createTempDirectory(String prefix) {
+    try {
+      return Files.createTempDirectory(prefix);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to create temp directory for contract test", e);
+    }
+  }
+
+  static void writeString(Path path, String value) {
+    try {
+      Files.createDirectories(path.getParent());
+      Files.writeString(path, value, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to prepare contract test input file: " + path, e);
+    }
+  }
+
+  static WebClient sendHttpEchoWebClient(String responsePrefix) {
+    DefaultDataBufferFactory bufferFactory = new DefaultDataBufferFactory();
+    ExchangeFunction exchangeFunction =
+        request -> {
+          AtomicReference<String> requestBody = new AtomicReference<>("");
+          MockClientHttpRequest mockRequest =
+              new MockClientHttpRequest(HttpMethod.POST, URI.create(request.url().toString()));
+          mockRequest.setWriteHandler(
+              body ->
+                  DataBufferUtils.join(body)
+                      .doOnNext(
+                          dataBuffer -> {
+                            byte[] bytes = new byte[dataBuffer.readableByteCount()];
+                            dataBuffer.read(bytes);
+                            requestBody.set(new String(bytes, StandardCharsets.UTF_8));
+                            DataBufferUtils.release(dataBuffer);
+                          })
+                      .then());
+          return request
+              .writeTo(mockRequest, ExchangeStrategies.withDefaults())
+              .then(Mono.fromSupplier(requestBody::get))
+              .map(
+                  body ->
+                      ClientResponse.create(HttpStatus.OK)
+                          .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN_VALUE)
+                          .body(
+                              Flux.just(
+                                  bufferFactory.wrap(
+                                      (responsePrefix + body).getBytes(StandardCharsets.UTF_8))))
+                          .build());
+        };
+    return WebClient.builder().exchangeFunction(exchangeFunction).build();
   }
 }
 
@@ -63,7 +157,7 @@ final class CharacterConvertCommandStreamingContractProvider
 
   @Override
   public StreamingExpectation expectation() {
-    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+    return StreamingExpectation.STREAMING_COMPLIANT;
   }
 }
 
@@ -88,7 +182,7 @@ final class LineEndingNormalizeCommandStreamingContractProvider
 
   @Override
   public StreamingExpectation expectation() {
-    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+    return StreamingExpectation.STREAMING_COMPLIANT;
   }
 }
 
@@ -111,7 +205,7 @@ final class CsvFilterCommandStreamingContractProvider implements CommandStreamin
 
   @Override
   public StreamingExpectation expectation() {
-    return StreamingExpectation.EXEMPT_FROM_STREAMING_CONTRACT;
+    return StreamingExpectation.ALLOWED_FULL_BUFFERING;
   }
 
   @Override
@@ -141,7 +235,7 @@ final class CsvNavigateCommandStreamingContractProvider
 
   @Override
   public StreamingExpectation expectation() {
-    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+    return StreamingExpectation.STREAMING_COMPLIANT;
   }
 }
 
@@ -165,7 +259,7 @@ final class CsvValidateCommandStreamingContractProvider
 
   @Override
   public StreamingExpectation expectation() {
-    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+    return StreamingExpectation.STREAMING_COMPLIANT;
   }
 }
 
@@ -191,7 +285,7 @@ final class JsonNavigateCommandStreamingContractProvider
 
   @Override
   public StreamingExpectation expectation() {
-    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+    return StreamingExpectation.STREAMING_COMPLIANT;
   }
 }
 
@@ -215,7 +309,7 @@ final class JsonFilterCommandStreamingContractProvider implements CommandStreami
 
   @Override
   public StreamingExpectation expectation() {
-    return StreamingExpectation.EXEMPT_FROM_STREAMING_CONTRACT;
+    return StreamingExpectation.KNOWN_STREAMING_VIOLATION;
   }
 
   @Override
@@ -245,7 +339,7 @@ final class ConvertCommandStreamingContractProvider implements CommandStreamingC
 
   @Override
   public StreamingExpectation expectation() {
-    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+    return StreamingExpectation.STREAMING_COMPLIANT;
   }
 }
 
@@ -267,7 +361,7 @@ final class ValidateCommandStreamingContractProvider implements CommandStreaming
 
   @Override
   public StreamingExpectation expectation() {
-    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+    return StreamingExpectation.STREAMING_COMPLIANT;
   }
 }
 
@@ -290,7 +384,7 @@ final class XmlFilterCommandStreamingContractProvider implements CommandStreamin
 
   @Override
   public StreamingExpectation expectation() {
-    return StreamingExpectation.EXEMPT_FROM_STREAMING_CONTRACT;
+    return StreamingExpectation.KNOWN_STREAMING_VIOLATION;
   }
 
   @Override
@@ -321,7 +415,7 @@ final class XmlNavigateCommandStreamingContractProvider
 
   @Override
   public StreamingExpectation expectation() {
-    return StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE;
+    return StreamingExpectation.STREAMING_COMPLIANT;
   }
 }
 
@@ -344,11 +438,252 @@ final class FileBufferCommandStreamingContractProvider implements CommandStreami
 
   @Override
   public StreamingExpectation expectation() {
-    return StreamingExpectation.EXEMPT_FROM_STREAMING_CONTRACT;
+    return StreamingExpectation.KNOWN_STREAMING_VIOLATION;
   }
 
   @Override
   public String exemptionReason() {
     return "FileBufferCommand intentionally writes the entire input to a temp file before emitting output.";
+  }
+}
+
+final class SendHttpCommandStreamingContractProvider implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return new SendHttpCommand(
+        "https://example.com/post",
+        CommandStreamingContractProviders.sendHttpEchoWebClient("ack:"));
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    return CommandStreamingContractProviders.utf8("{\"message\":\"probe\"}");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 8;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.KNOWN_STREAMING_VIOLATION;
+  }
+
+  @Override
+  public String exemptionReason() {
+    return "Current SendHttpCommand behavior starts processing the HTTP response after the request body upload completes.";
+  }
+}
+
+final class PmdXmlToMarkdownCommandStreamingContractProvider
+    implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return new PmdXmlToMarkdownCommand();
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    return CommandStreamingContractProviders.serializeObjects(
+        List.of(
+            new PmdViolation(
+                "streamconverter-core/src/main/java/Foo.java",
+                10,
+                "UnusedVariable",
+                "Best Practices",
+                3,
+                "Avoid unused variables. ".repeat(300),
+                "Foo",
+                "bar",
+                "x"),
+            new PmdViolation(
+                "streamconverter-tools/src/main/java/Bar.java",
+                20,
+                "LongMethod",
+                "Design",
+                2,
+                "Method too long. ".repeat(300),
+                "Bar",
+                "baz",
+                "")));
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 3_000;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.KNOWN_STREAMING_VIOLATION;
+  }
+
+  @Override
+  public String exemptionReason() {
+    return "PmdXmlToMarkdownCommand aggregates statistics for the whole stream before emitting the final report.";
+  }
+}
+
+final class PmdXmlToViolationsCommandStreamingContractProvider
+    implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return new PmdXmlToViolationsCommand();
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    return CommandStreamingContractProviders.utf8(
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <pmd>
+          <file name="/home/user/streamconverter-core/src/main/java/Foo.java">
+            <violation beginline="10" rule="UnusedVariable" ruleset="Best Practices"
+                       priority="3" class="Foo" method="bar" variable="x">
+              Avoid unused variables.
+            </violation>
+          </file>
+          <file name="/home/user/streamconverter-tools/src/main/java/Bar.java">
+            <violation beginline="20" rule="LongMethod" ruleset="Design"
+                       priority="2" class="Bar" method="baz" variable="">
+              Method too long.
+            </violation>
+          </file>
+        </pmd>
+        """);
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 320;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.STREAMING_COMPLIANT;
+  }
+}
+
+final class JacocoXmlToModuleSlocCommandStreamingContractProvider
+    implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return new JacocoXmlToModuleSlocCommand();
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    return CommandStreamingContractProviders.utf8(
+        "<report name=\"streamconverter-core\">"
+            + "<counter type=\"LINE\" missed=\"50\" covered=\"100\"/>"
+            + "</report>\n"
+            + "<report name=\"streamconverter-tools\">"
+            + "<counter type=\"LINE\" missed=\"5\" covered=\"30\"/>"
+            + "</report>\n");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 100;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.STREAMING_COMPLIANT;
+  }
+}
+
+final class ModuleXmlConcatCommandStreamingContractProvider
+    implements CommandStreamingContractProvider {
+  private static final String JACOCO_XML_PATH = "build/reports/jacoco/test/jacocoTestReport.xml";
+
+  @Override
+  public IStreamCommand createCommand() {
+    Path projectRoot = CommandStreamingContractProviders.createTempDirectory("module-xml-concat");
+    CommandStreamingContractProviders.writeString(
+        projectRoot.resolve("module-a").resolve(JACOCO_XML_PATH),
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<!DOCTYPE report PUBLIC \"-//JACOCO//DTD Report 1.1//EN\" \"report.dtd\">"
+            + "<report name=\"module-a\"><counter type=\"LINE\" missed=\"10\" covered=\"90\"/></report>\n");
+    CommandStreamingContractProviders.writeString(
+        projectRoot.resolve("module-b").resolve(JACOCO_XML_PATH),
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<!DOCTYPE report PUBLIC \"-//JACOCO//DTD Report 1.1//EN\" \"report.dtd\">"
+            + "<report name=\"module-b\"><counter type=\"LINE\" missed=\"5\" covered=\"35\"/></report>\n");
+    return new ModuleXmlConcatCommand(projectRoot);
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    return CommandStreamingContractProviders.utf8("module-a\nmodule-b\n");
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 9;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.STREAMING_COMPLIANT;
+  }
+}
+
+final class SlocAggregateCommandStreamingContractProvider
+    implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return new SlocAggregateCommand();
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    return CommandStreamingContractProviders.serializeObjects(
+        List.of(
+            new ModuleSloc("streamconverter-core", 1869, 1500, 369),
+            new ModuleSloc("streamconverter-tools", 1038, 900, 138)));
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 128;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.STREAMING_COMPLIANT;
+  }
+}
+
+final class SlocReportFormatCommandStreamingContractProvider
+    implements CommandStreamingContractProvider {
+  @Override
+  public IStreamCommand createCommand() {
+    return new SlocReportFormatCommand();
+  }
+
+  @Override
+  public byte[] sampleInput() {
+    return CommandStreamingContractProviders.serializeObjects(
+        List.of(
+            new ModuleSloc("streamconverter-core", 1869, 1500, 369),
+            new ModuleSloc("streamconverter-tools", 1038, 900, 138),
+            new ModuleSloc(ModuleSloc.TOTAL_NAME, 2907, 2400, 507)));
+  }
+
+  @Override
+  public int firstChunkSize() {
+    return 192;
+  }
+
+  @Override
+  public StreamingExpectation expectation() {
+    return StreamingExpectation.KNOWN_STREAMING_VIOLATION;
+  }
+
+  @Override
+  public String exemptionReason() {
+    return "SlocReportFormatCommand reads the whole ModuleSloc stream before formatting the final report.";
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractTest.java
@@ -44,11 +44,12 @@ class CommandStreamingContractTest {
   private static final String PROVIDER_PACKAGE_PREFIX = "com.streamconverter.command.contract.";
   private static final Duration FIRST_WRITE_TIMEOUT = Duration.ofSeconds(1);
   private static final Duration COMMAND_COMPLETION_TIMEOUT = Duration.ofSeconds(5);
+  private static final List<DiscoveredCommand> DISCOVERED_COMMANDS = discoverCommandClasses();
 
   @Test
-  void everyCommandImplementationHasAStreamingContractProvider() throws IOException {
+  void everyCommandImplementationHasAStreamingContractProvider() {
     List<String> missingProviders =
-        discoverCommandClasses().stream()
+        DISCOVERED_COMMANDS.stream()
             .map(CommandStreamingContractTest::missingProviderMessage)
             .filter(message -> message != null)
             .toList();
@@ -61,8 +62,8 @@ class CommandStreamingContractTest {
   }
 
   @TestFactory
-  Stream<DynamicTest> allCommandsParticipateInStreamingContract() throws IOException {
-    return discoverCommandClasses().stream()
+  Stream<DynamicTest> allCommandsParticipateInStreamingContract() {
+    return DISCOVERED_COMMANDS.stream()
         .filter(CommandStreamingContractTest::hasProvider)
         .map(
             commandClass ->
@@ -123,7 +124,7 @@ class CommandStreamingContractTest {
     try {
       awaitCompletion(commandClass, future);
     } finally {
-      shutdown(executor);
+      shutdown(executor, future);
     }
 
     if (failure != null) {
@@ -152,19 +153,36 @@ class CommandStreamingContractTest {
       }
       throw new RuntimeException("Unexpected command failure for " + commandClass.fqcn(), cause);
     } catch (java.util.concurrent.TimeoutException e) {
+      future.cancel(true);
       fail(commandClass.simpleName() + " did not finish after the input was released");
     }
   }
 
-  private static void shutdown(ExecutorService executor) {
+  private static void shutdown(ExecutorService executor, Future<?> future) {
     executor.shutdown();
+    try {
+      if (!executor.awaitTermination(
+          COMMAND_COMPLETION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+        future.cancel(true);
+        executor.shutdownNow();
+        if (!executor.awaitTermination(
+            COMMAND_COMPLETION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+          fail("Executor did not terminate promptly after test completion");
+        }
+      }
+    } catch (InterruptedException e) {
+      future.cancel(true);
+      executor.shutdownNow();
+      Thread.currentThread().interrupt();
+      fail("Interrupted while shutting down executor", e);
+    }
   }
 
   private static String missingProviderMessage(DiscoveredCommand commandClass) {
     try {
       instantiateProvider(commandClass);
       return null;
-    } catch (ReflectiveOperationException e) {
+    } catch (ReflectiveOperationException | RuntimeException e) {
       return "- "
           + commandClass.fqcn()
           + " -> expected provider "
@@ -179,7 +197,7 @@ class CommandStreamingContractTest {
     try {
       instantiateProvider(commandClass);
       return true;
-    } catch (ReflectiveOperationException e) {
+    } catch (ReflectiveOperationException | RuntimeException e) {
       return false;
     }
   }
@@ -195,10 +213,14 @@ class CommandStreamingContractTest {
     return PROVIDER_PACKAGE_PREFIX + commandClass.simpleName() + "StreamingContractProvider";
   }
 
-  private static List<DiscoveredCommand> discoverCommandClasses() throws IOException {
-    return CommandImplementationDiscovery.discover(REPOSITORY_ROOT).stream()
-        .map(command -> new DiscoveredCommand(command.fqcn(), command.simpleName()))
-        .toList();
+  private static List<DiscoveredCommand> discoverCommandClasses() {
+    try {
+      return CommandImplementationDiscovery.discover(REPOSITORY_ROOT).stream()
+          .map(command -> new DiscoveredCommand(command.fqcn(), command.simpleName()))
+          .toList();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to discover command implementations", e);
+    }
   }
 
   private record DiscoveredCommand(String fqcn, String simpleName) {}
@@ -206,7 +228,7 @@ class CommandStreamingContractTest {
   private static final class BlockingProbeInputStream extends InputStream {
     private final byte[] data;
     private final int firstChunkSize;
-    private final CountDownLatch releaseRemainingInput = new CountDownLatch(1);
+    private final CountDownLatch releaseLatch = new CountDownLatch(1);
     private int index;
 
     private BlockingProbeInputStream(byte[] data, int firstChunkSize) {
@@ -229,8 +251,7 @@ class CommandStreamingContractTest {
 
       if (index >= firstChunkSize) {
         try {
-          if (!releaseRemainingInput.await(
-              COMMAND_COMPLETION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+          if (!releaseLatch.await(COMMAND_COMPLETION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
             throw new IOException("Timed out waiting to release remaining input");
           }
         } catch (InterruptedException e) {
@@ -247,7 +268,7 @@ class CommandStreamingContractTest {
     }
 
     private void releaseRemainingInput() {
-      releaseRemainingInput.countDown();
+      releaseLatch.countDown();
     }
   }
 

--- a/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractTest.java
@@ -6,11 +6,8 @@ import com.streamconverter.command.IStreamCommand;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Modifier;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -23,11 +20,27 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
+/**
+ * Contract test for stream-oriented commands.
+ *
+ * <p>The probe works by:
+ *
+ * <ol>
+ *   <li>feeding a command an input stream that returns an initial chunk and then blocks
+ *   <li>watching whether the command writes anything to the output stream while input is still
+ *       blocked
+ *   <li>releasing the rest of the input and requiring the command to complete
+ * </ol>
+ *
+ * <p>This test answers a narrow but important question: "does output begin before input
+ * completion?" It does not prove full memory safety, throughput, or correctness for arbitrary
+ * payloads. Commands classified as {@link StreamingExpectation#KNOWN_STREAMING_VIOLATION} are
+ * expected to have been run through this probe already; that status is not a placeholder for
+ * unverified work.
+ */
 class CommandStreamingContractTest {
 
-  private static final Path COMMAND_IMPL_ROOT =
-      Path.of("src/main/java/com/streamconverter/command/impl");
-  private static final String COMMAND_PACKAGE_PREFIX = "com.streamconverter.command.impl.";
+  private static final Path REPOSITORY_ROOT = Path.of("..").normalize();
   private static final String PROVIDER_PACKAGE_PREFIX = "com.streamconverter.command.contract.";
   private static final Duration FIRST_WRITE_TIMEOUT = Duration.ofSeconds(1);
   private static final Duration COMMAND_COMPLETION_TIMEOUT = Duration.ofSeconds(5);
@@ -50,21 +63,29 @@ class CommandStreamingContractTest {
   @TestFactory
   Stream<DynamicTest> allCommandsParticipateInStreamingContract() throws IOException {
     return discoverCommandClasses().stream()
+        .filter(CommandStreamingContractTest::hasProvider)
         .map(
             commandClass ->
                 DynamicTest.dynamicTest(
-                    commandClass.getSimpleName(),
-                    () -> verifyCommandStreamingContract(commandClass)));
+                    commandClass.simpleName(), () -> verifyCommandStreamingContract(commandClass)));
   }
 
-  private static void verifyCommandStreamingContract(Class<?> commandClass) throws Exception {
+  private static void verifyCommandStreamingContract(DiscoveredCommand commandClass)
+      throws Exception {
     CommandStreamingContractProvider provider = instantiateProvider(commandClass);
-    assertNotNull(provider, () -> "No provider available for " + commandClass.getName());
+    assertNotNull(provider, () -> "No provider available for " + commandClass.fqcn());
 
-    if (provider.expectation() == StreamingExpectation.EXEMPT_FROM_STREAMING_CONTRACT) {
+    if (!provider.supportsProbeExecution()) {
+      assertFalse(
+          provider.probeSkipReason().isBlank(),
+          () -> "Probe-skipped command must explain why: " + commandClass.fqcn());
+      return;
+    }
+
+    if (provider.expectation() != StreamingExpectation.STREAMING_COMPLIANT) {
       assertFalse(
           provider.exemptionReason().isBlank(),
-          () -> "Exempt command must explain why: " + commandClass.getName());
+          () -> "Non-compliant command must explain why: " + commandClass.fqcn());
     }
 
     BlockingProbeInputStream inputStream =
@@ -79,18 +100,18 @@ class CommandStreamingContractTest {
     AssertionError failure = null;
     try {
       wroteBeforeRelease = outputStream.awaitFirstWrite(FIRST_WRITE_TIMEOUT);
-      if (provider.expectation() == StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE) {
+      if (provider.expectation() == StreamingExpectation.STREAMING_COMPLIANT) {
         assertTrue(
             wroteBeforeRelease,
             () ->
-                commandClass.getSimpleName()
+                commandClass.simpleName()
                     + " did not start writing before the remaining input was released");
       } else {
         assertFalse(
             wroteBeforeRelease,
             () ->
-                commandClass.getSimpleName()
-                    + " started writing early but is marked exempt: "
+                commandClass.simpleName()
+                    + " started writing early but is marked as non-compliant: "
                     + provider.exemptionReason());
       }
     } catch (AssertionError e) {
@@ -120,7 +141,8 @@ class CommandStreamingContractTest {
     }
   }
 
-  private static void awaitCompletion(Class<?> commandClass, Future<?> future) throws Exception {
+  private static void awaitCompletion(DiscoveredCommand commandClass, Future<?> future)
+      throws Exception {
     try {
       future.get(COMMAND_COMPLETION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
     } catch (ExecutionException e) {
@@ -128,9 +150,9 @@ class CommandStreamingContractTest {
       if (cause instanceof Exception exception) {
         throw exception;
       }
-      throw new RuntimeException("Unexpected command failure for " + commandClass.getName(), cause);
+      throw new RuntimeException("Unexpected command failure for " + commandClass.fqcn(), cause);
     } catch (java.util.concurrent.TimeoutException e) {
-      fail(commandClass.getSimpleName() + " did not finish after the input was released");
+      fail(commandClass.simpleName() + " did not finish after the input was released");
     }
   }
 
@@ -138,13 +160,13 @@ class CommandStreamingContractTest {
     executor.shutdown();
   }
 
-  private static String missingProviderMessage(Class<?> commandClass) {
+  private static String missingProviderMessage(DiscoveredCommand commandClass) {
     try {
       instantiateProvider(commandClass);
       return null;
     } catch (ReflectiveOperationException e) {
       return "- "
-          + commandClass.getName()
+          + commandClass.fqcn()
           + " -> expected provider "
           + providerClassName(commandClass)
           + " ("
@@ -153,47 +175,33 @@ class CommandStreamingContractTest {
     }
   }
 
-  private static CommandStreamingContractProvider instantiateProvider(Class<?> commandClass)
-      throws ReflectiveOperationException {
+  private static boolean hasProvider(DiscoveredCommand commandClass) {
+    try {
+      instantiateProvider(commandClass);
+      return true;
+    } catch (ReflectiveOperationException e) {
+      return false;
+    }
+  }
+
+  private static CommandStreamingContractProvider instantiateProvider(
+      DiscoveredCommand commandClass) throws ReflectiveOperationException {
     Class<?> providerClass = Class.forName(providerClassName(commandClass));
     Object provider = providerClass.getDeclaredConstructor().newInstance();
     return (CommandStreamingContractProvider) provider;
   }
 
-  private static String providerClassName(Class<?> commandClass) {
-    return PROVIDER_PACKAGE_PREFIX + commandClass.getSimpleName() + "StreamingContractProvider";
+  private static String providerClassName(DiscoveredCommand commandClass) {
+    return PROVIDER_PACKAGE_PREFIX + commandClass.simpleName() + "StreamingContractProvider";
   }
 
-  private static List<Class<?>> discoverCommandClasses() throws IOException {
-    try (Stream<Path> pathStream = Files.walk(COMMAND_IMPL_ROOT)) {
-      return pathStream
-          .filter(Files::isRegularFile)
-          .filter(path -> path.getFileName().toString().endsWith("Command.java"))
-          .sorted(Comparator.naturalOrder())
-          .map(CommandStreamingContractTest::toCommandClassName)
-          .map(CommandStreamingContractTest::loadClass)
-          .filter(commandClass -> !Modifier.isAbstract(commandClass.getModifiers()))
-          .toList();
-    }
+  private static List<DiscoveredCommand> discoverCommandClasses() throws IOException {
+    return CommandImplementationDiscovery.discover(REPOSITORY_ROOT).stream()
+        .map(command -> new DiscoveredCommand(command.fqcn(), command.simpleName()))
+        .toList();
   }
 
-  private static String toCommandClassName(Path sourceFile) {
-    Path relative = COMMAND_IMPL_ROOT.relativize(sourceFile);
-    String suffix =
-        relative
-            .toString()
-            .replace(sourceFile.getFileSystem().getSeparator(), ".")
-            .replace(".java", "");
-    return COMMAND_PACKAGE_PREFIX + suffix;
-  }
-
-  private static Class<?> loadClass(String className) {
-    try {
-      return Class.forName(className);
-    } catch (ClassNotFoundException e) {
-      throw new IllegalStateException("Failed to load command class " + className, e);
-    }
-  }
+  private record DiscoveredCommand(String fqcn, String simpleName) {}
 
   private static final class BlockingProbeInputStream extends InputStream {
     private final byte[] data;

--- a/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractTest.java
@@ -1,0 +1,267 @@
+package com.streamconverter.command.contract;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.streamconverter.command.IStreamCommand;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+class CommandStreamingContractTest {
+
+  private static final Path COMMAND_IMPL_ROOT =
+      Path.of("src/main/java/com/streamconverter/command/impl");
+  private static final String COMMAND_PACKAGE_PREFIX = "com.streamconverter.command.impl.";
+  private static final String PROVIDER_PACKAGE_PREFIX = "com.streamconverter.command.contract.";
+  private static final Duration FIRST_WRITE_TIMEOUT = Duration.ofSeconds(1);
+  private static final Duration COMMAND_COMPLETION_TIMEOUT = Duration.ofSeconds(5);
+
+  @Test
+  void everyCommandImplementationHasAStreamingContractProvider() throws IOException {
+    List<String> missingProviders =
+        discoverCommandClasses().stream()
+            .map(CommandStreamingContractTest::missingProviderMessage)
+            .filter(message -> message != null)
+            .toList();
+
+    assertTrue(
+        missingProviders.isEmpty(),
+        () ->
+            "Missing streaming contract providers for command implementations:\n"
+                + String.join("\n", missingProviders));
+  }
+
+  @TestFactory
+  Stream<DynamicTest> allCommandsParticipateInStreamingContract() throws IOException {
+    return discoverCommandClasses().stream()
+        .map(
+            commandClass ->
+                DynamicTest.dynamicTest(
+                    commandClass.getSimpleName(),
+                    () -> verifyCommandStreamingContract(commandClass)));
+  }
+
+  private static void verifyCommandStreamingContract(Class<?> commandClass) throws Exception {
+    CommandStreamingContractProvider provider = instantiateProvider(commandClass);
+    assertNotNull(provider, () -> "No provider available for " + commandClass.getName());
+
+    if (provider.expectation() == StreamingExpectation.EXEMPT_FROM_STREAMING_CONTRACT) {
+      assertFalse(
+          provider.exemptionReason().isBlank(),
+          () -> "Exempt command must explain why: " + commandClass.getName());
+    }
+
+    BlockingProbeInputStream inputStream =
+        new BlockingProbeInputStream(provider.sampleInput(), provider.firstChunkSize());
+    SignalingOutputStream outputStream = new SignalingOutputStream();
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    Future<?> future =
+        executor.submit(() -> executeCommand(provider.createCommand(), inputStream, outputStream));
+
+    boolean wroteBeforeRelease = false;
+    AssertionError failure = null;
+    try {
+      wroteBeforeRelease = outputStream.awaitFirstWrite(FIRST_WRITE_TIMEOUT);
+      if (provider.expectation() == StreamingExpectation.MUST_WRITE_BEFORE_INPUT_COMPLETE) {
+        assertTrue(
+            wroteBeforeRelease,
+            () ->
+                commandClass.getSimpleName()
+                    + " did not start writing before the remaining input was released");
+      } else {
+        assertFalse(
+            wroteBeforeRelease,
+            () ->
+                commandClass.getSimpleName()
+                    + " started writing early but is marked exempt: "
+                    + provider.exemptionReason());
+      }
+    } catch (AssertionError e) {
+      failure = e;
+    } finally {
+      inputStream.releaseRemainingInput();
+    }
+
+    try {
+      awaitCompletion(commandClass, future);
+    } finally {
+      shutdown(executor);
+    }
+
+    if (failure != null) {
+      throw failure;
+    }
+  }
+
+  private static Void executeCommand(
+      IStreamCommand command, InputStream inputStream, ByteArrayOutputStream outputStream) {
+    try {
+      command.execute(inputStream, outputStream);
+      return null;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void awaitCompletion(Class<?> commandClass, Future<?> future) throws Exception {
+    try {
+      future.get(COMMAND_COMPLETION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception exception) {
+        throw exception;
+      }
+      throw new RuntimeException("Unexpected command failure for " + commandClass.getName(), cause);
+    } catch (java.util.concurrent.TimeoutException e) {
+      fail(commandClass.getSimpleName() + " did not finish after the input was released");
+    }
+  }
+
+  private static void shutdown(ExecutorService executor) {
+    executor.shutdown();
+  }
+
+  private static String missingProviderMessage(Class<?> commandClass) {
+    try {
+      instantiateProvider(commandClass);
+      return null;
+    } catch (ReflectiveOperationException e) {
+      return "- "
+          + commandClass.getName()
+          + " -> expected provider "
+          + providerClassName(commandClass)
+          + " ("
+          + e.getClass().getSimpleName()
+          + ")";
+    }
+  }
+
+  private static CommandStreamingContractProvider instantiateProvider(Class<?> commandClass)
+      throws ReflectiveOperationException {
+    Class<?> providerClass = Class.forName(providerClassName(commandClass));
+    Object provider = providerClass.getDeclaredConstructor().newInstance();
+    return (CommandStreamingContractProvider) provider;
+  }
+
+  private static String providerClassName(Class<?> commandClass) {
+    return PROVIDER_PACKAGE_PREFIX + commandClass.getSimpleName() + "StreamingContractProvider";
+  }
+
+  private static List<Class<?>> discoverCommandClasses() throws IOException {
+    try (Stream<Path> pathStream = Files.walk(COMMAND_IMPL_ROOT)) {
+      return pathStream
+          .filter(Files::isRegularFile)
+          .filter(path -> path.getFileName().toString().endsWith("Command.java"))
+          .sorted(Comparator.naturalOrder())
+          .map(CommandStreamingContractTest::toCommandClassName)
+          .map(CommandStreamingContractTest::loadClass)
+          .filter(commandClass -> !Modifier.isAbstract(commandClass.getModifiers()))
+          .toList();
+    }
+  }
+
+  private static String toCommandClassName(Path sourceFile) {
+    Path relative = COMMAND_IMPL_ROOT.relativize(sourceFile);
+    String suffix =
+        relative
+            .toString()
+            .replace(sourceFile.getFileSystem().getSeparator(), ".")
+            .replace(".java", "");
+    return COMMAND_PACKAGE_PREFIX + suffix;
+  }
+
+  private static Class<?> loadClass(String className) {
+    try {
+      return Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException("Failed to load command class " + className, e);
+    }
+  }
+
+  private static final class BlockingProbeInputStream extends InputStream {
+    private final byte[] data;
+    private final int firstChunkSize;
+    private final CountDownLatch releaseRemainingInput = new CountDownLatch(1);
+    private int index;
+
+    private BlockingProbeInputStream(byte[] data, int firstChunkSize) {
+      this.data = data;
+      this.firstChunkSize = Math.min(Math.max(1, firstChunkSize), Math.max(1, data.length - 1));
+    }
+
+    @Override
+    public int read() throws IOException {
+      byte[] singleByte = new byte[1];
+      int read = read(singleByte, 0, 1);
+      return read == -1 ? -1 : singleByte[0] & 0xFF;
+    }
+
+    @Override
+    public int read(byte[] buffer, int off, int len) throws IOException {
+      if (index >= data.length) {
+        return -1;
+      }
+
+      if (index >= firstChunkSize) {
+        try {
+          if (!releaseRemainingInput.await(
+              COMMAND_COMPLETION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+            throw new IOException("Timed out waiting to release remaining input");
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException("Interrupted while waiting to release remaining input", e);
+        }
+      }
+
+      int upperBound = index < firstChunkSize ? firstChunkSize : data.length;
+      int bytesToCopy = Math.min(len, upperBound - index);
+      System.arraycopy(data, index, buffer, off, bytesToCopy);
+      index += bytesToCopy;
+      return bytesToCopy;
+    }
+
+    private void releaseRemainingInput() {
+      releaseRemainingInput.countDown();
+    }
+  }
+
+  private static final class SignalingOutputStream extends ByteArrayOutputStream {
+    private final CountDownLatch firstWriteLatch = new CountDownLatch(1);
+
+    @Override
+    public synchronized void write(int b) {
+      firstWriteLatch.countDown();
+      super.write(b);
+    }
+
+    @Override
+    public synchronized void write(byte[] b, int off, int len) {
+      if (len > 0) {
+        firstWriteLatch.countDown();
+      }
+      super.write(b, off, len);
+    }
+
+    private boolean awaitFirstWrite(Duration timeout) throws InterruptedException {
+      return firstWriteLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+  }
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/command/contract/StreamingExpectation.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/contract/StreamingExpectation.java
@@ -1,0 +1,7 @@
+package com.streamconverter.command.contract;
+
+/** Expected first-write behavior for a command under the streaming contract probe. */
+enum StreamingExpectation {
+  MUST_WRITE_BEFORE_INPUT_COMPLETE,
+  EXEMPT_FROM_STREAMING_CONTRACT
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/command/contract/StreamingExpectation.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/contract/StreamingExpectation.java
@@ -1,7 +1,23 @@
 package com.streamconverter.command.contract;
 
-/** Expected first-write behavior for a command under the streaming contract probe. */
+/**
+ * Classification of a command's conformance to the streaming contract.
+ *
+ * <p>These values describe confirmed state, not provisional guesses.
+ *
+ * <ul>
+ *   <li>{@link #STREAMING_COMPLIANT}: the probe was executed and observed output before the input
+ *       completed
+ *   <li>{@link #ALLOWED_FULL_BUFFERING}: the command is intentionally non-streaming and that
+ *       behavior is explicitly allowed by project policy
+ *   <li>{@link #KNOWN_STREAMING_VIOLATION}: the probe was executed and the command failed the
+ *       streaming expectation
+ * </ul>
+ *
+ * <p>{@code KNOWN_STREAMING_VIOLATION} must not be used as shorthand for "not verified yet".
+ */
 enum StreamingExpectation {
-  MUST_WRITE_BEFORE_INPUT_COMPLETE,
-  EXEMPT_FROM_STREAMING_CONTRACT
+  STREAMING_COMPLIANT,
+  ALLOWED_FULL_BUFFERING,
+  KNOWN_STREAMING_VIOLATION
 }

--- a/streamconverter-http/build.gradle.kts
+++ b/streamconverter-http/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     // JUnit 5
     testImplementation(platform("org.junit:junit-bom:6.0.3"))
     testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.springframework:spring-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/streamconverter-http/src/main/java/com/streamconverter/command/impl/SendHttpCommand.java
+++ b/streamconverter-http/src/main/java/com/streamconverter/command/impl/SendHttpCommand.java
@@ -36,7 +36,7 @@ public class SendHttpCommand extends AbstractStreamCommand {
 
   private static final Logger logger = LoggerFactory.getLogger(SendHttpCommand.class);
 
-  private String url;
+  private final String url;
   private final WebClient webClient;
 
   /**
@@ -46,9 +46,24 @@ public class SendHttpCommand extends AbstractStreamCommand {
    * @throws IllegalArgumentException URLが無効な場合
    */
   public SendHttpCommand(String url) {
+    this(url, createDefaultWebClient());
+  }
+
+  /**
+   * カスタム {@link WebClient} を使用するコンストラクタ。
+   *
+   * <p>主にテストや特殊なHTTPクライアント設定のために使用する。URLの検証は通常コンストラクタと同様に適用する。
+   *
+   * @param url 送信先のURL
+   * @param webClient 使用するWebClient
+   */
+  public SendHttpCommand(String url, WebClient webClient) {
     super();
     this.url = validateAndSanitizeUrl(url);
+    this.webClient = Objects.requireNonNull(webClient, "webClient must not be null");
+  }
 
+  private static WebClient createDefaultWebClient() {
     // Simple HttpClient configuration for Netty 4.1.123.Final compatibility
     HttpClient httpClient =
         HttpClient.create()
@@ -56,15 +71,14 @@ public class SendHttpCommand extends AbstractStreamCommand {
             .option(io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
             .keepAlive(false); // Disable keep-alive to avoid connection pool issues
 
-    this.webClient =
-        WebClient.builder()
-            .clientConnector(new ReactorClientHttpConnector(httpClient))
-            .codecs(
-                configurer ->
-                    // 1 MB limit for error response bodies (used by onStatus bodyToMono).
-                    // The streaming response path (bodyToFlux) bypasses this buffer entirely.
-                    configurer.defaultCodecs().maxInMemorySize(1024 * 1024))
-            .build();
+    return WebClient.builder()
+        .clientConnector(new ReactorClientHttpConnector(httpClient))
+        .codecs(
+            configurer ->
+                // 1 MB limit for error response bodies (used by onStatus bodyToMono).
+                // The streaming response path (bodyToFlux) bypasses this buffer entirely.
+                configurer.defaultCodecs().maxInMemorySize(1024 * 1024))
+        .build();
   }
 
   /**

--- a/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandWebClientTest.java
+++ b/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandWebClientTest.java
@@ -1,0 +1,182 @@
+package com.streamconverter.command.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.client.reactive.MockClientHttpRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+class SendHttpCommandWebClientTest {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(2);
+
+  @Test
+  void executeWritesResponseFromInjectedWebClient() throws Exception {
+    SendHttpCommand command =
+        new SendHttpCommand("https://example.com/post", createEchoWebClient("ack:"));
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    command.execute(
+        new ByteArrayInputStream("hello-stream".getBytes(StandardCharsets.UTF_8)), output);
+
+    assertEquals("ack:hello-stream", output.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void executeStartsResponseOnlyAfterRequestBodyCompletes() throws Exception {
+    SendHttpCommand command =
+        new SendHttpCommand("https://example.com/post", createEchoWebClient("ack:"));
+    BlockingInputStream input =
+        new BlockingInputStream("hello-streaming-body".getBytes(StandardCharsets.UTF_8), 5);
+    SignalingOutputStream output = new SignalingOutputStream();
+
+    try (var executor = Executors.newSingleThreadExecutor()) {
+      Future<?> future = executor.submit(() -> runCommand(command, input, output));
+
+      assertFalse(
+          output.awaitFirstWrite(TIMEOUT),
+          "レスポンスはリクエストボディ完了前には書き出されないはず");
+
+      input.releaseRemainingInput();
+      future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+
+      assertTrue(output.awaitFirstWrite(TIMEOUT), "入力解放後はレスポンスが書き出されるはず");
+      assertEquals("ack:hello-streaming-body", output.toString(StandardCharsets.UTF_8));
+    }
+  }
+
+  private static Void runCommand(
+      SendHttpCommand command, InputStream input, ByteArrayOutputStream output) {
+    try {
+      command.execute(input, output);
+      return null;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static WebClient createEchoWebClient(String responsePrefix) {
+    DefaultDataBufferFactory bufferFactory = new DefaultDataBufferFactory();
+    ExchangeFunction exchangeFunction =
+        request -> {
+          AtomicReference<String> requestBody = new AtomicReference<>("");
+          MockClientHttpRequest mockRequest = new MockClientHttpRequest(HttpMethod.POST, URI.create(request.url().toString()));
+          mockRequest.setWriteHandler(
+              body ->
+                  DataBufferUtils.join(body)
+                      .doOnNext(
+                          dataBuffer -> {
+                            byte[] bytes = new byte[dataBuffer.readableByteCount()];
+                            dataBuffer.read(bytes);
+                            requestBody.set(new String(bytes, StandardCharsets.UTF_8));
+                            DataBufferUtils.release(dataBuffer);
+                          })
+                      .then());
+          return request
+              .writeTo(mockRequest, ExchangeStrategies.withDefaults())
+              .then(Mono.fromSupplier(requestBody::get))
+              .map(
+                  body ->
+                      ClientResponse.create(HttpStatus.OK)
+                          .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN_VALUE)
+                          .body(
+                              Flux.just(
+                                  bufferFactory.wrap(
+                                      (responsePrefix + body).getBytes(StandardCharsets.UTF_8))))
+                          .build());
+        };
+    return WebClient.builder().exchangeFunction(exchangeFunction).build();
+  }
+
+  private static final class BlockingInputStream extends InputStream {
+    private final byte[] data;
+    private final int firstChunkSize;
+    private final CountDownLatch releaseRemainingInput = new CountDownLatch(1);
+    private int index;
+
+    private BlockingInputStream(byte[] data, int firstChunkSize) {
+      this.data = data;
+      this.firstChunkSize = firstChunkSize;
+    }
+
+    @Override
+    public int read() throws IOException {
+      byte[] singleByte = new byte[1];
+      int read = read(singleByte, 0, 1);
+      return read == -1 ? -1 : singleByte[0] & 0xFF;
+    }
+
+    @Override
+    public int read(byte[] buffer, int off, int len) throws IOException {
+      if (index >= data.length) {
+        return -1;
+      }
+
+      if (index >= firstChunkSize) {
+        try {
+          if (!releaseRemainingInput.await(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+            throw new IOException("Timed out waiting to release remaining input");
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException("Interrupted while waiting to release remaining input", e);
+        }
+      }
+
+      int upperBound = index < firstChunkSize ? firstChunkSize : data.length;
+      int bytesToCopy = Math.min(len, upperBound - index);
+      System.arraycopy(data, index, buffer, off, bytesToCopy);
+      index += bytesToCopy;
+      return bytesToCopy;
+    }
+
+    private void releaseRemainingInput() {
+      releaseRemainingInput.countDown();
+    }
+  }
+
+  private static final class SignalingOutputStream extends ByteArrayOutputStream {
+    private final CountDownLatch firstWriteLatch = new CountDownLatch(1);
+
+    @Override
+    public synchronized void write(int b) {
+      firstWriteLatch.countDown();
+      super.write(b);
+    }
+
+    @Override
+    public synchronized void write(byte[] b, int off, int len) {
+      if (len > 0) {
+        firstWriteLatch.countDown();
+      }
+      super.write(b, off, len);
+    }
+
+    private boolean awaitFirstWrite(Duration timeout) throws InterruptedException {
+      return firstWriteLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+  }
+}


### PR DESCRIPTION
## What changed
- expanded command discovery from `streamconverter-core` path-based `command/impl/*Command` scanning to repository-wide top-level `IStreamCommand` / `AbstractStreamCommand` / `ConsumerCommand` implementation discovery
- added discovery coverage tests so new top-level command implementations in other modules are detected automatically
- registered streaming contract providers for `streamconverter-http` and `streamconverter-tools` command implementations
- made `SendHttpCommand` executable under deterministic tests by injecting a `WebClient`, then classified its current behavior from measured results instead of skipping it
- refined command status naming to `STREAMING_COMPLIANT`, `ALLOWED_FULL_BUFFERING`, and `KNOWN_STREAMING_VIOLATION`
- documented the streaming contract probe both in test code and in `docs/reference/TESTING.md`
- restored early output for `CsvFilterCommand` and `JsonFilterCommand`, and corrected their probe fixtures so they block after a complete first value instead of in the middle of it

## Why
The project direction is to treat command implementations as streaming by default and to make deviations explicit. This PR tightens the guardrail so command coverage is based on the actual command abstraction, not on package layout, and so each known violation is a measured result rather than an unverified guess.

## Current classification
- `STREAMING_COMPLIANT`: command was executed under the probe and started writing before input completion
- `ALLOWED_FULL_BUFFERING`: intentionally non-streaming by policy
- `KNOWN_STREAMING_VIOLATION`: command was executed under the probe and did not satisfy the contract

At the moment:
- `FileBufferCommand` is the only `ALLOWED_FULL_BUFFERING` command
- known streaming violations are tracked separately as issues

## Known tracked issues
- Refs #595
- Closes #596
- Closes #599
- Refs #601
- Refs #602
- Refs #603

## Validation
- `./gradlew :streamconverter-core:test --tests com.streamconverter.command.contract.CommandStreamingContractTest --tests com.streamconverter.command.contract.CommandImplementationDiscoveryTest`
- `./gradlew :streamconverter-core:test --tests com.streamconverter.command.impl.FilterCommandBasicTest`
- `./gradlew :streamconverter-http:test --tests com.streamconverter.command.impl.SendHttpCommandWebClientTest`
- `./gradlew :streamconverter-core:spotlessApply`
