### PR TITLE
fix(http): resolve SSRF bypass and error body exposure in SendHttpCommand (#653, #657)

### DIFF
--- a/streamconverter-http/src/main/java/com/streamconverter/command/impl/SendHttpCommand.java
+++ b/streamconverter-http/src/main/java/com/streamconverter/command/impl/SendHttpCommand.java
@@ -150,13 +150,13 @@ public class SendHttpCommand extends AbstractStreamCommand {
     // まずリテラルIPとして解析を試みる
     if (InetAddresses.isInetAddress(host)) {
       InetAddress address = InetAddresses.forString(host);
-      return address.isSiteLocalAddress() || address.isLoopbackAddress();
+      return isNonRoutable(address);
     }
     // ホスト名: DNS解決して全アドレスを検査する
     try {
       InetAddress[] addresses = InetAddress.getAllByName(host);
       for (InetAddress address : addresses) {
-        if (address.isSiteLocalAddress() || address.isLoopbackAddress()) {
+        if (isNonRoutable(address)) {
           return true;
         }
       }
@@ -164,6 +164,14 @@ public class SendHttpCommand extends AbstractStreamCommand {
     } catch (UnknownHostException e) {
       throw new IllegalArgumentException("Cannot resolve hostname: " + host, e);
     }
+  }
+
+  private static boolean isNonRoutable(InetAddress address) {
+    return address.isSiteLocalAddress()
+        || address.isLoopbackAddress()
+        || address.isLinkLocalAddress()
+        || address.isAnyLocalAddress()
+        || address.isMulticastAddress();
   }
 
   /**
@@ -211,7 +219,7 @@ public class SendHttpCommand extends AbstractStreamCommand {
                                   String.format(
                                       "HTTP request failed: status=%d, url=%s, response=%s",
                                       response.statusCode().value(),
-                                      url,
+                                      sanitizeUrl(url),
                                       truncate(errorBody, 256)))))
           .bodyToFlux(org.springframework.core.io.buffer.DataBuffer.class)
           .timeout(Duration.ofMinutes(5)) // 大容量データ処理のため5分に延長
@@ -228,7 +236,7 @@ public class SendHttpCommand extends AbstractStreamCommand {
                   throw new RuntimeException(
                       String.format(
                           "Failed to write response data to output stream (url=%s, bytesWritten=%d)",
-                          url, totalBytesWritten[0]),
+                          sanitizeUrl(url), totalBytesWritten[0]),
                       e);
                 } finally {
                   org.springframework.core.io.buffer.DataBufferUtils.release(dataBuffer);
@@ -261,5 +269,21 @@ public class SendHttpCommand extends AbstractStreamCommand {
       return s;
     }
     return s.substring(0, maxLength) + "...[truncated]";
+  }
+
+  /** URLのクエリ文字列とユーザー情報を除去してログ・例外メッセージへの資格情報漏洩を防ぐ。 */
+  static String sanitizeUrl(String rawUrl) {
+    if (rawUrl == null) {
+      return null;
+    }
+    try {
+      URI uri = new URI(rawUrl);
+      return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(), null, null)
+          .toString();
+    } catch (URISyntaxException e) {
+      // 解析不能な場合はスキームとホストのみ抽出を試みる
+      int idx = rawUrl.indexOf('?');
+      return idx >= 0 ? rawUrl.substring(0, idx) : rawUrl;
+    }
   }
 }

--- a/streamconverter-http/src/main/java/com/streamconverter/command/impl/SendHttpCommand.java
+++ b/streamconverter-http/src/main/java/com/streamconverter/command/impl/SendHttpCommand.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Objects;
@@ -140,16 +141,28 @@ public class SendHttpCommand extends AbstractStreamCommand {
         || "::1".equals(cleanHost);
   }
 
-  /** プライベートIPアドレスかどうかを判定する（Guava使用） */
+  /**
+   * ホストがプライベートIPに解決されるかを判定する。
+   * リテラルIPはGuavaで即解析し、ホスト名はDNS解決後に検査する。
+   * 解決不能なホスト名は例外をスローしてアクセスを拒否する。
+   */
   private boolean isPrivateIpAddress(String host) {
-    try {
-      // GuavaのInetAddressesを使用してIPアドレスを解析
+    // まずリテラルIPとして解析を試みる
+    if (InetAddresses.isInetAddress(host)) {
       InetAddress address = InetAddresses.forString(host);
-      // RFC 1918準拠のプライベートアドレス判定
       return address.isSiteLocalAddress() || address.isLoopbackAddress();
-    } catch (IllegalArgumentException e) {
-      // IPアドレス形式でない場合（ホスト名など）はfalseを返す
+    }
+    // ホスト名: DNS解決して全アドレスを検査する
+    try {
+      InetAddress[] addresses = InetAddress.getAllByName(host);
+      for (InetAddress address : addresses) {
+        if (address.isSiteLocalAddress() || address.isLoopbackAddress()) {
+          return true;
+        }
+      }
       return false;
+    } catch (UnknownHostException e) {
+      throw new IllegalArgumentException("Cannot resolve hostname: " + host, e);
     }
   }
 
@@ -197,7 +210,9 @@ public class SendHttpCommand extends AbstractStreamCommand {
                               new RuntimeException(
                                   String.format(
                                       "HTTP request failed: status=%d, url=%s, response=%s",
-                                      response.statusCode().value(), url, errorBody))))
+                                      response.statusCode().value(),
+                                      url,
+                                      truncate(errorBody, 256)))))
           .bodyToFlux(org.springframework.core.io.buffer.DataBuffer.class)
           .timeout(Duration.ofMinutes(5)) // 大容量データ処理のため5分に延長
           .doOnNext(
@@ -239,5 +254,12 @@ public class SendHttpCommand extends AbstractStreamCommand {
       logger.error(errorMessage, e);
       throw new IOException(errorMessage, e);
     }
+  }
+
+  private static String truncate(String s, int maxLength) {
+    if (s == null || s.length() <= maxLength) {
+      return s;
+    }
+    return s.substring(0, maxLength) + "...[truncated]";
   }
 }

