### PR TITLE
refactor: rename NavigateCommand to Walker (Xml/Csv/Json)

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -35,10 +35,10 @@
         <Bug pattern="ODR_OPEN_DATABASE_RESOURCE" />
     </Match>
 
-    <!-- XmlNavigateCommand: constructor null-checks are intentional (Copilot review #662).
+    <!-- XmlWalker: constructor null-checks are intentional (Copilot review #662).
          The class is package-private and not subclassed externally, so finalizer attack risk is negligible. -->
     <Match>
-        <Class name="com.streamconverter.command.impl.xml.XmlNavigateCommand" />
+        <Class name="com.streamconverter.command.impl.xml.XmlWalker" />
         <Bug pattern="CT_CONSTRUCTOR_THROW" />
     </Match>
 </FindBugsFilter>

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvFilterCommand.java
@@ -16,9 +16,9 @@ import java.util.List;
 /**
  * CSV Filter Command Class
  *
- * <p>This class implements pure data extraction from CSV using column selectors. Unlike
- * CsvNavigateCommand which applies transformations, CsvFilterCommand only extracts/filters columns
- * based on specified column names or indices without any modifications.
+ * <p>This class implements pure data extraction from CSV using column selectors. Unlike CsvWalker
+ * which applies transformations, CsvFilterCommand only extracts/filters columns based on specified
+ * column names or indices without any modifications.
  *
  * <p>Features: - Extract specific columns using column names or indices - Preserve exact data
  * values from extracted columns - Memory-efficient streaming processing - Support for multiple

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
@@ -15,13 +15,13 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 
 /**
- * CSV Navigate Command Class
+ * CSV Walker
  *
  * <p>This class implements command for targeted CSV transformation using column selectors. It
  * identifies specific columns using column names or indices and applies IRule transformations to
  * those columns while preserving the overall CSV structure.
  */
-public class CsvNavigateCommand extends AbstractStreamCommand {
+public class CsvWalker extends AbstractStreamCommand {
 
   private final CSVPath columnSelector;
   private final IRule rule;
@@ -33,7 +33,7 @@ public class CsvNavigateCommand extends AbstractStreamCommand {
    * @param rule the transformation rule to apply to selected column
    * @throws IllegalArgumentException if columnSelector or rule is null
    */
-  private CsvNavigateCommand(CSVPath columnSelector, IRule rule) {
+  private CsvWalker(CSVPath columnSelector, IRule rule) {
     this.columnSelector = columnSelector;
     this.rule = rule;
   }
@@ -45,7 +45,7 @@ public class CsvNavigateCommand extends AbstractStreamCommand {
    * @param rule the transformation rule to apply to selected column
    * @throws IllegalArgumentException if treePath or rule is null
    */
-  private CsvNavigateCommand(TreePath treePath, IRule rule) {
+  private CsvWalker(TreePath treePath, IRule rule) {
     this.columnSelector = CSVPath.of(treePath.toString());
     this.rule = rule;
   }
@@ -55,35 +55,35 @@ public class CsvNavigateCommand extends AbstractStreamCommand {
    *
    * @param columnSelector the typed CSVPath to select column
    * @param rule the transformation rule to apply to selected column data
-   * @return a CsvNavigateCommand that extracts the specified column with the given rule
+   * @return a CsvWalker that extracts the specified column with the given rule
    * @throws IllegalArgumentException if columnSelector or rule is null
    */
-  public static CsvNavigateCommand create(CSVPath columnSelector, IRule rule) {
+  public static CsvWalker create(CSVPath columnSelector, IRule rule) {
     if (columnSelector == null) {
       throw new IllegalArgumentException("Column selector cannot be null");
     }
     if (rule == null) {
       throw new IllegalArgumentException("Rule cannot be null");
     }
-    return new CsvNavigateCommand(columnSelector, rule);
+    return new CsvWalker(columnSelector, rule);
   }
 
   /**
-   * Factory method for creating a CSV navigation command with TreePath compatibility.
+   * Factory method for creating a CSV walker with TreePath compatibility.
    *
    * @param treePath the TreePath representing column selector
    * @param rule the transformation rule to apply to selected column data
-   * @return a CsvNavigateCommand that extracts the specified column with the given rule
+   * @return a CsvWalker that extracts the specified column with the given rule
    * @throws IllegalArgumentException if treePath or rule is null
    */
-  public static CsvNavigateCommand create(TreePath treePath, IRule rule) {
+  public static CsvWalker create(TreePath treePath, IRule rule) {
     if (treePath == null) {
       throw new IllegalArgumentException("TreePath cannot be null");
     }
     if (rule == null) {
       throw new IllegalArgumentException("Rule cannot be null");
     }
-    return new CsvNavigateCommand(treePath, rule);
+    return new CsvWalker(treePath, rule);
   }
 
   @Override

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
@@ -55,7 +55,7 @@ public class CsvWalker extends AbstractStreamCommand {
    *
    * @param columnSelector the typed CSVPath to select column
    * @param rule the transformation rule to apply to selected column data
-   * @return a CsvWalker that extracts the specified column with the given rule
+   * @return a CsvWalker that transforms values in the specified column using the given rule
    * @throws IllegalArgumentException if columnSelector or rule is null
    */
   public static CsvWalker create(CSVPath columnSelector, IRule rule) {
@@ -73,7 +73,7 @@ public class CsvWalker extends AbstractStreamCommand {
    *
    * @param treePath the TreePath representing column selector
    * @param rule the transformation rule to apply to selected column data
-   * @return a CsvWalker that extracts the specified column with the given rule
+   * @return a CsvWalker that transforms values in the specified column using the given rule
    * @throws IllegalArgumentException if treePath or rule is null
    */
   public static CsvWalker create(TreePath treePath, IRule rule) {

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonFilterCommand.java
@@ -14,8 +14,8 @@ import java.util.List;
  * JSON Filter Command Class
  *
  * <p>This class implements pure data extraction from JSON using TreePath expressions. Unlike
- * JsonNavigateCommand which applies transformations, JsonFilterCommand only extracts/filters data
- * based on specified paths without any modifications.
+ * JsonWalker which applies transformations, JsonFilterCommand only extracts/filters data based on
+ * specified paths without any modifications.
  *
  * <p>Features: - Extract specific elements using TreePath expressions - Preserve exact data types
  * and structure of extracted elements - Streaming processing via Jackson Streaming API

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonWalker.java
@@ -17,8 +17,7 @@ import java.util.List;
  * JSON Walker for applying transformations to JSON data.
  *
  * <p>This command navigates through JSON structures and applies transformations using rules while
- * preserving the overall JSON structure. It focuses purely on navigation and transformation, not
- * extraction.
+ * preserving the overall JSON structure.
  *
  * <p>Responsibilities: - Navigate to specified JSON paths - Apply transformation rules to matching
  * elements - Preserve JSON structure during transformation - Stream processing for memory

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonWalker.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * JSON Navigation Command for applying transformations to JSON data
+ * JSON Walker for applying transformations to JSON data.
  *
  * <p>This command navigates through JSON structures and applies transformations using rules while
  * preserving the overall JSON structure. It focuses purely on navigation and transformation, not
@@ -24,7 +24,7 @@ import java.util.List;
  * elements - Preserve JSON structure during transformation - Stream processing for memory
  * efficiency
  */
-public class JsonNavigateCommand extends AbstractStreamCommand {
+public class JsonWalker extends AbstractStreamCommand {
 
   private final TreePath treePath;
   private final IRule rule;
@@ -37,7 +37,7 @@ public class JsonNavigateCommand extends AbstractStreamCommand {
    * @param rule the transformation rule to apply to selected elements
    * @throws IllegalArgumentException if treePath or rule is null
    */
-  private JsonNavigateCommand(TreePath treePath, IRule rule) {
+  private JsonWalker(TreePath treePath, IRule rule) {
     this.treePath = treePath;
     this.rule = rule;
     this.jsonFactory = new JsonFactory();
@@ -48,17 +48,17 @@ public class JsonNavigateCommand extends AbstractStreamCommand {
    *
    * @param treePath the TreePath to select data
    * @param rule the transformation rule to apply to selected elements
-   * @return a JsonNavigateCommand that transforms the specified path with the given rule
+   * @return a JsonWalker that transforms the specified path with the given rule
    * @throws IllegalArgumentException if treePath or rule is null
    */
-  public static JsonNavigateCommand create(TreePath treePath, IRule rule) {
+  public static JsonWalker create(TreePath treePath, IRule rule) {
     if (treePath == null) {
       throw new IllegalArgumentException("TreePath cannot be null");
     }
     if (rule == null) {
       throw new IllegalArgumentException("Rule cannot be null");
     }
-    return new JsonNavigateCommand(treePath, rule);
+    return new JsonWalker(treePath, rule);
   }
 
   @Override

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlFilterCommand.java
@@ -21,8 +21,8 @@ import org.slf4j.LoggerFactory;
  * XML Filter Command Class
  *
  * <p>This class implements pure data extraction from XML using TreePath expressions. Unlike
- * XmlNavigateCommand which applies transformations, XmlFilterCommand only extracts/filters elements
- * based on specified paths without any modifications.
+ * XmlWalker which applies transformations, XmlFilterCommand only extracts/filters elements based on
+ * specified paths without any modifications.
  *
  * <p>Features: - Extract specific elements using TreePath expressions - Preserve exact XML
  * structure of extracted elements - Memory-efficient streaming processing - Support for complex

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlWalker.java
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * XML Navigate Command for applying transformations to XML data.
+ * XML Walker for applying transformations to XML data.
  *
  * <p>This command navigates through XML structures and applies transformations using rules while
  * preserving the overall XML structure. It identifies specific elements using TreePath
@@ -31,8 +31,8 @@ import org.slf4j.LoggerFactory;
  * configured {@link TreePath} is transformed by the rule; all other events are passed through
  * unchanged.
  */
-public class XmlNavigateCommand extends AbstractStreamCommand {
-  private static final Logger logger = LoggerFactory.getLogger(XmlNavigateCommand.class);
+public class XmlWalker extends AbstractStreamCommand {
+  private static final Logger logger = LoggerFactory.getLogger(XmlWalker.class);
 
   private final TreePath treePath;
   private final IRule rule;
@@ -44,7 +44,7 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
    * @param rule the transformation rule to apply to selected elements
    * @throws IllegalArgumentException if treePath or rule is null
    */
-  XmlNavigateCommand(TreePath treePath, IRule rule) {
+  XmlWalker(TreePath treePath, IRule rule) {
     if (treePath == null) {
       throw new IllegalArgumentException("TreePath cannot be null");
     }
@@ -60,18 +60,17 @@ public class XmlNavigateCommand extends AbstractStreamCommand {
    *
    * @param treePath the TreePath to select elements
    * @param rule the transformation rule to apply to selected elements
-   * @return an XmlNavigateCommand that transforms the specified TreePath elements with the given
-   *     rule
+   * @return an XmlWalker that transforms the specified TreePath elements with the given rule
    * @throws IllegalArgumentException if treePath or rule is null
    */
-  public static XmlNavigateCommand create(TreePath treePath, IRule rule) {
+  public static XmlWalker create(TreePath treePath, IRule rule) {
     if (treePath == null) {
       throw new IllegalArgumentException("TreePath cannot be null");
     }
     if (rule == null) {
       throw new IllegalArgumentException("Rule cannot be null");
     }
-    return new XmlNavigateCommand(treePath, rule);
+    return new XmlWalker(treePath, rule);
   }
 
   @Override

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/IRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/IRule.java
@@ -20,7 +20,7 @@ package com.streamconverter.command.rule;
  *
  * // StreamConverterコマンドでの使用例
  * IRule dataCleaningRule = input -> input.trim().replaceAll("\\s+", " ");
- * JsonNavigateCommand command = JsonNavigateCommand.create(
+ * JsonWalker command = JsonWalker.create(
  *     TreePath.fromJson("$.user.name"),
  *     dataCleaningRule
  * );

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
@@ -24,7 +24,7 @@ import com.streamconverter.context.PipelineContext;
  * <pre>{@code
  * // XMLの orderId を抽出してMDCに伝搬
  * XmlWalker command = XmlWalker.create(
- *     TreePath.fromXPath("/order/@id"),
+ *     TreePath.fromXml("order/@id"),
  *     MdcPropagatingRule.create("orderId")
  * );
  * }</pre>

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
@@ -23,7 +23,7 @@ import com.streamconverter.context.PipelineContext;
  *
  * <pre>{@code
  * // XMLの orderId を抽出してMDCに伝搬
- * XmlNavigateCommand command = XmlNavigateCommand.create(
+ * XmlWalker command = XmlWalker.create(
  *     TreePath.fromXPath("/order/@id"),
  *     MdcPropagatingRule.create("orderId")
  * );
@@ -43,7 +43,7 @@ public final class MdcPropagatingRule implements IRule {
    * <p>使用例:
    *
    * <pre>{@code
-   * XmlNavigateCommand.create(
+   * XmlWalker.create(
    *     TreePath.fromXml("request/userId"),
    *     MdcPropagatingRule.create("userId"));
    * }</pre>

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/casing/CamelToSnakeCaseRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/casing/CamelToSnakeCaseRule.java
@@ -22,7 +22,7 @@ import java.util.Locale;
  *
  * <pre>{@code
  * IRule rule = CamelToSnakeCaseRule.builder().build();
- * IStreamCommand command = JsonNavigateCommand.create("$.userName", rule);
+ * IStreamCommand command = JsonWalker.create(TreePath.fromJson("$.userName"), rule);
  * }</pre>
  *
  * @since 1.0

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/casing/SnakeToCamelCaseRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/casing/SnakeToCamelCaseRule.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
  *
  * <pre>{@code
  * IRule rule = SnakeToCamelCaseRule.builder().build();
- * IStreamCommand command = JsonNavigateCommand.create("$.user_name", rule);
+ * IStreamCommand command = JsonWalker.create(TreePath.fromJson("$.user_name"), rule);
  * }</pre>
  *
  * @since 1.0

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/string/LowerCaseRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/string/LowerCaseRule.java
@@ -21,7 +21,7 @@ import java.util.Locale;
  *
  * <pre>{@code
  * IRule rule = new LowerCaseRule();
- * IRule localeRule = new LowerCaseRule(Locale.ENGLISH);
+ * IRule localeRule = LowerCaseRule.create(Locale.ENGLISH);
  * IStreamCommand command = JsonWalker.create(TreePath.fromJson("$.name"), rule);
  * }</pre>
  *

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/string/LowerCaseRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/string/LowerCaseRule.java
@@ -22,7 +22,7 @@ import java.util.Locale;
  * <pre>{@code
  * IRule rule = new LowerCaseRule();
  * IRule localeRule = new LowerCaseRule(Locale.ENGLISH);
- * IStreamCommand command = JsonNavigateCommand.create("$.name", rule);
+ * IStreamCommand command = JsonWalker.create(TreePath.fromJson("$.name"), rule);
  * }</pre>
  *
  * @since 1.0

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/string/TrimRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/string/TrimRule.java
@@ -20,7 +20,7 @@ import com.streamconverter.command.rule.IRule;
  *
  * <pre>{@code
  * IRule rule = new TrimRule();
- * IStreamCommand command = JsonNavigateCommand.create("$.name", rule);
+ * IStreamCommand command = JsonWalker.create(TreePath.fromJson("$.name"), rule);
  * }</pre>
  *
  * @since 1.0

--- a/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractProviders.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandStreamingContractProviders.java
@@ -7,13 +7,13 @@ import com.streamconverter.command.impl.LineEndingNormalizeCommand.LineEndingTyp
 import com.streamconverter.command.impl.SendHttpCommand;
 import com.streamconverter.command.impl.charcode.CharacterConvertCommand;
 import com.streamconverter.command.impl.csv.CsvFilterCommand;
-import com.streamconverter.command.impl.csv.CsvNavigateCommand;
 import com.streamconverter.command.impl.csv.CsvValidateCommand;
+import com.streamconverter.command.impl.csv.CsvWalker;
 import com.streamconverter.command.impl.json.JsonFilterCommand;
-import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.json.JsonWalker;
 import com.streamconverter.command.impl.xml.ValidateCommand;
 import com.streamconverter.command.impl.xml.XmlFilterCommand;
-import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.command.impl.xml.XmlWalker;
 import com.streamconverter.command.rule.TestRule;
 import com.streamconverter.path.CSVPath;
 import com.streamconverter.path.TreePath;
@@ -196,11 +196,10 @@ final class CsvFilterCommandStreamingContractProvider implements CommandStreamin
   }
 }
 
-final class CsvNavigateCommandStreamingContractProvider
-    implements CommandStreamingContractProvider {
+final class CsvWalkerStreamingContractProvider implements CommandStreamingContractProvider {
   @Override
   public IStreamCommand createCommand() {
-    return CsvNavigateCommand.create(CSVPath.of("1"), new TestRule("original", "transformed"));
+    return CsvWalker.create(CSVPath.of("1"), new TestRule("original", "transformed"));
   }
 
   @Override
@@ -235,11 +234,10 @@ final class CsvValidateCommandStreamingContractProvider
   }
 }
 
-final class JsonNavigateCommandStreamingContractProvider
-    implements CommandStreamingContractProvider {
+final class JsonWalkerStreamingContractProvider implements CommandStreamingContractProvider {
   @Override
   public IStreamCommand createCommand() {
-    return JsonNavigateCommand.create(
+    return JsonWalker.create(
         TreePath.fromJson("$.user.name"), new TestRule("original", "transformed"));
   }
 
@@ -328,12 +326,10 @@ final class XmlFilterCommandStreamingContractProvider implements CommandStreamin
   }
 }
 
-final class XmlNavigateCommandStreamingContractProvider
-    implements CommandStreamingContractProvider {
+final class XmlWalkerStreamingContractProvider implements CommandStreamingContractProvider {
   @Override
   public IStreamCommand createCommand() {
-    return XmlNavigateCommand.create(
-        TreePath.fromXml("root/item"), new TestRule("original", "transformed"));
+    return XmlWalker.create(TreePath.fromXml("root/item"), new TestRule("original", "transformed"));
   }
 
   @Override

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -29,15 +29,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for CsvNavigateCommand. */
-class CsvNavigateCommandTest {
+/** Unit tests for CsvWalker. */
+class CsvWalkerTest {
 
-  private CsvNavigateCommand command;
+  private CsvWalker command;
 
   @BeforeEach
   void setUp() {
     // Use a specific column selector instead of createForAll
-    command = CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule());
+    command = CsvWalker.create(CSVPath.of("name"), new PassThroughRule());
   }
 
   @Test
@@ -105,8 +105,7 @@ class CsvNavigateCommandTest {
     String csvData = csvBuilder.toString();
 
     // Create command for the specific column that exists in this test's data
-    CsvNavigateCommand testCommand =
-        CsvNavigateCommand.create(CSVPath.of("id"), new PassThroughRule());
+    CsvWalker testCommand = CsvWalker.create(CSVPath.of("id"), new PassThroughRule());
 
     TrackingInputStream trackingInputStream =
         new TrackingInputStream(csvData.getBytes(StandardCharsets.UTF_8));
@@ -137,8 +136,7 @@ class CsvNavigateCommandTest {
   void testConcurrentExecutionThreadSafety() throws Exception {
     // Use a real transformation (upper-case) so we can verify the correct column was targeted
     String csvInput = "name,age,city\nAlice,30,NYC\nBob,25,LA\nCarol,35,Chicago\n";
-    CsvNavigateCommand sharedCommand =
-        CsvNavigateCommand.create(CSVPath.of("name"), s -> s.toUpperCase());
+    CsvWalker sharedCommand = CsvWalker.create(CSVPath.of("name"), s -> s.toUpperCase());
 
     int threadCount = 8;
     ExecutorService executor = Executors.newFixedThreadPool(threadCount);
@@ -193,8 +191,7 @@ class CsvNavigateCommandTest {
     String csvData = csvBuilder.toString();
 
     // Create command for the specific column that exists in this test's data
-    CsvNavigateCommand testCommand =
-        CsvNavigateCommand.create(CSVPath.of("employee_id"), new PassThroughRule());
+    CsvWalker testCommand = CsvWalker.create(CSVPath.of("employee_id"), new PassThroughRule());
 
     TrackingInputStream trackingInputStream =
         new TrackingInputStream(csvData.getBytes(StandardCharsets.UTF_8));
@@ -230,8 +227,7 @@ class CsvNavigateCommandTest {
     // Field containing a quote character: She said "hello"  (RFC 4180: doubled quotes)
     String csvInput = "name,comment\nAlice,\"She said \"\"hello\"\"\"\n";
     // Select the "comment" column which contains the quoted value
-    CsvNavigateCommand testCommand =
-        CsvNavigateCommand.create(CSVPath.of("comment"), new PassThroughRule());
+    CsvWalker testCommand = CsvWalker.create(CSVPath.of("comment"), new PassThroughRule());
 
     ByteArrayInputStream input =
         new ByteArrayInputStream(csvInput.getBytes(StandardCharsets.UTF_8));
@@ -269,8 +265,7 @@ class CsvNavigateCommandTest {
   @DisplayName("[#546] RFC 4180: output uses CRLF line endings per RFC 4180 §2")
   void testOutputUsesCrlfLineEndings() throws IOException {
     String csvInput = "name,age\nAlice,30\n";
-    CsvNavigateCommand testCommand =
-        CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule());
+    CsvWalker testCommand = CsvWalker.create(CSVPath.of("name"), new PassThroughRule());
 
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     testCommand.execute(
@@ -284,8 +279,7 @@ class CsvNavigateCommandTest {
   @DisplayName("[#546] RFC 4180: comma inside quoted field is not split")
   void testRfc4180CommaInsideQuotedField() throws IOException {
     String csvInput = "name,address\nAlice,\"123 Main St, Suite 4\"\n";
-    CsvNavigateCommand testCommand =
-        CsvNavigateCommand.create(CSVPath.of("address"), new PassThroughRule());
+    CsvWalker testCommand = CsvWalker.create(CSVPath.of("address"), new PassThroughRule());
 
     ByteArrayInputStream input =
         new ByteArrayInputStream(csvInput.getBytes(StandardCharsets.UTF_8));

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonWalkerTest.java
@@ -21,15 +21,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for JsonNavigateCommand. */
-class JsonNavigateCommandTest {
+/** Unit tests for JsonWalker. */
+class JsonWalkerTest {
 
-  private JsonNavigateCommand command;
+  private JsonWalker command;
 
   @BeforeEach
   void setUp() {
     // Use a specific JSONPath instead of createForAll
-    command = JsonNavigateCommand.create(TreePath.fromJson("$.test"), new PassThroughRule());
+    command = JsonWalker.create(TreePath.fromJson("$.test"), new PassThroughRule());
   }
 
   @Test
@@ -83,7 +83,7 @@ class JsonNavigateCommandTest {
 
   @Test
   void testInvalidJsonInput() throws IOException {
-    // JsonNavigateCommand propagates JsonParseException as IOException for invalid input.
+    // JsonWalker propagates JsonParseException as IOException for invalid input.
     String invalidJson = "{invalid json}";
     InputStream inputStream =
         new ByteArrayInputStream(invalidJson.getBytes(StandardCharsets.UTF_8));
@@ -188,8 +188,8 @@ class JsonNavigateCommandTest {
   void testNestedPathTransformation() throws IOException {
     String jsonInput =
         "{\"a\":{\"b\":{\"c\":\"original\",\"d\":\"unchanged\"}},\"other\":\"untouched\"}";
-    JsonNavigateCommand cmd =
-        JsonNavigateCommand.create(TreePath.fromJson("$.a.b.c"), TestRule.contentTransformRule());
+    JsonWalker cmd =
+        JsonWalker.create(TreePath.fromJson("$.a.b.c"), TestRule.contentTransformRule());
 
     ByteArrayInputStream input =
         new ByteArrayInputStream(jsonInput.getBytes(StandardCharsets.UTF_8));
@@ -206,8 +206,7 @@ class JsonNavigateCommandTest {
   @DisplayName("[#548] Sibling fields at same level are not transformed")
   void testSiblingFieldsNotTransformed() throws IOException {
     String jsonInput = "{\"x\":\"original value\",\"y\":\"original value\"}";
-    JsonNavigateCommand cmd =
-        JsonNavigateCommand.create(TreePath.fromJson("$.x"), TestRule.contentTransformRule());
+    JsonWalker cmd = JsonWalker.create(TreePath.fromJson("$.x"), TestRule.contentTransformRule());
 
     ByteArrayInputStream input =
         new ByteArrayInputStream(jsonInput.getBytes(StandardCharsets.UTF_8));
@@ -225,9 +224,8 @@ class JsonNavigateCommandTest {
   void testArraySyntaxPathMatching() throws IOException {
     String jsonInput =
         "{\"orders\":[{\"product_code\":\"ABC\",\"qty\":1},{\"product_code\":\"XYZ\",\"qty\":2}]}";
-    JsonNavigateCommand cmd =
-        JsonNavigateCommand.create(
-            TreePath.fromJson("$.orders[*].product_code"), s -> s.toLowerCase());
+    JsonWalker cmd =
+        JsonWalker.create(TreePath.fromJson("$.orders[*].product_code"), s -> s.toLowerCase());
 
     ByteArrayInputStream input =
         new ByteArrayInputStream(jsonInput.getBytes(StandardCharsets.UTF_8));
@@ -245,9 +243,8 @@ class JsonNavigateCommandTest {
   void testSecondObjectPathDoesNotTransformFirst() throws IOException {
     String jsonInput =
         "{\"first\":{\"x\":\"original\",\"y\":\"keep\"},\"second\":{\"x\":\"original\",\"y\":\"keep\"}}";
-    JsonNavigateCommand cmd =
-        JsonNavigateCommand.create(
-            TreePath.fromJson("$.second.x"), TestRule.contentTransformRule());
+    JsonWalker cmd =
+        JsonWalker.create(TreePath.fromJson("$.second.x"), TestRule.contentTransformRule());
 
     ByteArrayInputStream input =
         new ByteArrayInputStream(jsonInput.getBytes(StandardCharsets.UTF_8));
@@ -267,8 +264,8 @@ class JsonNavigateCommandTest {
   @DisplayName("Rule RuntimeException is wrapped as IOException with original cause")
   void testRuleRuntimeExceptionWrappedAsIOException() {
     RuntimeException ruleEx = new RuntimeException("rule failure");
-    JsonNavigateCommand failingRuleCommand =
-        JsonNavigateCommand.create(
+    JsonWalker failingRuleCommand =
+        JsonWalker.create(
             TreePath.fromJson("$.value"),
             v -> {
               throw ruleEx;
@@ -297,8 +294,8 @@ class JsonNavigateCommandTest {
             + "{\"order_id\":\"ORD-001\",\"product_code\":\"original\"},"
             + "{\"order_id\":\"ORD-002\",\"product_code\":\"original\"}"
             + "]}";
-    JsonNavigateCommand cmd =
-        JsonNavigateCommand.create(
+    JsonWalker cmd =
+        JsonWalker.create(
             TreePath.fromJson("$.orders[*].product_code"), TestRule.contentTransformRule());
 
     ByteArrayInputStream input =

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/XmlWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/XmlWalkerTest.java
@@ -23,14 +23,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for XmlNavigateCommand. */
-class XmlNavigateCommandTest {
+/** Unit tests for XmlWalker. */
+class XmlWalkerTest {
 
-  private XmlNavigateCommand command;
+  private XmlWalker command;
 
   @BeforeEach
   void setUp() {
-    command = XmlNavigateCommand.create(TreePath.fromXml("root/item"), new PassThroughRule());
+    command = XmlWalker.create(TreePath.fromXml("root/item"), new PassThroughRule());
   }
 
   @Test
@@ -43,7 +43,7 @@ class XmlNavigateCommandTest {
   void testNullTreePathThrowsIllegalArgumentException() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> XmlNavigateCommand.create(null, new PassThroughRule()),
+        () -> XmlWalker.create(null, new PassThroughRule()),
         "Should throw IllegalArgumentException for null treePath");
   }
 
@@ -52,7 +52,7 @@ class XmlNavigateCommandTest {
   void testNullRuleThrowsIllegalArgumentException() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> XmlNavigateCommand.create(TreePath.fromXml("root/item"), null),
+        () -> XmlWalker.create(TreePath.fromXml("root/item"), null),
         "Should throw IllegalArgumentException for null rule");
   }
 
@@ -98,8 +98,8 @@ class XmlNavigateCommandTest {
   void testRuleAppliedToMatchedElement() throws IOException {
     String xmlInput =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root><item>original</item><other>unchanged</other></root>";
-    XmlNavigateCommand upperCaseCommand =
-        XmlNavigateCommand.create(TreePath.fromXml("root/item"), value -> value.toUpperCase());
+    XmlWalker upperCaseCommand =
+        XmlWalker.create(TreePath.fromXml("root/item"), value -> value.toUpperCase());
 
     InputStream inputStream = new ByteArrayInputStream(xmlInput.getBytes(StandardCharsets.UTF_8));
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -137,8 +137,8 @@ class XmlNavigateCommandTest {
           </metadata>
         </root>
         """;
-    XmlNavigateCommand nameCommand =
-        XmlNavigateCommand.create(TreePath.fromXml("root/users/user/name"), new PassThroughRule());
+    XmlWalker nameCommand =
+        XmlWalker.create(TreePath.fromXml("root/users/user/name"), new PassThroughRule());
     InputStream inputStream = new ByteArrayInputStream(xmlInput.getBytes(StandardCharsets.UTF_8));
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
@@ -156,8 +156,8 @@ class XmlNavigateCommandTest {
   @DisplayName("Rule RuntimeException is wrapped as IOException with original cause")
   void testRuleRuntimeExceptionWrappedAsIOException() {
     RuntimeException ruleEx = new RuntimeException("rule failure");
-    XmlNavigateCommand failingRuleCommand =
-        XmlNavigateCommand.create(
+    XmlWalker failingRuleCommand =
+        XmlWalker.create(
             TreePath.fromXml("root/item"),
             value -> {
               throw ruleEx;
@@ -192,8 +192,7 @@ class XmlNavigateCommandTest {
     // could underflow if the guard is absent.
     String xmlInput =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root><item>a</item><item>b</item></root>";
-    XmlNavigateCommand cmd =
-        XmlNavigateCommand.create(TreePath.fromXml("root/item"), new PassThroughRule());
+    XmlWalker cmd = XmlWalker.create(TreePath.fromXml("root/item"), new PassThroughRule());
     InputStream inputStream = new ByteArrayInputStream(xmlInput.getBytes(StandardCharsets.UTF_8));
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
@@ -228,12 +227,10 @@ class XmlNavigateCommandTest {
   @Test
   @DisplayName("close() の XMLStreamException はプライマリ例外の suppressed に追加される（#662）")
   void testWriterCloseXmlStreamExceptionSuppressedOnPrimaryException() throws IOException {
-    // 修正前: XMLStreamException は WARN ログのみ → addSuppressed されない
-    // 修正後: primaryException != null なら addSuppressed する
     XMLStreamException closeEx = new XMLStreamException("close failed");
 
-    XmlNavigateCommand cmd =
-        new XmlNavigateCommand(TreePath.fromXml("root/item"), new PassThroughRule()) {
+    XmlWalker cmd =
+        new XmlWalker(TreePath.fromXml("root/item"), new PassThroughRule()) {
           @Override
           protected XMLEventWriter createXMLEventWriter(OutputStream out)
               throws XMLStreamException {
@@ -283,12 +280,10 @@ class XmlNavigateCommandTest {
   @Test
   @DisplayName("close() の XMLStreamException はプライマリ例外なし時に IOException でラップされる（#662）")
   void testWriterCloseXmlStreamExceptionThrowsRuntimeWhenNoPrimary() {
-    // 修正前: XMLStreamException は WARN ログのみ → 呼び出し元に伝播しない
-    // 修正後: primaryException == null なら buildXmlException で IOException にラップして再スロー
     XMLStreamException closeEx = new XMLStreamException("close failed");
 
-    XmlNavigateCommand cmd =
-        new XmlNavigateCommand(TreePath.fromXml("root/item"), new PassThroughRule()) {
+    XmlWalker cmd =
+        new XmlWalker(TreePath.fromXml("root/item"), new PassThroughRule()) {
           @Override
           protected XMLEventWriter createXMLEventWriter(OutputStream out)
               throws XMLStreamException {
@@ -371,10 +366,10 @@ class XmlNavigateCommandTest {
   }
 
   @Test
-  @DisplayName("XmlNavigateCommand は XMLEventFactory を static final フィールドとして保持しない（スレッドセーフ保証のため）")
-  void xmlNavigateCommand_hasNoStaticFinalXmlEventFactoryField() {
+  @DisplayName("XmlWalker は XMLEventFactory を static final フィールドとして保持しない（スレッドセーフ保証のため）")
+  void xmlWalker_hasNoStaticFinalXmlEventFactoryField() {
     boolean hasStaticFinalEventFactory =
-        Arrays.stream(XmlNavigateCommand.class.getDeclaredFields())
+        Arrays.stream(XmlWalker.class.getDeclaredFields())
             .filter(f -> XMLEventFactory.class.isAssignableFrom(f.getType()))
             .anyMatch(
                 f -> {

--- a/streamconverter-core/src/test/java/com/streamconverter/command/rule/impl/TransformationRuleIntegrationTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/rule/impl/TransformationRuleIntegrationTest.java
@@ -3,7 +3,7 @@ package com.streamconverter.command.rule.impl;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.streamconverter.command.IStreamCommand;
-import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.json.JsonWalker;
 import com.streamconverter.command.rule.impl.casing.CamelToSnakeCaseRule;
 import com.streamconverter.command.rule.impl.casing.SnakeToCamelCaseRule;
 import com.streamconverter.command.rule.impl.composite.ChainRule;
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.Test;
 /**
  * Integration tests for transformation rules with Navigate commands.
  *
- * <p>Updated to match the new JsonNavigateCommand behavior which preserves JSON structure while
- * transforming matching fields, rather than extracting values.
+ * <p>Updated to match the new JsonWalker behavior which preserves JSON structure while transforming
+ * matching fields, rather than extracting values.
  */
 class TransformationRuleIntegrationTest {
 
@@ -28,10 +28,10 @@ class TransformationRuleIntegrationTest {
     String inputJson = "{\"userName\": \"john_doe\", \"firstName\": \"John\"}";
 
     IStreamCommand command =
-        JsonNavigateCommand.create(TreePath.fromJson("$.userName"), CamelToSnakeCaseRule.create());
+        JsonWalker.create(TreePath.fromJson("$.userName"), CamelToSnakeCaseRule.create());
 
     String result = executeCommand(command, inputJson);
-    // JsonNavigateCommand preserves structure and transforms the matching field value
+    // JsonWalker preserves structure and transforms the matching field value
     assertTrue(
         result.contains("\"userName\":\"john_doe\""),
         "Should contain transformed userName field value");
@@ -43,7 +43,7 @@ class TransformationRuleIntegrationTest {
     String inputJson = "{\"user_name\": \"john_doe\", \"first_name\": \"John\"}";
 
     IStreamCommand command =
-        JsonNavigateCommand.create(TreePath.fromJson("$.user_name"), SnakeToCamelCaseRule.create());
+        JsonWalker.create(TreePath.fromJson("$.user_name"), SnakeToCamelCaseRule.create());
 
     String result = executeCommand(command, inputJson);
     // Structure preserved, user_name field value transformed
@@ -58,7 +58,7 @@ class TransformationRuleIntegrationTest {
     String inputJson = "{\"user_name\": \"hello_world\"}";
 
     IStreamCommand command =
-        JsonNavigateCommand.create(
+        JsonWalker.create(
             TreePath.fromJson("$.user_name"), SnakeToCamelCaseRule.createPascalCase());
 
     String result = executeCommand(command, inputJson);
@@ -78,8 +78,7 @@ class TransformationRuleIntegrationTest {
             .addRule(new LowerCaseRule())
             .build();
 
-    IStreamCommand command =
-        JsonNavigateCommand.create(TreePath.fromJson("$.fieldName"), chainRule);
+    IStreamCommand command = JsonWalker.create(TreePath.fromJson("$.fieldName"), chainRule);
 
     String result = executeCommand(command, inputJson);
     // Structure preserved, chain transformation applied to field value
@@ -98,8 +97,7 @@ class TransformationRuleIntegrationTest {
             new TrimRule(),
             CamelToSnakeCaseRule.builder().handleAcronyms(true).preserveUnderscores(false).build());
 
-    IStreamCommand command =
-        JsonNavigateCommand.create(TreePath.fromJson("$.userAccountID"), chainRule);
+    IStreamCommand command = JsonWalker.create(TreePath.fromJson("$.userAccountID"), chainRule);
 
     String result = executeCommand(command, inputJson);
     // Structure preserved, complex transformation applied to field value
@@ -116,7 +114,7 @@ class TransformationRuleIntegrationTest {
     ChainRule roundTrip =
         ChainRule.of(CamelToSnakeCaseRule.create(), SnakeToCamelCaseRule.create());
 
-    IStreamCommand command = JsonNavigateCommand.create(TreePath.fromJson("$.original"), roundTrip);
+    IStreamCommand command = JsonWalker.create(TreePath.fromJson("$.original"), roundTrip);
 
     String result = executeCommand(command, inputJson);
     // Structure preserved, round trip transformation applied
@@ -130,7 +128,7 @@ class TransformationRuleIntegrationTest {
 
     // Process firstName field
     IStreamCommand command1 =
-        JsonNavigateCommand.create(TreePath.fromJson("$.firstName"), CamelToSnakeCaseRule.create());
+        JsonWalker.create(TreePath.fromJson("$.firstName"), CamelToSnakeCaseRule.create());
     String result1 = executeCommand(command1, inputJson);
     // Structure preserved, firstName value transformed
     assertTrue(result1.contains("\"firstName\":\"john\""), "Should transform firstName value");
@@ -138,7 +136,7 @@ class TransformationRuleIntegrationTest {
 
     // Process lastName field
     IStreamCommand command2 =
-        JsonNavigateCommand.create(TreePath.fromJson("$.lastName"), CamelToSnakeCaseRule.create());
+        JsonWalker.create(TreePath.fromJson("$.lastName"), CamelToSnakeCaseRule.create());
     String result2 = executeCommand(command2, inputJson);
     // Structure preserved, lastName value transformed
     assertTrue(result2.contains("\"lastName\":\"doe\""), "Should transform lastName value");
@@ -150,7 +148,7 @@ class TransformationRuleIntegrationTest {
     String inputJson = "{\"field\": null}";
 
     IStreamCommand command =
-        JsonNavigateCommand.create(TreePath.fromJson("$.field"), CamelToSnakeCaseRule.create());
+        JsonWalker.create(TreePath.fromJson("$.field"), CamelToSnakeCaseRule.create());
 
     // Should handle null gracefully and preserve structure
     String result = executeCommand(command, inputJson);
@@ -162,8 +160,7 @@ class TransformationRuleIntegrationTest {
     String inputJson = "{\"existing\": \"value\"}";
 
     IStreamCommand command =
-        JsonNavigateCommand.create(
-            TreePath.fromJson("$.nonExistent"), CamelToSnakeCaseRule.create());
+        JsonWalker.create(TreePath.fromJson("$.nonExistent"), CamelToSnakeCaseRule.create());
 
     String result = executeCommand(command, inputJson);
     // Non-existent path should preserve original structure unchanged

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory;
  * );
  * String result = rule.apply("123"); // ユーザーID 123 の名前を取得
  *
- * // NavigateCommandと組み合わせた使用例
- * JsonNavigateCommand command = new JsonNavigateCommand("$.userId", rule);
+ * // JsonWalkerと組み合わせた使用例
+ * JsonWalker command = JsonWalker.create(TreePath.fromJson("$.userId"), rule);
  * command.execute(inputStream, outputStream); // JSON中のuserIdでDBを検索して置換
  * }</pre>
  *

--- a/streamconverter-db/src/test/java/com/streamconverter/integration/DatabaseRuleIntegrationTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/integration/DatabaseRuleIntegrationTest.java
@@ -2,8 +2,8 @@ package com.streamconverter.integration;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.streamconverter.command.impl.csv.CsvNavigateCommand;
-import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.csv.CsvWalker;
+import com.streamconverter.command.impl.json.JsonWalker;
 import com.streamconverter.command.rule.DatabaseFetchRule;
 import com.streamconverter.path.CSVPath;
 import com.streamconverter.path.TreePath;
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-/** DatabaseFetchRuleとNavigateCommandsの統合テスト 実際のDBデータを使用してJSON/CSVの値を置換する動作を検証 */
+/** DatabaseFetchRuleとWalkersの統合テスト 実際のDBデータを使用してJSON/CSVの値を置換する動作を検証 */
 // Re-enabled for cross-platform testing with improved H2 configuration
 class DatabaseRuleIntegrationTest {
 
@@ -108,8 +108,8 @@ class DatabaseRuleIntegrationTest {
     // DatabaseFetchRuleの作成
     DatabaseFetchRule dbRule = new DatabaseFetchRule(DB_URL, "SELECT name FROM users WHERE id = ?");
 
-    // JsonNavigateCommandの作成
-    JsonNavigateCommand command = JsonNavigateCommand.create(TreePath.fromJson("$.userId"), dbRule);
+    // JsonWalkerの作成
+    JsonWalker command = JsonWalker.create(TreePath.fromJson("$.userId"), dbRule);
 
     // テスト用JSON
     String inputJson =
@@ -145,8 +145,8 @@ class DatabaseRuleIntegrationTest {
     DatabaseFetchRule dbRule =
         new DatabaseFetchRule(DB_URL, "SELECT name FROM products WHERE code = ?");
 
-    // CsvNavigateCommandの作成
-    CsvNavigateCommand command = CsvNavigateCommand.create(CSVPath.of("product_code"), dbRule);
+    // CsvWalkerの作成
+    CsvWalker command = CsvWalker.create(CSVPath.of("product_code"), dbRule);
 
     // テスト用CSV
     String inputCsv =
@@ -180,8 +180,8 @@ class DatabaseRuleIntegrationTest {
     // DatabaseFetchRuleの作成
     DatabaseFetchRule dbRule = new DatabaseFetchRule(DB_URL, "SELECT name FROM users WHERE id = ?");
 
-    // JsonNavigateCommandの作成
-    JsonNavigateCommand command = JsonNavigateCommand.create(TreePath.fromJson("$.userId"), dbRule);
+    // JsonWalkerの作成
+    JsonWalker command = JsonWalker.create(TreePath.fromJson("$.userId"), dbRule);
 
     // 存在しないユーザーIDを含むJSON
     String inputJson =
@@ -214,8 +214,8 @@ class DatabaseRuleIntegrationTest {
     DatabaseFetchRule dbRule =
         new DatabaseFetchRule(DB_URL, "SELECT department FROM users WHERE id = ?");
 
-    // JsonNavigateCommandの作成
-    JsonNavigateCommand command = JsonNavigateCommand.create(TreePath.fromJson("$.userId"), dbRule);
+    // JsonWalkerの作成
+    JsonWalker command = JsonWalker.create(TreePath.fromJson("$.userId"), dbRule);
 
     // 複数のユーザーIDを含むJSON配列
     String inputJson =
@@ -251,9 +251,9 @@ class DatabaseRuleIntegrationTest {
     DatabaseFetchRule dbRule =
         new DatabaseFetchRule(DB_URL, "SELECT price FROM products WHERE code = ?");
 
-    // JsonNavigateCommandの作成
-    JsonNavigateCommand command =
-        JsonNavigateCommand.create(TreePath.fromJson("$.productCode"), dbRule);
+    // JsonWalkerの作成
+    JsonWalker command =
+        JsonWalker.create(TreePath.fromJson("$.productCode"), dbRule);
 
     // テスト用JSON
     String inputJson =

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/NavigateAndRuleExample.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/NavigateAndRuleExample.java
@@ -1,9 +1,9 @@
 package com.streamconverter.examples;
 
 import com.streamconverter.StreamConverter;
-import com.streamconverter.command.impl.csv.CsvNavigateCommand;
-import com.streamconverter.command.impl.json.JsonNavigateCommand;
-import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.command.impl.csv.CsvWalker;
+import com.streamconverter.command.impl.json.JsonWalker;
+import com.streamconverter.command.impl.xml.XmlWalker;
 import com.streamconverter.command.rule.IRule;
 import com.streamconverter.command.rule.impl.casing.CamelToSnakeCaseRule;
 import com.streamconverter.command.rule.impl.composite.ChainRule;
@@ -38,29 +38,29 @@ import org.slf4j.LoggerFactory;
  * <p><b>シナリオ（CSV 3段パイプライン）:</b>
  *
  * <pre>
- * [コマンド1] CsvNavigateCommand(name列) + ChainRule(TrimRule → LowerCaseRule)
+ * [コマンド1] CsvWalker(name列) + ChainRule(TrimRule → LowerCaseRule)
  *             商品名の前後空白を除去して小文字に統一
  *          ↓
- * [コマンド2] CsvNavigateCommand(price列) + カスタムIRule実装クラス（PriceFormattingRule）
+ * [コマンド2] CsvWalker(price列) + カスタムIRule実装クラス（PriceFormattingRule）
  *             価格を "¥1,234" 形式にフォーマット
  *          ↓
- * [コマンド3] CsvNavigateCommand(category列) + ラムダIRule
+ * [コマンド3] CsvWalker(category列) + ラムダIRule
  *             カテゴリを大文字に変換（ラムダで実装）
  * </pre>
  *
  * <p><b>シナリオ（JSON 3段パイプライン）:</b>
  *
  * <pre>
- * [コマンド1] JsonNavigateCommand($.name) + ChainRule(TrimRule → LowerCaseRule)
- * [コマンド2] JsonNavigateCommand($.category) + CamelToSnakeCaseRule（組み込みRuleの例）
- * [コマンド3] JsonNavigateCommand($.sku) + ラムダIRule（"SKU-" プレフィックス付与）
+ * [コマンド1] JsonWalker($.name) + ChainRule(TrimRule → LowerCaseRule)
+ * [コマンド2] JsonWalker($.category) + CamelToSnakeCaseRule（組み込みRuleの例）
+ * [コマンド3] JsonWalker($.sku) + ラムダIRule（"SKU-" プレフィックス付与）
  * </pre>
  *
  * <p><b>シナリオ（XML 2段パイプライン）:</b>
  *
  * <pre>
- * [コマンド1] XmlNavigateCommand(product/name) + ChainRule(TrimRule → LowerCaseRule)
- * [コマンド2] XmlNavigateCommand(product/category) + CamelToSnakeCaseRule
+ * [コマンド1] XmlWalker(product/name) + ChainRule(TrimRule → LowerCaseRule)
+ * [コマンド2] XmlWalker(product/category) + CamelToSnakeCaseRule
  * </pre>
  */
 public class NavigateAndRuleExample {
@@ -106,16 +106,16 @@ public class NavigateAndRuleExample {
     IRule upperCase = s -> s.toUpperCase();
 
     // PriceFormattingRule が "¥128,000" を出力する（カンマを含む）。
-    // CsvNavigateCommand は RFC 4180 に従い、カンマを含む値を二重引用符で囲む。
+    // CsvWalker は RFC 4180 に従い、カンマを含む値を二重引用符で囲む。
     String csvExpected =
         "name,price,category\r\nlaptop computer,\"¥128,000\",ELECTRONICS\r\nwireless mouse,\"¥3,200\",ACCESSORIES\r\n";
     log.info("期待値:\n{}", csvExpected);
 
     ByteArrayOutputStream csvOut = new ByteArrayOutputStream();
     StreamConverter.create(
-            CsvNavigateCommand.create(CSVPath.of("name"), trimAndLower),
-            CsvNavigateCommand.create(CSVPath.of("price"), priceFormatter),
-            CsvNavigateCommand.create(CSVPath.of("category"), upperCase))
+            CsvWalker.create(CSVPath.of("name"), trimAndLower),
+            CsvWalker.create(CSVPath.of("price"), priceFormatter),
+            CsvWalker.create(CSVPath.of("category"), upperCase))
         .run(new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8)), csvOut);
     log.info("出力:\n{}", csvOut.toString(StandardCharsets.UTF_8));
   }
@@ -152,9 +152,9 @@ public class NavigateAndRuleExample {
 
     ByteArrayOutputStream jsonOut = new ByteArrayOutputStream();
     StreamConverter.create(
-            JsonNavigateCommand.create(TreePath.fromJson("$.name"), trimAndLower),
-            JsonNavigateCommand.create(TreePath.fromJson("$.category"), camelToSnake),
-            JsonNavigateCommand.create(TreePath.fromJson("$.sku"), addSkuPrefix))
+            JsonWalker.create(TreePath.fromJson("$.name"), trimAndLower),
+            JsonWalker.create(TreePath.fromJson("$.category"), camelToSnake),
+            JsonWalker.create(TreePath.fromJson("$.sku"), addSkuPrefix))
         .run(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), jsonOut);
     log.info("出力:\n{}", jsonOut.toString(StandardCharsets.UTF_8));
   }
@@ -165,7 +165,7 @@ public class NavigateAndRuleExample {
 
   private static void xmlPipeline() throws IOException {
     log.info("--- XML パイプライン ---");
-    // XmlNavigateCommand は JSON と同様に XML 全体構造を保持しながら特定パスの値を変換する。
+    // XmlWalker は JSON と同様に XML 全体構造を保持しながら特定パスの値を変換する。
     // 複数フィールドを別々のコマンドで変換することも可能。
     //   コマンド1: product/name の前後空白をトリムして小文字化
     //   コマンド2: product/category をスネークケースに変換
@@ -191,11 +191,10 @@ public class NavigateAndRuleExample {
 
     ByteArrayOutputStream xmlOut = new ByteArrayOutputStream();
     StreamConverter.create(
-            XmlNavigateCommand.create(
+            XmlWalker.create(
                 TreePath.fromXml("product/name"),
                 ChainRule.builder().addRule(new TrimRule()).addRule(new LowerCaseRule()).build()),
-            XmlNavigateCommand.create(
-                TreePath.fromXml("product/category"), CamelToSnakeCaseRule.create()))
+            XmlWalker.create(TreePath.fromXml("product/category"), CamelToSnakeCaseRule.create()))
         .run(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), xmlOut);
     log.info("出力:\n{}", xmlOut.toString(StandardCharsets.UTF_8));
   }

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/PipelineContextExample.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/PipelineContextExample.java
@@ -2,7 +2,7 @@ package com.streamconverter.examples;
 
 import com.streamconverter.StreamConverter;
 import com.streamconverter.command.IStreamCommand;
-import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.csv.CsvWalker;
 import com.streamconverter.command.rule.MdcPropagatingRule;
 import com.streamconverter.command.rule.impl.string.TrimRule;
 import com.streamconverter.context.PipelineContext;
@@ -35,11 +35,11 @@ import org.slf4j.LoggerFactory;
  * [コマンド1: ラムダ]
  *   最初の1行から注文IDを読み取り PipelineContext.putShared("orderId", ...) に格納
  *          ↓
- * [コマンド2: CsvNavigateCommand + MdcPropagatingRule]
+ * [コマンド2: CsvWalker + MdcPropagatingRule]
  *   productName 列を抽出し、値を "productName" キーで MDC に自動伝搬
  *   → このコマンドのログに orderId と productName が含まれる
  *          ↓
- * [コマンド3: CsvNavigateCommand + TrimRule]
+ * [コマンド3: CsvWalker + TrimRule]
  *   address 列の前後空白をトリム
  *   → このコマンドのログにも orderId が含まれる（PipelineContext 経由）
  * </pre>
@@ -87,13 +87,12 @@ public class PipelineContextExample {
     // MdcPropagatingRule は値をパススルーしながら PipelineContext.putShared() を呼び出す Rule。
     // これにより、後続の全コマンドのログに productName が自動的に含まれる。
     IStreamCommand propagateProductName =
-        CsvNavigateCommand.create(
-            CSVPath.of("productName"), MdcPropagatingRule.create("productName"));
+        CsvWalker.create(CSVPath.of("productName"), MdcPropagatingRule.create("productName"));
 
     // --- コマンド3: TrimRule で address をトリム ---
     // このコマンドのログには orderId が含まれる。
     // PipelineContextTurboFilter がログ出力直前に PipelineContext の共有値を MDC に同期するため。
-    IStreamCommand trimAddress = CsvNavigateCommand.create(CSVPath.of("address"), new TrimRule());
+    IStreamCommand trimAddress = CsvWalker.create(CSVPath.of("address"), new TrimRule());
 
     // --- パイプライン実行 ---
     StreamConverter converter =

--- a/streamconverter-examples/src/main/java/com/streamconverter/examples/ValidationPipelineExample.java
+++ b/streamconverter-examples/src/main/java/com/streamconverter/examples/ValidationPipelineExample.java
@@ -3,8 +3,8 @@ package com.streamconverter.examples;
 import com.streamconverter.StreamConverter;
 import com.streamconverter.StreamProcessingException;
 import com.streamconverter.command.impl.FileBufferCommand;
-import com.streamconverter.command.impl.csv.CsvNavigateCommand;
 import com.streamconverter.command.impl.csv.CsvValidateCommand;
+import com.streamconverter.command.impl.csv.CsvWalker;
 import com.streamconverter.command.rule.impl.string.TrimRule;
 import com.streamconverter.path.CSVPath;
 import java.io.ByteArrayInputStream;
@@ -33,15 +33,15 @@ import org.slf4j.LoggerFactory;
  *
  * <pre>
  * パターンA（問題あり）:
- *   CsvValidateCommand → CsvNavigateCommand
+ *   CsvValidateCommand → CsvWalker
  *   検証失敗でも後段に部分データが届く可能性がある
  *
  * パターンB（安全）:
- *   CsvValidateCommand → FileBufferCommand → CsvNavigateCommand
+ *   CsvValidateCommand → FileBufferCommand → CsvWalker
  *   FileBufferCommand が前段の完了を待ち、後段は確実に検証済みデータのみを受け取る
  *
  * パターンC（機密データ）:
- *   CsvValidateCommand → FileBufferCommand.createEncrypted() → CsvNavigateCommand
+ *   CsvValidateCommand → FileBufferCommand.createEncrypted() → CsvWalker
  *   一時ファイルを AES-256-GCM で暗号化するため、機密データでも安全
  * </pre>
  */
@@ -86,7 +86,7 @@ public class ValidationPipelineExample {
     // TeeInputStream を使って入力を読みながら出力にも同時に流す。
     // そのため検証が失敗した時点で後段にはすでに部分データが流れている可能性がある。
     CsvValidateCommand validator = CsvValidateCommand.create("id", "name", "email");
-    CsvNavigateCommand trimName = CsvNavigateCommand.create(CSVPath.of("name"), new TrimRule());
+    CsvWalker trimName = CsvWalker.create(CSVPath.of("name"), new TrimRule());
 
     StreamConverter converter = StreamConverter.create(validator, trimName);
 
@@ -103,7 +103,7 @@ public class ValidationPipelineExample {
 
     // 同じ StreamConverter を使いまわすことはできないため再生成
     validator = CsvValidateCommand.create("id", "name", "email");
-    trimName = CsvNavigateCommand.create(CSVPath.of("name"), new TrimRule());
+    trimName = CsvWalker.create(CSVPath.of("name"), new TrimRule());
     converter = StreamConverter.create(validator, trimName);
 
     log.info(
@@ -125,7 +125,7 @@ public class ValidationPipelineExample {
     // FileBufferCommand を検証コマンドの後に挿入することで逐次化できる。
     // FileBufferCommand は:
     //   1. 前段（CsvValidateCommand）の出力を一時ファイルに書き込む（前段が完全に完了するまで待機）
-    //   2. 前段完了後に一時ファイルを後段（CsvNavigateCommand）への入力として流す
+    //   2. 前段完了後に一時ファイルを後段（CsvWalker）への入力として流す
     // これにより「検証が成功した場合のみ後段が動く」ことが保証される。
     String validExpected =
         "id,name,email\r\n" + "1,Alice,alice@example.com\r\n" + "2,Bob,bob@example.com\r\n";
@@ -135,7 +135,7 @@ public class ValidationPipelineExample {
       StreamConverter.create(
               CsvValidateCommand.create("id", "name", "email"),
               FileBufferCommand.create(),
-              CsvNavigateCommand.create(CSVPath.of("name"), new TrimRule()))
+              CsvWalker.create(CSVPath.of("name"), new TrimRule()))
           .run(new ByteArrayInputStream(validCsv.getBytes(StandardCharsets.UTF_8)), out3);
       log.info("出力:\n{}", out3.toString(StandardCharsets.UTF_8));
     } catch (StreamProcessingException e) {
@@ -149,7 +149,7 @@ public class ValidationPipelineExample {
       StreamConverter.create(
               CsvValidateCommand.create("id", "name", "email"),
               FileBufferCommand.create(),
-              CsvNavigateCommand.create(CSVPath.of("name"), new TrimRule()))
+              CsvWalker.create(CSVPath.of("name"), new TrimRule()))
           .run(new ByteArrayInputStream(invalidCsv.getBytes(StandardCharsets.UTF_8)), out4);
       log.warn("後段が実行された（問題あり）:\n{}", out4.toString(StandardCharsets.UTF_8));
     } catch (StreamProcessingException e) {
@@ -173,7 +173,7 @@ public class ValidationPipelineExample {
       StreamConverter.create(
               CsvValidateCommand.create("id", "name", "email"),
               FileBufferCommand.createEncrypted(),
-              CsvNavigateCommand.create(CSVPath.of("name"), new TrimRule()))
+              CsvWalker.create(CSVPath.of("name"), new TrimRule()))
           .run(new ByteArrayInputStream(validCsv.getBytes(StandardCharsets.UTF_8)), out5);
       log.info("出力（一時ファイルは AES-256-GCM で暗号化）:\n{}", out5.toString(StandardCharsets.UTF_8));
     } catch (StreamProcessingException e) {

--- a/streamconverter-tools/src/test/java/com/streamconverter/benchmark/LargeDataBenchmark.java
+++ b/streamconverter-tools/src/test/java/com/streamconverter/benchmark/LargeDataBenchmark.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.streamconverter.StreamConverter;
 import com.streamconverter.command.IStreamCommand;
 import com.streamconverter.command.impl.charcode.CharacterConvertCommand;
-import com.streamconverter.command.impl.csv.CsvNavigateCommand;
-import com.streamconverter.command.impl.json.JsonNavigateCommand;
-import com.streamconverter.command.impl.xml.XmlNavigateCommand;
+import com.streamconverter.command.impl.csv.CsvWalker;
+import com.streamconverter.command.impl.json.JsonWalker;
+import com.streamconverter.command.impl.xml.XmlWalker;
 import com.streamconverter.command.rule.PassThroughRule;
 import com.streamconverter.path.CSVPath;
 import com.streamconverter.path.TreePath;
@@ -373,7 +373,7 @@ class LargeDataBenchmark {
     // 複雑なパイプライン（メモリプレッシャーをかける）
     StreamConverter converter =
         StreamConverter.create(
-            JsonNavigateCommand.create(TreePath.fromXml("/orders"), new PassThroughRule()),
+            JsonWalker.create(TreePath.fromXml("/orders"), new PassThroughRule()),
             (in, out) -> in.transferTo(out),
             (in, out) -> in.transferTo(out),
             (in, out) -> in.transferTo(out));
@@ -473,7 +473,7 @@ class LargeDataBenchmark {
       // 複雑な4段階パイプライン
       StreamConverter converter =
           StreamConverter.create(
-              XmlNavigateCommand.create(TreePath.fromXml("/orders"), new PassThroughRule()),
+              XmlWalker.create(TreePath.fromXml("/orders"), new PassThroughRule()),
               (in, out) -> in.transferTo(out),
               (in, out) -> in.transferTo(out),
               (in, out) -> in.transferTo(out));
@@ -781,11 +781,11 @@ class LargeDataBenchmark {
   private IStreamCommand createFormatSpecificCommand(String format) {
     switch (format.toUpperCase()) {
       case "XML":
-        return XmlNavigateCommand.create(TreePath.fromXml("/orders"), new PassThroughRule());
+        return XmlWalker.create(TreePath.fromXml("/orders"), new PassThroughRule());
       case "JSON":
-        return JsonNavigateCommand.create(TreePath.fromXml("/orders"), new PassThroughRule());
+        return JsonWalker.create(TreePath.fromXml("/orders"), new PassThroughRule());
       case "CSV":
-        return CsvNavigateCommand.create(CSVPath.of("name"), new PassThroughRule());
+        return CsvWalker.create(CSVPath.of("name"), new PassThroughRule());
       default:
         return (in, out) -> in.transferTo(out);
     }

--- a/streamconverter-web/src/main/java/com/streamconverter/web/StreamProcessingController.java
+++ b/streamconverter-web/src/main/java/com/streamconverter/web/StreamProcessingController.java
@@ -18,8 +18,8 @@ import org.springframework.web.bind.annotation.*;
 import com.streamconverter.StreamConverter;
 import com.streamconverter.command.AbstractStreamCommand;
 import com.streamconverter.command.IStreamCommand;
-import com.streamconverter.command.impl.csv.CsvNavigateCommand;
-import com.streamconverter.command.impl.json.JsonNavigateCommand;
+import com.streamconverter.command.impl.csv.CsvWalker;
+import com.streamconverter.command.impl.json.JsonWalker;
 import com.streamconverter.command.rule.PassThroughRule;
 import com.streamconverter.path.CSVPath;
 import com.streamconverter.path.TreePath;
@@ -64,7 +64,7 @@ public class StreamProcessingController {
                 ResponseEntity.ok(
                     processWithStreamConverter(
                         inputData,
-                        CsvNavigateCommand.create(
+                        CsvWalker.create(
                             CSVPath.of(columnName), new PassThroughRule()))))
         .onErrorResume(
             e -> {
@@ -95,7 +95,7 @@ public class StreamProcessingController {
                 ResponseEntity.ok(
                     processWithStreamConverter(
                         inputData,
-                        JsonNavigateCommand.create(
+                        JsonWalker.create(
                             TreePath.fromJson(jsonPath), new PassThroughRule()))))
         .onErrorResume(
             e -> {
@@ -219,13 +219,13 @@ public class StreamProcessingController {
               if (parameter.isEmpty()) {
                 throw new IllegalArgumentException("csv command requires a column name at index " + i);
               }
-              yield CsvNavigateCommand.create(CSVPath.of(parameter), new PassThroughRule());
+              yield CsvWalker.create(CSVPath.of(parameter), new PassThroughRule());
             }
             case "json" -> {
               if (parameter.isEmpty()) {
                 throw new IllegalArgumentException("json command requires a path at index " + i);
               }
-              yield JsonNavigateCommand.create(TreePath.fromJson(parameter), new PassThroughRule());
+              yield JsonWalker.create(TreePath.fromJson(parameter), new PassThroughRule());
             }
             case "process" -> new AbstractStreamCommand() {
               @Override

--- a/streamconverter-web/src/test/java/com/streamconverter/web/StreamProcessingControllerTest.java
+++ b/streamconverter-web/src/test/java/com/streamconverter/web/StreamProcessingControllerTest.java
@@ -111,7 +111,7 @@ class StreamProcessingControllerTest {
               assertNotNull(responseBody, "Response body should not be null");
               String responseString = new String(responseBody, StandardCharsets.UTF_8);
 
-              // JsonNavigateCommand with PassThroughRule preserves the entire JSON
+              // JsonWalker with PassThroughRule preserves the entire JSON
               assertFalse(responseString.isEmpty(), "Response should not be empty");
 
               // Verify the complete JSON structure is preserved


### PR DESCRIPTION
## 概要

`XmlNavigateCommand` / `CsvNavigateCommand` / `JsonNavigateCommand` を `XmlWalker` / `CsvWalker` / `JsonWalker` にリネームする。

- "Walker"（巡回しながら変換する）という名前が動作をより直感的に表現する
- 抽出専用の `XxxFilterCommand` との対比が明確になる

機能変更はなし。

## 変更内容

- `git mv` で実装クラス3件・テストクラス3件をリネーム
- 全クラス内のクラス名・コンストラクタ名・ロガー定義を更新
- `CommandStreamingContractProviders`, `spotbugs-exclude.xml` を更新
- `examples` / `web` / `db` 各モジュールの import・使用箇所を更新
- `FilterCommand` / `IRule` / Rule実装クラスの Javadoc サンプルコードを更新
- Walker Javadoc から "extract/not extraction" など Filter と誤解させる表現を除去
- `MdcPropagatingRule` の `TreePath.fromXPath()` → `TreePath.fromXml()`（存在しないメソッドを修正）
- `LowerCaseRule` のサンプルコード `new LowerCaseRule(Locale)` → `LowerCaseRule.create(Locale)`（private コンストラクタ呼び出しを修正）

## テスト

- `streamconverter-core` 416件 PASS
- `streamconverter-db` 36件 PASS
- `streamconverter-web` 13件 PASS
- `NavigateCommand` 残存ゼロ確認済み（`grep -r "NavigateCommand" --include="*.java" --include="*.xml"` で0件）
