### PR TITLE
refactor: unify logger naming and fix lambda command (#659, #663)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/StreamConverter.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StreamConverter {
 
-  private static final Logger LOG = LoggerFactory.getLogger(StreamConverter.class);
+  private static final Logger logger = LoggerFactory.getLogger(StreamConverter.class);
   private static final int DEFAULT_BUFFER_SIZE = 64 * 1024; // 64KB buffer
 
   private final CommandStageRunner commandStageRunner;
@@ -58,10 +58,10 @@ public class StreamConverter {
       executor.shutdown();
       try {
         if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
-          LOG.warn("Executor did not terminate gracefully, forcing shutdown");
+          logger.warn("Executor did not terminate gracefully, forcing shutdown");
           executor.shutdownNow();
           if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
-            LOG.error("Executor did not terminate after forced shutdown");
+            logger.error("Executor did not terminate after forced shutdown");
           }
         }
       } catch (InterruptedException e) {
@@ -116,7 +116,7 @@ public class StreamConverter {
   private static List<IStreamCommand> wrapWithLogging(List<IStreamCommand> commands) {
     List<IStreamCommand> wrapped = new ArrayList<>(commands.size());
     for (IStreamCommand command : commands) {
-      wrapped.add(command.withLogging(LOG));
+      wrapped.add(command.withLogging(logger));
     }
     return wrapped;
   }
@@ -146,11 +146,11 @@ public class StreamConverter {
     Objects.requireNonNull(inputStream);
     Objects.requireNonNull(outputStream);
 
-    LOG.info("Starting StreamConverter with {} commands", commands.size());
+    logger.info("Starting StreamConverter with {} commands", commands.size());
 
     executeCommands(inputStream, outputStream);
 
-    LOG.info("Completed StreamConverter pipeline");
+    logger.info("Completed StreamConverter pipeline");
   }
 
   /** コマンド（単一または複数）を並列実行 */
@@ -181,7 +181,7 @@ public class StreamConverter {
               try {
                 closeResources(resources);
               } catch (RuntimeException ex) {
-                LOG.error("Unexpected error during resource cleanup on pipeline failure", ex);
+                logger.error("Unexpected error during resource cleanup on pipeline failure", ex);
               }
               return null;
             });
@@ -197,7 +197,7 @@ public class StreamConverter {
         pipelineFailureHandler.rethrowExecutionFailure(e, futures);
       }
 
-      LOG.info("All commands completed successfully");
+      logger.info("All commands completed successfully");
 
     } finally {
       // リソースクリーンアップ
@@ -219,9 +219,10 @@ public class StreamConverter {
       try {
         resource.close();
       } catch (IOException e) {
-        LOG.warn("Failed to close resource [{}]", resource.getClass().getSimpleName(), e);
+        logger.warn("Failed to close resource [{}]", resource.getClass().getSimpleName(), e);
       } catch (RuntimeException e) {
-        LOG.warn("Unexpected error closing resource [{}]", resource.getClass().getSimpleName(), e);
+        logger.warn(
+            "Unexpected error closing resource [{}]", resource.getClass().getSimpleName(), e);
       }
     }
   }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvRowValidator.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvRowValidator.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 /** Validates CSV headers and data rows, collecting error messages up to a configurable limit. */
 final class CsvRowValidator {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(CsvRowValidator.class);
+  private static final Logger logger = LoggerFactory.getLogger(CsvRowValidator.class);
 
   private final Set<String> requiredColumns;
   private final int maxErrorsToReport;
@@ -26,7 +26,7 @@ final class CsvRowValidator {
     }
     checkDuplicateHeaders(headers, errors);
     checkRequiredColumns(headers, errors);
-    LOGGER.debug("Header validation completed - {} columns found", headers.length);
+    logger.debug("Header validation completed - {} columns found", headers.length);
   }
 
   private void checkDuplicateHeaders(String[] headers, List<String> errors) {

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * </pre>
  */
 public class CsvValidateCommand extends ConsumerCommand {
-  private static final Logger LOGGER = LoggerFactory.getLogger(CsvValidateCommand.class);
+  private static final Logger logger = LoggerFactory.getLogger(CsvValidateCommand.class);
 
   private final Set<String> requiredColumns;
   private final boolean hasHeader;
@@ -73,9 +73,9 @@ public class CsvValidateCommand extends ConsumerCommand {
     }
 
     if (requiredColumns.length == 0) {
-      LOGGER.info("No required columns specified, column validation will be skipped");
+      logger.info("No required columns specified, column validation will be skipped");
     } else {
-      LOGGER.info("Required columns: {}", this.requiredColumns);
+      logger.info("Required columns: {}", this.requiredColumns);
     }
   }
 
@@ -121,7 +121,7 @@ public class CsvValidateCommand extends ConsumerCommand {
   public void consume(final InputStream inputStream) throws IOException {
     Objects.requireNonNull(inputStream, "InputStream cannot be null");
 
-    LOGGER.info(
+    logger.info(
         "Starting CSV validation - hasHeader: {}, requiredColumns: {}",
         hasHeader,
         requiredColumns.size());
@@ -135,7 +135,7 @@ public class CsvValidateCommand extends ConsumerCommand {
     if (!validationErrors.isEmpty()) {
       handleValidationErrors(validationErrors);
     }
-    LOGGER.info("CSV validation completed successfully");
+    logger.info("CSV validation completed successfully");
   }
 
   private boolean readAndValidate(InputStream inputStream, List<String> validationErrors)
@@ -156,10 +156,10 @@ public class CsvValidateCommand extends ConsumerCommand {
       return validateDataRows(csvReader, rowValidator, headers, validationErrors);
 
     } catch (CsvValidationException e) {
-      LOGGER.error("CSV parsing error: {}", e.getMessage(), e);
+      logger.error("CSV parsing error: {}", e.getMessage(), e);
       throw new StreamProcessingException("Failed to parse CSV: " + e.getMessage(), e);
     } catch (IOException e) {
-      LOGGER.error("CSV validation failed: {}", e.getMessage(), e);
+      logger.error("CSV validation failed: {}", e.getMessage(), e);
       throw new StreamProcessingException("Failed to parse CSV: " + e.getMessage(), e);
     }
   }
@@ -189,16 +189,16 @@ public class CsvValidateCommand extends ConsumerCommand {
 
     for (int i = 0; i < errors.size(); i++) {
       errorBuilder.append("\n  ").append(i + 1).append(". ").append(errors.get(i));
-      LOGGER.error("CSV validation error {}: {}", i + 1, errors.get(i));
+      logger.error("CSV validation error {}: {}", i + 1, errors.get(i));
     }
 
     String errorMessage = errorBuilder.toString();
-    LOGGER.error("CSV validation summary: {}", errorMessage);
+    logger.error("CSV validation summary: {}", errorMessage);
 
     String finalErrorMessage = errorMessage;
     if (errorMessage.length() > 1000) {
       finalErrorMessage = errorMessage.substring(0, 997) + "...";
-      LOGGER.warn(
+      logger.warn(
           "Error message truncated due to length (original: {} chars)", errorMessage.length());
     }
 

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlCaptureSession.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlCaptureSession.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  * {@link #finish} or {@link #abort}). Writing to a closed session is a no-op.
  */
 final class XmlCaptureSession {
-  private static final Logger LOGGER = LoggerFactory.getLogger(XmlCaptureSession.class);
+  private static final Logger logger = LoggerFactory.getLogger(XmlCaptureSession.class);
 
   private final XMLOutputFactory outputFactory;
   private StringWriter elementWriter = new StringWriter();
@@ -56,7 +56,7 @@ final class XmlCaptureSession {
     try {
       eventWriter.close();
     } catch (XMLStreamException e) {
-      LOGGER.warn("Error closing event writer: {}", e.getMessage(), e);
+      logger.warn("Error closing event writer: {}", e.getMessage(), e);
     } finally {
       open = false;
     }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * path expressions including nested elements and attributes
  */
 public class XmlFilterCommand extends AbstractStreamCommand {
-  private static final Logger LOGGER = LoggerFactory.getLogger(XmlFilterCommand.class);
+  private static final Logger logger = LoggerFactory.getLogger(XmlFilterCommand.class);
 
   private final IPath<List<String>> xpath;
 
@@ -103,7 +103,7 @@ public class XmlFilterCommand extends AbstractStreamCommand {
     try {
       reader.close();
     } catch (XMLStreamException e) {
-      LOGGER.warn("Error closing XML reader: {}", e.getMessage(), e);
+      logger.warn("Error closing XML reader: {}", e.getMessage(), e);
     }
   }
 

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * unchanged.
  */
 public class XmlNavigateCommand extends AbstractStreamCommand {
-  private static final Logger LOGGER = LoggerFactory.getLogger(XmlNavigateCommand.class);
+  private static final Logger logger = LoggerFactory.getLogger(XmlNavigateCommand.class);
   private static final XMLEventFactory EVENT_FACTORY = XMLEventFactory.newInstance();
 
   private final TreePath treePath;
@@ -104,7 +104,7 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
         currentPath.add(event.asStartElement().getName().getLocalPart());
       } else if (event.isEndElement()) {
         if (currentPath.isEmpty()) {
-          LOGGER.warn(
+          logger.warn(
               "Unexpected end element '{}' with empty path stack — possible malformed XML",
               event.asEndElement().getName().getLocalPart());
         } else {
@@ -134,7 +134,7 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
       try {
         reader.close();
       } catch (XMLStreamException closeEx) {
-        LOGGER.warn("Failed to close empty XMLEventReader", closeEx);
+        logger.warn("Failed to close empty XMLEventReader", closeEx);
       }
       throw new XMLStreamException("Empty XML input");
     }
@@ -155,7 +155,7 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
         location = String.format(" at line %d, column %d", line, column);
       }
     }
-    LOGGER.error("XML processing failed{}", location, e);
+    logger.error("XML processing failed{}", location, e);
     return new IOException("XML processing failed" + location, e);
   }
 
@@ -175,12 +175,12 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
     try {
       eventWriter.flush();
     } catch (XMLStreamException e) {
-      LOGGER.warn("Failed to flush XMLEventWriter during cleanup", e);
+      logger.warn("Failed to flush XMLEventWriter during cleanup", e);
     }
     try {
       eventWriter.close();
     } catch (XMLStreamException e) {
-      LOGGER.warn("Failed to close XMLEventWriter", e);
+      logger.warn("Failed to close XMLEventWriter", e);
     } catch (RuntimeException e) {
       if (primaryException != null) {
         primaryException.addSuppressed(e);
@@ -200,7 +200,7 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
     try {
       eventReader.close();
     } catch (XMLStreamException e) {
-      LOGGER.warn("Failed to close XMLEventReader", e);
+      logger.warn("Failed to close XMLEventReader", e);
     } catch (RuntimeException e) {
       if (primaryException != null) {
         primaryException.addSuppressed(e);

--- a/streamconverter-core/src/main/java/com/streamconverter/logging/MDCInitializer.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/logging/MDCInitializer.java
@@ -44,7 +44,7 @@ import org.slf4j.spi.MDCAdapter;
  */
 public final class MDCInitializer {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(MDCInitializer.class);
+  private static final Logger logger = LoggerFactory.getLogger(MDCInitializer.class);
 
   private MDCInitializer() {}
 
@@ -149,7 +149,7 @@ public final class MDCInitializer {
     } catch (ClassNotFoundException ignored) {
       return true; // Logback not on classpath
     } catch (ReflectiveOperationException | RuntimeException e) {
-      LOGGER.warn("Failed to check Logback MDC adapter; will attempt reinstall", e);
+      logger.warn("Failed to check Logback MDC adapter; will attempt reinstall", e);
       return false;
     }
   }

--- a/streamconverter-web/src/main/java/com/streamconverter/web/StreamProcessingController.java
+++ b/streamconverter-web/src/main/java/com/streamconverter/web/StreamProcessingController.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.streamconverter.StreamConverter;
+import com.streamconverter.command.AbstractStreamCommand;
 import com.streamconverter.command.IStreamCommand;
 import com.streamconverter.command.impl.csv.CsvNavigateCommand;
 import com.streamconverter.command.impl.json.JsonNavigateCommand;
@@ -35,7 +36,7 @@ import reactor.core.publisher.Mono;
 @RequestMapping("/api/v1/stream")
 public class StreamProcessingController {
 
-  private static final Logger log = LoggerFactory.getLogger(StreamProcessingController.class);
+  private static final Logger logger = LoggerFactory.getLogger(StreamProcessingController.class);
 
   private static final int MAX_PIPELINE_CONFIG_LENGTH = 1000;
   private static final int MAX_PIPELINE_COMMANDS = 10;
@@ -55,7 +56,7 @@ public class StreamProcessingController {
   public Mono<ResponseEntity<Flux<DataBuffer>>> processCsvExtraction(
       @RequestBody Flux<DataBuffer> inputData, @RequestParam String columnName) {
 
-    log.info("Processing CSV extraction for column: {}", columnName);
+    logger.info("Processing CSV extraction for column: {}", columnName);
 
     return Mono
         .fromCallable(
@@ -67,7 +68,7 @@ public class StreamProcessingController {
                             CSVPath.of(columnName), new PassThroughRule()))))
         .onErrorResume(
             e -> {
-              log.error("CSV extraction failed: {}", e.getMessage(), e);
+              logger.error("CSV extraction failed: {}", e.getMessage(), e);
               return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
             });
   }
@@ -86,7 +87,7 @@ public class StreamProcessingController {
   public Mono<ResponseEntity<Flux<DataBuffer>>> processJsonExtraction(
       @RequestBody Flux<DataBuffer> inputData, @RequestParam String jsonPath) {
 
-    log.info("Processing JSON extraction for path: {}", jsonPath);
+    logger.info("Processing JSON extraction for path: {}", jsonPath);
 
     return Mono
         .fromCallable(
@@ -98,7 +99,7 @@ public class StreamProcessingController {
                             TreePath.fromJson(jsonPath), new PassThroughRule()))))
         .onErrorResume(
             e -> {
-              log.error("JSON extraction failed: {}", e.getMessage(), e);
+              logger.error("JSON extraction failed: {}", e.getMessage(), e);
               return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
             });
   }
@@ -122,18 +123,18 @@ public class StreamProcessingController {
         .fromCallable(() -> buildPipelineFromConfig(pipelineConfig))
         .map(
             commands -> {
-              log.info("Processing pipeline with {} commands", commands.length);
+              logger.info("Processing pipeline with {} commands", commands.length);
               return ResponseEntity.ok(processWithStreamConverter(inputData, commands));
             })
         .onErrorResume(
             IllegalArgumentException.class,
             e -> {
-              log.warn("Invalid pipeline config: {}", e.getMessage());
+              logger.warn("Invalid pipeline config: {}", e.getMessage());
               return Mono.just(ResponseEntity.status(HttpStatus.BAD_REQUEST).build());
             })
         .onErrorResume(
             e -> {
-              log.error("Pipeline processing failed: {}", e.getMessage(), e);
+              logger.error("Pipeline processing failed: {}", e.getMessage(), e);
               return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
             });
   }
@@ -226,12 +227,17 @@ public class StreamProcessingController {
               }
               yield JsonNavigateCommand.create(TreePath.fromJson(parameter), new PassThroughRule());
             }
-            case "process" -> (IStreamCommand) (in, out) -> in.transferTo(out);
+            case "process" -> new AbstractStreamCommand() {
+              @Override
+              public void execute(InputStream in, java.io.OutputStream out) throws IOException {
+                in.transferTo(out);
+              }
+            };
             default -> throw new IllegalArgumentException("Unknown command type: " + commandType);
           };
     }
 
-    log.info("Built pipeline with {} commands", commands.length);
+    logger.info("Built pipeline with {} commands", commands.length);
     return commands;
   }
 }

--- a/streamconverter-web/src/main/java/com/streamconverter/web/StreamProcessingController.java
+++ b/streamconverter-web/src/main/java/com/streamconverter/web/StreamProcessingController.java
@@ -232,6 +232,11 @@ public class StreamProcessingController {
               public void execute(InputStream in, java.io.OutputStream out) throws IOException {
                 in.transferTo(out);
               }
+
+              @Override
+              public String commandName() {
+                return "process";
+              }
             };
             default -> throw new IllegalArgumentException("Unknown command type: " + commandType);
           };


### PR DESCRIPTION
## Summary

- **#659**: `Logger` フィールド名を全ファイルで `logger` に統一（`LOG`/`LOGGER`/`log` → `logger`）
  - 対象: `StreamConverter`, `XmlNavigateCommand`, `XmlFilterCommand`, `XmlCaptureSession`, `CsvValidateCommand`, `CsvRowValidator`, `MDCInitializer`, `StreamProcessingController`
- **#663**: `StreamProcessingController.buildPipelineFromConfig()` の `case "process"` でラムダが `IStreamCommand` を直接実装していた箇所を `AbstractStreamCommand` 匿名クラスに変更
  - ラムダは `commandName()` が固定値になり、`withLogging()` ラッピングも機能しない問題を修正

## Test plan

- [ ] `./gradlew :streamconverter-core:test` — 411テストパス
- [ ] `./gradlew :streamconverter-web:test` — 13テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
