### PR TITLE
fix: move XMLEventFactory to method-local scope in XmlNavigateCommand

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlNavigateCommand.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
  */
 public class XmlNavigateCommand extends AbstractStreamCommand {
   private static final Logger logger = LoggerFactory.getLogger(XmlNavigateCommand.class);
-  private static final XMLEventFactory EVENT_FACTORY = XMLEventFactory.newInstance();
 
   private final TreePath treePath;
   private final IRule rule;
@@ -104,6 +103,7 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
   private void navigateXmlWithRule(
       XMLEventReader eventReader, XMLEventWriter eventWriter, TreePath treePath, IRule rule)
       throws XMLStreamException {
+    XMLEventFactory eventFactory = XMLEventFactory.newInstance();
     List<String> currentPath = new ArrayList<>();
 
     while (eventReader.hasNext()) {
@@ -129,7 +129,7 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
         }
         // Write every event unconditionally; character events at the target path are replaced
         // above.
-        event = EVENT_FACTORY.createCharacters(transformed);
+        event = eventFactory.createCharacters(transformed);
       }
 
       eventWriter.add(event);

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/XmlNavigateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/XmlNavigateCommandTest.java
@@ -1,5 +1,6 @@
 package com.streamconverter.command.impl.xml;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,7 +13,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLStreamException;
 import org.junit.jupiter.api.BeforeEach;
@@ -364,5 +368,22 @@ class XmlNavigateCommandTest {
     public javax.xml.namespace.NamespaceContext getNamespaceContext() {
       return delegate.getNamespaceContext();
     }
+  }
+
+  @Test
+  @DisplayName("XmlNavigateCommand は XMLEventFactory を static final フィールドとして保持しない（スレッドセーフ保証のため）")
+  void xmlNavigateCommand_hasNoStaticFinalXmlEventFactoryField() {
+    boolean hasStaticFinalEventFactory =
+        Arrays.stream(XmlNavigateCommand.class.getDeclaredFields())
+            .filter(f -> XMLEventFactory.class.isAssignableFrom(f.getType()))
+            .anyMatch(
+                f -> {
+                  int mod = f.getModifiers();
+                  return Modifier.isStatic(mod) && Modifier.isFinal(mod);
+                });
+
+    assertFalse(
+        hasStaticFinalEventFactory,
+        "XMLEventFactory should not be held as static final field — thread safety is not guaranteed by the spec");
   }
 }


### PR DESCRIPTION
## Summary

- `XmlNavigateCommand` の `static final XMLEventFactory EVENT_FACTORY` フィールドを削除
- `navigateXmlWithRule()` 内でメソッドローカル変数として `XMLEventFactory.newInstance()` を生成するよう変更
- `XMLEventFactory` のスレッドセーフ保証は JAXP 仕様上存在しないため、共有インスタンスを排除

## Test plan

- [x] `XmlNavigateCommandTest.xmlNavigateCommand_hasNoStaticFinalXmlEventFactoryField`: `static final XMLEventFactory` フィールドがないことをリフレクションで確認（修正前は `assertFalse` で失敗）
- [x] 既存の `XmlNavigateCommandTest`（12件）がすべてパス
- [x] PMD 違反 0
- [x] SpotBugs 違反 0

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)