--- a/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandSecurityTest.java
+++ b/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandSecurityTest.java
@@ -123,4 +123,18 @@ class SendHttpCommandSecurityTest {
         ex172.getMessage().contains("private") || ex172.getMessage().contains("localhost"),
         "エラーメッセージにprivate or localhostが含まれるべき");
   }
+
+  // ---- #653: ホスト名を DNS 解決してプライベート IP を検出する ----
+
+  @Test
+  @DisplayName("解決不能なホスト名は IllegalArgumentException をスローする（#653）")
+  void testUnresolvableHostThrows() {
+    // 修正前: InetAddresses.forString() がホスト名で IllegalArgumentException → catch して false
+    // を返す。つまり解決不能ホスト名が通過する。
+    // 修正後: InetAddress.getAllByName() で解決を試みて失敗したら IllegalArgumentException をスロー。
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new SendHttpCommand("http://this-host-does-not-exist.invalid"),
+        "解決不能なホスト名はブロックされるべき");
+  }
 }

--- a/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandSecurityTest.java
+++ b/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandSecurityTest.java
@@ -3,7 +3,9 @@ package com.streamconverter.command.impl;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /** SendHttpCommandのセキュリティ機能専用テスト */
 class SendHttpCommandSecurityTest {
@@ -47,6 +49,8 @@ class SendHttpCommandSecurityTest {
   }
 
   @Test
+  @Tag("network")
+  @DisabledIfSystemProperty(named = "skipNetworkTests", matches = "true")
   @DisplayName("有効な外部URLは許可されることを確認")
   void testValidExternalUrl() {
     assertDoesNotThrow(
@@ -127,6 +131,8 @@ class SendHttpCommandSecurityTest {
   // ---- #653: ホスト名を DNS 解決してプライベート IP を検出する ----
 
   @Test
+  @Tag("network")
+  @DisabledIfSystemProperty(named = "skipNetworkTests", matches = "true")
   @DisplayName("解決不能なホスト名は IllegalArgumentException をスローする（#653）")
   void testUnresolvableHostThrows() {
     // 修正前: InetAddresses.forString() がホスト名で IllegalArgumentException → catch して false

--- a/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandWebClientTest.java
+++ b/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandWebClientTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
@@ -238,5 +239,71 @@ class SendHttpCommandWebClientTest {
     private boolean awaitFirstWrite(Duration timeout) throws InterruptedException {
       return firstWriteLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
     }
+  }
+
+  // ---- #657: エラーレスポンスボディを 256 文字に切り詰める ----
+
+  @Test
+  @DisplayName("エラーレスポンスボディが 256 文字を超える場合は切り詰められる（#657）")
+  void testErrorBodyIsTruncatedToMaxLength() throws Exception {
+    // 修正前: errorBody をそのままメッセージに埋め込む → 大きなボディが例外メッセージに入る
+    // 修正後: 256 文字超は "...[truncated]" サフィックス付きで切り詰める
+    String longBody = "E".repeat(300);
+    WebClient errorClient = createErrorWebClient(500, longBody);
+    SendHttpCommand command = new SendHttpCommand("https://example.com/post", errorClient);
+
+    IOException ex =
+        assertThrows(
+            IOException.class,
+            () ->
+                command.execute(
+                    new ByteArrayInputStream("body".getBytes(StandardCharsets.UTF_8)),
+                    new ByteArrayOutputStream()));
+
+    String causeMessage = ex.getCause().getMessage();
+    assertTrue(
+        causeMessage.contains("...[truncated]"),
+        "エラーメッセージに切り詰め表示が含まれるべき: " + causeMessage);
+    assertFalse(
+        causeMessage.contains(longBody),
+        "エラーメッセージに完全な 300 文字ボディが含まれてはいけない");
+  }
+
+  @Test
+  @DisplayName("エラーレスポンスボディが 256 文字以下の場合は切り詰めない（#657）")
+  void testShortErrorBodyIsNotTruncated() throws Exception {
+    String shortBody = "short error";
+    WebClient errorClient = createErrorWebClient(400, shortBody);
+    SendHttpCommand command = new SendHttpCommand("https://example.com/post", errorClient);
+
+    IOException ex =
+        assertThrows(
+            IOException.class,
+            () ->
+                command.execute(
+                    new ByteArrayInputStream("body".getBytes(StandardCharsets.UTF_8)),
+                    new ByteArrayOutputStream()));
+
+    String causeMessage = ex.getCause().getMessage();
+    assertTrue(causeMessage.contains(shortBody), "短いエラーボディはそのまま含まれるべき");
+    assertFalse(causeMessage.contains("...[truncated]"), "短いエラーボディは切り詰められないべき");
+  }
+
+  static WebClient createErrorWebClient(int statusCode, String responseBody) {
+    DefaultDataBufferFactory bufferFactory = new DefaultDataBufferFactory();
+    org.springframework.http.HttpStatus status =
+        org.springframework.http.HttpStatus.valueOf(statusCode);
+    ExchangeFunction exchangeFunction =
+        request ->
+            reactor.core.publisher.Mono.just(
+                ClientResponse.create(status)
+                    .header(HttpHeaders.CONTENT_TYPE,
+                        org.springframework.http.MediaType.TEXT_PLAIN_VALUE)
+                    .body(
+                        Flux.just(
+                            bufferFactory.wrap(
+                                responseBody.getBytes(StandardCharsets.UTF_8))))
+                    .build());
+    return WebClient.builder().exchangeFunction(exchangeFunction).build();
   }
 }


### PR DESCRIPTION
## Summary

- **#653**: `isPrivateIpAddress()` がホスト名を `InetAddresses.forString()` で解析し、失敗時に `false` を返してSSRF防御を回避できた。`InetAddress.getAllByName()` でDNS解決を行うよう修正。解決不能ホスト名は `IllegalArgumentException` をスロー
- **#657**: エラーレスポンスボディを無制限にメッセージへ埋め込んでいた。`truncate()` ヘルパーで 256 文字上限を追加

## 検証手順

1. develop ブランチで両テストが失敗することを確認
2. `isPrivateIpAddress()` を DNS 解決版に変更、`truncate()` メソッドを追加
3. テストが全て通過することを確認

## 対象ファイル

- `streamconverter-http/src/main/java/com/streamconverter/command/impl/SendHttpCommand.java`
- `streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandSecurityTest.java`
- `streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandWebClientTest.java`

Closes #653
Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)
