### PR TITLE
fix(spotbugs): remove blanket test exclusion for resource leak checks

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -25,13 +25,4 @@
         <Bug pattern="DM_PRINT_DUMP" />
     </Match>
     
-    <!-- Exclude resource leak warnings for test classes using mock objects -->
-    <Match>
-        <Class name="~.*Test" />
-        <Bug pattern="OBL_UNSATISFIED_OBLIGATION" />
-    </Match>
-    <Match>
-        <Class name="~.*Test" />
-        <Bug pattern="ODR_OPEN_DATABASE_RESOURCE" />
-    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Summary

spotbugs-exclude.xml からテストクラス全体への一括除外を削除。

修正前: `~.*Test` パターンで全テストクラスのリソースリーク検査を一括免除。
修正後: 除外を削除し、テストコードもプロダクションコードと同等の検査対象とした。
プロダクションに近い integration test でのリソース漏れを早期検出できる。

Resolves issue 656

## Test plan

- [ ] `./gradlew :streamconverter-core:spotbugsMain` — 違反なし
- [ ] `./gradlew build` — CIパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
