### PR TITLE
fix(db): remove database URL from INFO-level log output (#669)

### DIFF
--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/HikariConnectionPoolConfig.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/HikariConnectionPoolConfig.java
@@ -43,7 +43,6 @@ public class HikariConnectionPoolConfig implements AutoCloseable {
   private static final Logger logger = LoggerFactory.getLogger(HikariConnectionPoolConfig.class);
 
   private final HikariDataSource dataSource;
-  private final String databaseUrl;
 
   /**
    * デフォルト設定で接続プールを初期化
@@ -70,8 +69,6 @@ public class HikariConnectionPoolConfig implements AutoCloseable {
       throw new IllegalArgumentException("Maximum pool size must be positive");
     }
     Objects.requireNonNull(connectionTimeout, "Connection timeout cannot be null");
-
-    this.databaseUrl = databaseUrl;
 
     HikariConfig config = new HikariConfig();
     config.setJdbcUrl(databaseUrl);
@@ -141,7 +138,7 @@ public class HikariConnectionPoolConfig implements AutoCloseable {
   /**
    * プールの詳細統計情報を取得
    *
-   * @return 詳細統計情報文字列
+   * @return 詳細統計情報文字列（URLは含まない）
    */
   public String getDetailedStats() {
     if (dataSource.isClosed()) {
@@ -150,12 +147,11 @@ public class HikariConnectionPoolConfig implements AutoCloseable {
 
     com.zaxxer.hikari.HikariPoolMXBean mxBean = dataSource.getHikariPoolMXBean();
     return String.format(
-        "HikariCP Details[active=%d, idle=%d, total=%d, waiting=%d, url=%s]",
+        "HikariCP Details[active=%d, idle=%d, total=%d, waiting=%d]",
         mxBean.getActiveConnections(),
         mxBean.getIdleConnections(),
         mxBean.getTotalConnections(),
-        mxBean.getThreadsAwaitingConnection(),
-        databaseUrl);
+        mxBean.getThreadsAwaitingConnection());
   }
 
   /**

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/HikariConnectionPoolConfig.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/HikariConnectionPoolConfig.java
@@ -98,8 +98,7 @@ public class HikariConnectionPoolConfig implements AutoCloseable {
     this.dataSource = new HikariDataSource(config);
 
     logger.info(
-        "HikariCP connection pool initialized - URL: {}, MaxPoolSize: {}, ConnectionTimeout: {}ms",
-        databaseUrl,
+        "HikariCP connection pool initialized - MaxPoolSize: {}, ConnectionTimeout: {}ms",
         maximumPoolSize,
         connectionTimeout.toMillis());
   }

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
@@ -70,7 +70,7 @@ public class PooledDatabaseFetchRule implements IRule {
     logger.info(
         "PooledDatabaseFetchRule initialized - Query length: {}, Pool: {}",
         this.query.length(),
-        connectionPool.getDetailedStats());
+        connectionPool.getPoolStats());
   }
 
   /**

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/HikariConnectionPoolConfigLogTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/HikariConnectionPoolConfigLogTest.java
@@ -6,6 +6,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import java.time.Duration;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
@@ -44,5 +45,36 @@ class HikariConnectionPoolConfigLogTest {
             .anyMatch(e -> e.getFormattedMessage().contains(testUrl));
 
     assertFalse(urlAppearsInInfoLog, "INFO ログにデータベース URL が含まれてはいけない");
+  }
+
+  // ---- #669: PooledDatabaseFetchRule の初期化 INFO ログも URL を含まない ----
+
+  @Test
+  @DisplayName("PooledDatabaseFetchRule の初期化 INFO ログにデータベース URL が含まれない（#669）")
+  void testPooledRuleInitInfoLogDoesNotContainDatabaseUrl() {
+    String testUrl = "jdbc:h2:mem:pooled-rule-669-" + System.nanoTime();
+
+    Logger pooledLogger =
+        (Logger) LoggerFactory.getLogger(PooledDatabaseFetchRule.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    pooledLogger.addAppender(appender);
+    pooledLogger.setLevel(Level.INFO);
+
+    try (HikariConnectionPoolConfig pool =
+            new HikariConnectionPoolConfig(testUrl, 2, Duration.ofSeconds(5))) {
+      new PooledDatabaseFetchRule(pool, "SELECT 1");
+    } catch (Exception e) {
+      // 接続失敗は無視 — URL ログ不在の確認が目的
+    } finally {
+      pooledLogger.detachAppender(appender);
+    }
+
+    boolean urlAppearsInInfoLog =
+        appender.list.stream()
+            .filter(e -> e.getLevel() == Level.INFO)
+            .anyMatch(e -> e.getFormattedMessage().contains(testUrl));
+
+    assertFalse(urlAppearsInInfoLog, "PooledDatabaseFetchRule の INFO ログにデータベース URL が含まれてはいけない");
   }
 }

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/HikariConnectionPoolConfigLogTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/HikariConnectionPoolConfigLogTest.java
@@ -1,6 +1,7 @@
 package com.streamconverter.command.rule;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -25,20 +26,23 @@ class HikariConnectionPoolConfigLogTest {
 
     Logger hikariLogger =
         (Logger) LoggerFactory.getLogger(HikariConnectionPoolConfig.class);
+    Level originalLevel = hikariLogger.getLevel();
     ListAppender<ILoggingEvent> appender = new ListAppender<>();
     appender.start();
     hikariLogger.addAppender(appender);
     hikariLogger.setLevel(Level.INFO);
 
     try (HikariConnectionPoolConfig pool = new HikariConnectionPoolConfig(testUrl)) {
-      // URL を含むINFOログが出力されているかを確認するため構築するだけでよい
-      // AutoCloseable なのでリソースは自動解放される
-    } catch (Exception e) {
-      // URL ログの確認が目的なので接続失敗は無視
+      // do nothing — construction triggers the INFO log under test
     } finally {
       hikariLogger.detachAppender(appender);
+      appender.stop();
+      hikariLogger.setLevel(originalLevel);
     }
 
+    assertTrue(
+        appender.list.stream().anyMatch(e -> e.getLevel() == Level.INFO),
+        "コンストラクタは少なくとも 1 件の INFO ログを出力するべき");
     boolean urlAppearsInInfoLog =
         appender.list.stream()
             .filter(e -> e.getLevel() == Level.INFO)
@@ -56,20 +60,24 @@ class HikariConnectionPoolConfigLogTest {
 
     Logger pooledLogger =
         (Logger) LoggerFactory.getLogger(PooledDatabaseFetchRule.class);
+    Level originalLevel = pooledLogger.getLevel();
     ListAppender<ILoggingEvent> appender = new ListAppender<>();
     appender.start();
     pooledLogger.addAppender(appender);
     pooledLogger.setLevel(Level.INFO);
 
     try (HikariConnectionPoolConfig pool =
-            new HikariConnectionPoolConfig(testUrl, 2, Duration.ofSeconds(5))) {
+        new HikariConnectionPoolConfig(testUrl, 2, Duration.ofSeconds(5))) {
       new PooledDatabaseFetchRule(pool, "SELECT 1");
-    } catch (Exception e) {
-      // 接続失敗は無視 — URL ログ不在の確認が目的
     } finally {
       pooledLogger.detachAppender(appender);
+      appender.stop();
+      pooledLogger.setLevel(originalLevel);
     }
 
+    assertTrue(
+        appender.list.stream().anyMatch(e -> e.getLevel() == Level.INFO),
+        "PooledDatabaseFetchRule の初期化は少なくとも 1 件の INFO ログを出力するべき");
     boolean urlAppearsInInfoLog =
         appender.list.stream()
             .filter(e -> e.getLevel() == Level.INFO)

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/HikariConnectionPoolConfigLogTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/HikariConnectionPoolConfigLogTest.java
@@ -1,0 +1,48 @@
+package com.streamconverter.command.rule;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+@DisplayName("HikariConnectionPoolConfig ログ出力テスト")
+class HikariConnectionPoolConfigLogTest {
+
+  // ---- #669: DB URL は INFO ログに含まれてはいけない ----
+
+  @Test
+  @DisplayName("コンストラクタの INFO ログにデータベース URL が含まれない（#669）")
+  void testConstructorInfoLogDoesNotContainDatabaseUrl() {
+    // 修正前: logger.info(..., databaseUrl, ...) で URL が INFO ログに出力される
+    // 修正後: URL をログに含めないよう修正
+    String testUrl = "jdbc:h2:mem:testdb-669-" + System.nanoTime();
+
+    Logger hikariLogger =
+        (Logger) LoggerFactory.getLogger(HikariConnectionPoolConfig.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    hikariLogger.addAppender(appender);
+    hikariLogger.setLevel(Level.INFO);
+
+    try (HikariConnectionPoolConfig pool = new HikariConnectionPoolConfig(testUrl)) {
+      // URL を含むINFOログが出力されているかを確認するため構築するだけでよい
+      // AutoCloseable なのでリソースは自動解放される
+    } catch (Exception e) {
+      // URL ログの確認が目的なので接続失敗は無視
+    } finally {
+      hikariLogger.detachAppender(appender);
+    }
+
+    boolean urlAppearsInInfoLog =
+        appender.list.stream()
+            .filter(e -> e.getLevel() == Level.INFO)
+            .anyMatch(e -> e.getFormattedMessage().contains(testUrl));
+
+    assertFalse(urlAppearsInInfoLog, "INFO ログにデータベース URL が含まれてはいけない");
+  }
+}


### PR DESCRIPTION
## Summary

- `HikariConnectionPoolConfig` コンストラクタが JDBC URL を INFO ログに出力していた（資格情報・内部ネットワーク情報の漏洩リスク）
- URL パラメータをログメッセージから除去。MaxPoolSize・ConnectionTimeout（非機密）は維持
- `getDetailedStats()` の `url=` フィールドも除去（Copilot レビュー対応）
- `PooledDatabaseFetchRule` コンストラクタの INFO ログを `getDetailedStats()` から `getPoolStats()`（URL なし）に変更（Copilot レビュー対応）
- `databaseUrl` インスタンスフィールドを削除（コンストラクタ内でのみ使用していたため）
- Logback `ListAppender` を使った回帰テストで develop での失敗→修正後の通過を確認
- `PooledDatabaseFetchRule` の初期化ログに URL が含まれないことも検証するテストを追加（Copilot レビュー対応）

## 検証手順

1. develop ブランチでテストが失敗することを確認（URL が INFO ログに含まれる）
2. `logger.info(...)` から `databaseUrl` パラメータを除去
3. テストが通過することを確認

## 対象ファイル

- `streamconverter-db/src/main/java/com/streamconverter/command/rule/HikariConnectionPoolConfig.java`
- `streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java`
- `streamconverter-db/src/test/java/com/streamconverter/command/rule/HikariConnectionPoolConfigLogTest.java` (新規)

Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)
