### PR TITLE
fix(security): route XMLOutputFactory creation through SecureXmlConfiguration

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
@@ -12,7 +12,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
 import org.slf4j.Logger;
@@ -71,7 +70,8 @@ public class XmlFilterCommand extends AbstractStreamCommand {
 
   private void processEvents(XMLEventReader reader, Writer writer) throws IOException {
     try {
-      XmlExtractionState state = new XmlExtractionState(XMLOutputFactory.newInstance());
+      XmlExtractionState state =
+          new XmlExtractionState(SecureXmlConfiguration.createSecureXMLOutputFactory());
       drainEvents(reader, writer, state);
       if (state.isCaptureOpen()) {
         state.abortCapture();

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
@@ -13,7 +13,6 @@ import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
 import org.slf4j.Logger;
@@ -151,16 +150,17 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
   }
 
   /**
-   * Creates the {@link XMLEventWriter} for the given output stream. Protected for testing.
+   * 出力ストリームへの XMLEventWriter を作成する。
    *
-   * @param outputStream the stream to write XML events to
-   * @return a new XMLEventWriter backed by the given stream
-   * @throws XMLStreamException if the writer cannot be created
+   * <p>テスト時にオーバーライドしてファクトリをモック可能にするため protected スコープとしている。
+   *
+   * @param outputStream 書き込み先ストリーム
+   * @return 設定済み XMLEventWriter
+   * @throws XMLStreamException ライターの生成に失敗した場合
    */
   protected XMLEventWriter createXMLEventWriter(OutputStream outputStream)
       throws XMLStreamException {
-    XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-    return outputFactory.createXMLEventWriter(outputStream);
+    return SecureXmlConfiguration.createSecureXMLOutputFactory().createXMLEventWriter(outputStream);
   }
 
   private IOException buildXmlException(XMLStreamException e) {

--- a/streamconverter-core/src/main/java/com/streamconverter/security/SecureXmlConfiguration.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/security/SecureXmlConfiguration.java
@@ -6,6 +6,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.validation.SchemaFactory;
 import org.slf4j.Logger;
@@ -114,6 +115,21 @@ public class SecureXmlConfiguration {
     factory.setProperty(XMLInputFactory.IS_VALIDATING, false);
 
     securityLogger.info("Secure XMLInputFactory created with XXE protection");
+    return factory;
+  }
+
+  /**
+   * セキュリティ設定を明示した XMLOutputFactory を作成します。
+   *
+   * <p>XMLOutputFactory 仕様には外部エンティティ制御プロパティが存在しないが、 使用箇所を一元管理することで将来の実装差し替え時の保護となる。 {@code
+   * IS_REPAIRING_NAMESPACES} を false に設定し、 不正な名前空間宣言の自動補完を防ぐ。
+   *
+   * @return セキュリティ設定済み XMLOutputFactory
+   */
+  public static XMLOutputFactory createSecureXMLOutputFactory() {
+    XMLOutputFactory factory = XMLOutputFactory.newInstance();
+    factory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, false);
+    securityLogger.info("Secure XMLOutputFactory created");
     return factory;
   }
 

--- a/streamconverter-core/src/test/java/com/streamconverter/security/SecureXmlConfigurationTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/security/SecureXmlConfigurationTest.java
@@ -1,0 +1,29 @@
+package com.streamconverter.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import javax.xml.stream.XMLOutputFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** SecureXmlConfiguration の XMLOutputFactory 生成メソッドのテスト */
+class SecureXmlConfigurationTest {
+
+  @Test
+  @DisplayName("createSecureXMLOutputFactory が null でない XMLOutputFactory を返す")
+  void createSecureXMLOutputFactory_returnsNonNull() {
+    XMLOutputFactory factory = SecureXmlConfiguration.createSecureXMLOutputFactory();
+    assertNotNull(factory);
+  }
+
+  @Test
+  @DisplayName("createSecureXMLOutputFactory が IS_REPAIRING_NAMESPACES=false の設定で返す")
+  void createSecureXMLOutputFactory_repairingNamespacesDisabled() {
+    XMLOutputFactory factory = SecureXmlConfiguration.createSecureXMLOutputFactory();
+    Object value = factory.getProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES);
+    assertFalse(
+        Boolean.TRUE.equals(value),
+        "IS_REPAIRING_NAMESPACES should be false to prevent namespace auto-repair");
+  }
+}


### PR DESCRIPTION
## Summary

- `SecureXmlConfiguration.createSecureXMLOutputFactory()` を追加し、`XMLOutputFactory` の生成を一元管理
- `XmlNavigateCommand.createXMLEventWriter()` と `XmlFilterCommand.processEvents()` が直接 `XMLOutputFactory.newInstance()` を呼んでいた箇所を新メソッド経由に変更
- `IS_REPAIRING_NAMESPACES=false` を明示設定し、不正な名前空間宣言の自動補完を防止

## Test plan

- [x] `SecureXmlConfigurationTest`: `createSecureXMLOutputFactory()` が非 null かつ `IS_REPAIRING_NAMESPACES=false` を返すことを確認（修正前はコンパイルエラーで失敗）
- [x] 既存の `XmlNavigateCommandTest`（11件）がすべてパス
- [x] `streamconverter-core` 全413テスト通過
- [x] PMD 違反 0
- [x] SpotBugs 違反 0

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)
