### PR TITLE
refactor(csv): add since/forRemoval to @Deprecated annotations in CsvNavigateCommand

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvNavigateCommand.java
@@ -34,7 +34,7 @@ public class CsvNavigateCommand extends AbstractStreamCommand {
    * @throws IllegalArgumentException if columnSelector or rule is null
    * @deprecated Use {@link #CsvNavigateCommand(CSVPath, IRule)} instead
    */
-  @Deprecated
+  @Deprecated(since = "1.2", forRemoval = true)
   private CsvNavigateCommand(String columnSelector, IRule rule) {
     this.columnSelector = CSVPath.of(columnSelector);
     this.rule = rule;
@@ -75,7 +75,7 @@ public class CsvNavigateCommand extends AbstractStreamCommand {
    * @throws IllegalArgumentException if rule is null
    * @deprecated Use {@link #create(CSVPath, IRule)} instead
    */
-  @Deprecated
+  @Deprecated(since = "1.2", forRemoval = true)
   public static CsvNavigateCommand create(String columnSelector, IRule rule) {
     if (columnSelector == null) {
       throw new IllegalArgumentException("Column selector cannot be null");


### PR DESCRIPTION
## Summary

- **#655**: `CsvNavigateCommand.java` の `@Deprecated` アノテーションに `since` と `forRemoval` 属性を追加
  - 修正前: `@Deprecated` のみで廃止予定時期と削除予定の有無が不明
  - 修正後: `@Deprecated(since = "1.2", forRemoval = true)` で廃止バージョンと削除予定を明示
  - IDEや静的解析ツールが適切な警告を表示できるようになる

## Test plan

- [ ] `./gradlew :streamconverter-core:test` — 411テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
