### PR TITLE
refactor(db): remove sanitizeInput() and keyword-based SQL injection pattern

### DIFF
--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
@@ -36,9 +36,7 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li>SELECTクエリのみ許可（INSERT/UPDATE/DELETE等は禁止）
- *   <li>SQLインジェクション攻撃の検出と防止
  *   <li>許可されたデータベーススキーマのみ接続可能
- *   <li>入力パラメータの自動サニタイズ
  * </ul>
  */
 public class DatabaseFetchRule implements IRule {
@@ -117,10 +115,6 @@ public class DatabaseFetchRule implements IRule {
     return SqlQueryUtils.validateQuery(queryString, logger);
   }
 
-  private String sanitizeInput(String input) {
-    return SqlQueryUtils.sanitizeInput(input, logger);
-  }
-
   /**
    * ルールの適用を実行します。
    *
@@ -140,17 +134,8 @@ public class DatabaseFetchRule implements IRule {
 
       // 入力文字列をパラメータとして設定（クエリに「?」プレースホルダーがある場合）
       if (query.contains("?") && input != null && !input.isEmpty()) {
-        // 入力値のサニタイズとセキュリティチェック
-        String sanitizedInput = sanitizeInput(input);
-        if (sanitizedInput.isEmpty()) {
-          logger.warn(
-              "Input parameter was sanitized to empty string. Rejecting input for security reasons. Original input: {}",
-              input);
-          return "";
-        }
-
-        statement.setString(1, sanitizedInput);
-        logger.debug("Parameter set for prepared statement: length={}", sanitizedInput.length());
+        statement.setString(1, input);
+        logger.debug("Parameter set for prepared statement: length={}", input.length());
       }
 
       // クエリ実行

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
@@ -69,7 +69,13 @@ public class DatabaseFetchRule implements IRule {
     this.databaseUrl = validateDatabaseUrl(databaseUrl.trim());
 
     // クエリの検証
-    this.query = validateQuery(query.trim());
+    String trimmed = query.trim();
+    long placeholderCount = trimmed.chars().filter(c -> c == '?').count();
+    if (placeholderCount > 1) {
+      throw new IllegalArgumentException(
+          "Query must have at most one placeholder '?', found " + placeholderCount);
+    }
+    this.query = validateQuery(trimmed);
 
     logger.info(
         "DatabaseFetchRule initialized with secure validation - URL: {}, Query length: {}",

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
@@ -65,7 +65,13 @@ public class PooledDatabaseFetchRule implements IRule {
     Objects.requireNonNull(query, "Query cannot be null");
 
     this.connectionPool = connectionPool;
-    this.query = validateQuery(query.trim());
+    String trimmed = query.trim();
+    long placeholderCount = trimmed.chars().filter(c -> c == '?').count();
+    if (placeholderCount > 1) {
+      throw new IllegalArgumentException(
+          "Query must have at most one placeholder '?', found " + placeholderCount);
+    }
+    this.query = validateQuery(trimmed);
 
     logger.info(
         "PooledDatabaseFetchRule initialized - Query length: {}, Pool: {}",
@@ -84,10 +90,6 @@ public class PooledDatabaseFetchRule implements IRule {
     return SqlQueryUtils.validateQuery(queryString, logger);
   }
 
-  private String sanitizeInput(String input) {
-    return SqlQueryUtils.sanitizeInput(input, logger);
-  }
-
   /**
    * ルールの適用を実行します。
    *
@@ -104,52 +106,13 @@ public class PooledDatabaseFetchRule implements IRule {
     try (Connection connection = connectionPool.getConnection();
         PreparedStatement statement = connection.prepareStatement(query)) {
 
-      if (query.contains("?") && input != null && !input.isEmpty()) {
-        String sanitizedInput = sanitizeInput(input);
-        if (sanitizedInput.isEmpty()) {
-          logger.warn(
-              "Input parameter was sanitized to empty string. Rejecting input for security reasons. Original input: {}",
-              input);
-          return "";
-        }
-
-        statement.setString(1, sanitizedInput);
-        logger.debug("Parameter set for prepared statement: length={}", sanitizedInput.length());
+      if (!bindParameters(statement, input)) {
+        return "";
       }
 
       logger.debug("Executing query with pooled connection: {}", query);
       try (ResultSet resultSet = statement.executeQuery()) {
-        ResultSetMetaData metaData = resultSet.getMetaData();
-        int columnCount = metaData.getColumnCount();
-
-        if (!resultSet.next()) {
-          logger.debug("Query returned no results.");
-          return "";
-        }
-
-        if (columnCount != 1) {
-          logger.debug("Query returned {} columns; using first column.", columnCount);
-        }
-
-        String value = resultSet.getString(1);
-
-        boolean hasMoreRows = resultSet.next();
-        if (hasMoreRows) {
-          logger.info("Query returned multiple rows; using first row.");
-        }
-
-        if (value == null) {
-          logger.debug("First row value is NULL.");
-          return "";
-        }
-
-        if (columnCount == 1 && !hasMoreRows) {
-          logger.debug("Fetched single value from database (pooled): {}", value);
-        } else {
-          logger.debug("Fetched first value from database (pooled): {}", value);
-        }
-
-        return value;
+        return extractFirstValue(resultSet);
       }
 
     } catch (SQLException e) {
@@ -163,6 +126,54 @@ public class PooledDatabaseFetchRule implements IRule {
       throw new StreamProcessingException(
           "Database fetch failed: " + e.getMessage(), e);
     }
+  }
+
+  /** クエリにプレースホルダーがある場合に入力値をバインドする。拒否すべき入力なら false を返す。 */
+  private boolean bindParameters(PreparedStatement statement, String input) throws SQLException {
+    if (!query.contains("?")) {
+      return true;
+    }
+    if (input == null || input.isEmpty()) {
+      logger.warn("Query has a placeholder but input is null or empty. Rejecting to prevent unbound parameter.");
+      return false;
+    }
+    statement.setString(1, input);
+    logger.debug("Parameter set for prepared statement: length={}", input.length());
+    return true;
+  }
+
+  /** ResultSet から先頭行・先頭列の値を取得して返す。結果なしの場合は空文字列を返す。 */
+  private String extractFirstValue(ResultSet resultSet) throws SQLException {
+    ResultSetMetaData metaData = resultSet.getMetaData();
+    int columnCount = metaData.getColumnCount();
+
+    if (!resultSet.next()) {
+      logger.warn("クエリ結果が空です。");
+      return "";
+    }
+
+    if (columnCount != 1) {
+      logger.warn("クエリ結果が一列ではありません。列数: {}。先頭列の値を使用します。", columnCount);
+    }
+
+    String value = resultSet.getString(1);
+    boolean hasMoreRows = resultSet.next();
+    if (hasMoreRows) {
+      logger.warn("クエリ結果が複数行あります。先頭行の値を使用します。");
+    }
+
+    if (value == null) {
+      logger.info("クエリ結果の先頭値がNULLです。");
+      return "";
+    }
+
+    if (columnCount == 1 && !hasMoreRows) {
+      logger.debug("データベースから単一値を取得しました（プール使用）: {}", value);
+    } else {
+      logger.debug("データベースから先頭値を取得しました（プール使用）: {}", value);
+    }
+
+    return value;
   }
 
   /**

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/SqlQueryUtils.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/SqlQueryUtils.java
@@ -1,22 +1,15 @@
 package com.streamconverter.command.rule;
 
 import java.util.Locale;
-import java.util.regex.Pattern;
 import org.slf4j.Logger;
 
 /**
- * SQLクエリの検証・サニタイズユーティリティ。
+ * SQLクエリの検証ユーティリティ。
  *
  * <p>{@link DatabaseFetchRule} と {@link PooledDatabaseFetchRule} で共有される
  * ロジックを提供します。
  */
 final class SqlQueryUtils {
-
-  /** SQLインジェクション攻撃を検出するパターン（SELECT以外の危険なSQL文） */
-  private static final Pattern SQL_INJECTION_PATTERN =
-      Pattern.compile(
-          ".*(union|insert|update|delete|drop|create|alter|exec|execute|sp_|xp_).*",
-          Pattern.CASE_INSENSITIVE);
 
   private SqlQueryUtils() {}
 
@@ -39,12 +32,6 @@ final class SqlQueryUtils {
       throw new SecurityException("Only SELECT queries are allowed: " + queryString);
     }
 
-    // SQLインジェクション攻撃の検出（パターンマッチング使用）
-    if (SQL_INJECTION_PATTERN.matcher(queryString).matches()) {
-      throw new SecurityException(
-          "Query contains potentially dangerous SQL commands: " + queryString);
-    }
-
     // セミコロンによる複数文の実行を防止（末尾の1個のみ許可）
     String stripped = queryString.trim();
     String withoutTrailingSemicolon = stripped.endsWith(";") ? stripped.substring(0, stripped.length() - 1) : stripped;
@@ -56,33 +43,4 @@ final class SqlQueryUtils {
     return queryString;
   }
 
-  /**
-   * 入力パラメータをサニタイズします。
-   *
-   * @param input サニタイズ対象の入力
-   * @param logger ロガー
-   * @return サニタイズされた入力（非null）
-   * @throws IllegalArgumentException inputがnullの場合
-   */
-  static String sanitizeInput(String input, Logger logger) {
-    if (input == null) {
-      throw new IllegalArgumentException("Input parameter cannot be null");
-    }
-
-    // PreparedStatement がパラメータバインディングを担うため、シングルクォートエスケープは行わない。
-    // ここでは PreparedStatement を通じないコンテキスト向けに残存する危険パターンのみ除去する。
-    String sanitized =
-        input
-            .replace("--", "") // SQLコメントの除去
-            .replace("/*", "") // ブロックコメント開始の除去
-            .replace("*/", ""); // ブロックコメント終了の除去
-
-    // 極端に長い入力の制限
-    if (sanitized.length() > 1000) {
-      logger.warn("Input parameter is extremely long, truncating: length={}", sanitized.length());
-      sanitized = sanitized.substring(0, 1000);
-    }
-
-    return sanitized;
-  }
 }

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseFetchRuleIntegrationTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseFetchRuleIntegrationTest.java
@@ -158,11 +158,6 @@ public class DatabaseFetchRuleIntegrationTest {
           new DatabaseFetchRule(dbUrl, "INSERT INTO users VALUES (99, 'hacker', 'evil@hack.com')");
         });
 
-    assertThrows(
-        SecurityException.class,
-        () -> {
-          new DatabaseFetchRule(dbUrl, "SELECT * FROM users UNION SELECT * FROM products");
-        });
   }
 
   @Test
@@ -189,7 +184,7 @@ public class DatabaseFetchRuleIntegrationTest {
 
     // シングルクォートを含む入力
     String result = rule.apply("John's");
-    // サニタイズされて検索されるが、マッチしないため空文字列
+    // PreparedStatement で安全にバインドされるが、マッチしないため空文字列
     assertEquals("", result);
   }
 

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/SqlQueryUtilsTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/SqlQueryUtilsTest.java
@@ -1,0 +1,54 @@
+package com.streamconverter.command.rule;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@DisplayName("SqlQueryUtils.validateQuery のテスト")
+class SqlQueryUtilsTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(SqlQueryUtilsTest.class);
+
+  @Test
+  @DisplayName("空文字列は IllegalArgumentException")
+  void testEmptyQueryRejected() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SqlQueryUtils.validateQuery("", logger));
+  }
+
+  @Test
+  @DisplayName("SELECT 以外のクエリは SecurityException")
+  void testNonSelectRejected() {
+    assertThrows(
+        SecurityException.class,
+        () -> SqlQueryUtils.validateQuery("INSERT INTO users VALUES (1, 'x')", logger));
+  }
+
+  @Test
+  @DisplayName("セミコロンによる複数文は SecurityException")
+  void testMultipleStatementRejected() {
+    assertThrows(
+        SecurityException.class,
+        () -> SqlQueryUtils.validateQuery("SELECT 1; DROP TABLE users", logger));
+  }
+
+  @Test
+  @DisplayName("正常な SELECT クエリは通過する")
+  void testValidSelectPasses() {
+    assertDoesNotThrow(
+        () -> SqlQueryUtils.validateQuery("SELECT name FROM users WHERE id = ?", logger));
+  }
+
+  @Test
+  @DisplayName("updates_count カラムを含むクエリは誤検知されない")
+  void testUpdatesCountColumnPasses() {
+    assertDoesNotThrow(
+        () -> SqlQueryUtils.validateQuery(
+            "SELECT updates_count, reunion_id FROM events WHERE id = ?", logger));
+  }
+}


### PR DESCRIPTION
## Summary

- `SqlQueryUtils.sanitizeInput()` を削除
  - PreparedStatement のパラメータバインドで SQL インジェクションは完全に防がれるため不要
  - `--` や `/*` の文字列置換は正当な入力値（例: ユーザー名に `--` を含む）を破壊する
- `SqlQueryUtils` のキーワード正規表現（`UNION`, `INSERT` 等）を削除
  - 開発者が渡す固定クエリに対するキーワード検出は `updates_count` 等の正当なカラム名を誤拒否するリスクがある
  - `SELECT` 始まり制約とセミコロン複数文禁止のみで十分
- `PooledDatabaseFetchRule` に `bindParameters()` / `extractFirstValue()` を抽出（#678 のアイデアを吸収）
- `PooledDatabaseFetchRule` のコンストラクタに `?` 複数チェックを追加

Closes #651, closes #678, closes #679
Supersedes #678, #679

## Test plan

- [x] `./gradlew :streamconverter-db:test` — 34テストパス
- [x] `SqlQueryUtilsTest` 新規追加（5テスト）
- [x] `updates_count` を含む SELECT クエリが `SecurityException` を投げないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
