### PR TITLE
feat: known-bug タグで通常 CI からバグ証明テストを除外し、バグ存在確認タスクを追加

### DIFF
--- a/.github/workflows/commit-rules.yml
+++ b/.github/workflows/commit-rules.yml
@@ -55,8 +55,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.daemon.timeout=60000 -Xmx2g -Xms1g"
         run: ./gradlew.bat build --daemon --parallel
 
-
-
   verify-known-bugs:
     name: Verify Known Bugs Still Exist
     runs-on: ubuntu-latest

--- a/.github/workflows/commit-rules.yml
+++ b/.github/workflows/commit-rules.yml
@@ -54,3 +54,29 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon.timeout=60000 -Xmx2g -Xms1g"
         run: ./gradlew.bat build --daemon --parallel
+
+
+
+  verify-known-bugs:
+    name: Verify Known Bugs Still Exist
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Verify known bugs are not accidentally fixed
+        run: ./gradlew :streamconverter-core:verifyKnownBugs

--- a/.github/workflows/commit-rules.yml
+++ b/.github/workflows/commit-rules.yml
@@ -79,4 +79,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Verify known bugs are not accidentally fixed
-        run: ./gradlew :streamconverter-core:verifyKnownBugs
+        run: ./gradlew verifyKnownBugs

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -360,8 +360,8 @@ repositories {
 tasks.test {
     // JUnit 5 を使うための設定
     useJUnitPlatform {
-        // ベンチマークテストを通常のテスト実行から除外
-        excludeTags("benchmark", "large-data")
+        // ベンチマークテストと known-bug テストを通常のテスト実行から除外
+        excludeTags("benchmark", "large-data", "known-bug")
     }
 
     // クラス名・パスパターンでもベンチマーク系テストを除外

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -357,11 +357,67 @@ repositories {
 
 // Root project has no direct runtime sources; keep dependencies in subprojects
 
+subprojects {
+    tasks.withType<Test>().matching { it.name != "verifyKnownBugs" }.configureEach {
+        useJUnitPlatform {
+            excludeTags("known-bug")
+        }
+    }
+
+    tasks.register<Test>("verifyKnownBugs") {
+        group = "verification"
+        description = "Verify that all known-bug tests fail (proving bugs still exist)"
+        testClassesDirs = sourceSets["test"].output.classesDirs
+        classpath = sourceSets["test"].runtimeClasspath
+        useJUnitPlatform {
+            includeTags("known-bug")
+        }
+        ignoreFailures = true
+        jvmArgs("-Xmx2g", "-Xms1g", "-Dfile.encoding=UTF-8")
+
+        val projectName = project.name
+        addTestListener(object : org.gradle.api.tasks.testing.TestListener {
+            override fun beforeSuite(suite: org.gradle.api.tasks.testing.TestDescriptor) = Unit
+            override fun beforeTest(testDescriptor: org.gradle.api.tasks.testing.TestDescriptor) = Unit
+            override fun afterTest(
+                testDescriptor: org.gradle.api.tasks.testing.TestDescriptor,
+                result: org.gradle.api.tasks.testing.TestResult
+            ) = Unit
+
+            override fun afterSuite(
+                suite: org.gradle.api.tasks.testing.TestDescriptor,
+                result: org.gradle.api.tasks.testing.TestResult
+            ) {
+                if (suite.parent != null) return
+                val total = result.testCount
+                val failed = result.failedTestCount
+                val passed = result.successfulTestCount
+                val skipped = result.skippedTestCount
+                if (total == 0L) {
+                    logger.lifecycle("verifyKnownBugs: no known-bug tests found in $projectName — skipping.")
+                    return
+                }
+                logger.lifecycle(
+                    "Known-bug verification ($projectName): $total test(s), $failed failed, $passed passed, $skipped skipped"
+                )
+                if (passed > 0L || skipped > 0L || failed != total) {
+                    throw GradleException(
+                        "verifyKnownBugs ($projectName): expected all known-bug tests to fail, but got " +
+                        "$failed failed, $passed passed, $skipped skipped out of $total. " +
+                        "If a bug was fixed, remove the @Tag(\"known-bug\") annotation and close the related issue."
+                    )
+                }
+                logger.lifecycle("verifyKnownBugs ($projectName): OK — all $failed known-bug test(s) are still failing as expected.")
+            }
+        })
+    }
+}
+
 tasks.test {
     // JUnit 5 を使うための設定
     useJUnitPlatform {
-        // ベンチマークテストと known-bug テストを通常のテスト実行から除外
-        excludeTags("benchmark", "large-data", "known-bug")
+        // ベンチマークテストを通常のテスト実行から除外（known-bug は subprojects ブロックで除外）
+        excludeTags("benchmark", "large-data")
     }
 
     // クラス名・パスパターンでもベンチマーク系テストを除外

--- a/streamconverter-core/build.gradle.kts
+++ b/streamconverter-core/build.gradle.kts
@@ -146,15 +146,17 @@ tasks.register<Test>("verifyKnownBugs") {
             val total = result.testCount
             val failed = result.failedTestCount
             val passed = result.successfulTestCount
+            val skipped = result.skippedTestCount
             logger.lifecycle(
-                "Known-bug verification: $total test(s), $failed failed, $passed passed"
+                "Known-bug verification: $total test(s), $failed failed, $passed passed, $skipped skipped"
             )
             if (total == 0L) {
                 throw GradleException("verifyKnownBugs: no known-bug tests found. Add @Tag(\"known-bug\") tests.")
             }
-            if (passed > 0L) {
+            if (passed > 0L || skipped > 0L || failed != total) {
                 throw GradleException(
-                    "verifyKnownBugs: $passed known-bug test(s) passed unexpectedly. " +
+                    "verifyKnownBugs: expected all known-bug tests to fail, but got " +
+                    "$failed failed, $passed passed, $skipped skipped out of $total. " +
                     "If a bug was fixed, remove the @Tag(\"known-bug\") annotation and close the related issue."
                 )
             }

--- a/streamconverter-core/build.gradle.kts
+++ b/streamconverter-core/build.gradle.kts
@@ -91,8 +91,8 @@ spotless {
 tasks.test {
     // JUnit 5 を使うための設定
     useJUnitPlatform {
-        // ベンチマークテストを通常のテスト実行から除外
-        excludeTags("benchmark", "large-data")
+        // ベンチマークテストと known-bug テストを通常のテスト実行から除外
+        excludeTags("benchmark", "large-data", "known-bug")
     }
 
     // Exclude benchmark-related tests by class name and path patterns as well
@@ -115,6 +115,52 @@ tasks.test {
     }
     // テスト実行後にjavadocを生成
     finalizedBy(tasks.javadoc)
+}
+
+// known-bug タグのテストを実行し、全テストが失敗することを検証する
+// バグが修正された場合（テストがパスした場合）にビルドを失敗させる
+tasks.register<Test>("verifyKnownBugs") {
+    group = "verification"
+    description = "Verify that all known-bug tests fail (proving bugs still exist)"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    useJUnitPlatform {
+        includeTags("known-bug")
+    }
+    ignoreFailures = true
+    jvmArgs("-Xmx2g", "-Xms1g", "-Dfile.encoding=UTF-8")
+
+    addTestListener(object : org.gradle.api.tasks.testing.TestListener {
+        override fun beforeSuite(suite: org.gradle.api.tasks.testing.TestDescriptor) = Unit
+        override fun beforeTest(testDescriptor: org.gradle.api.tasks.testing.TestDescriptor) = Unit
+        override fun afterTest(
+            testDescriptor: org.gradle.api.tasks.testing.TestDescriptor,
+            result: org.gradle.api.tasks.testing.TestResult
+        ) = Unit
+
+        override fun afterSuite(
+            suite: org.gradle.api.tasks.testing.TestDescriptor,
+            result: org.gradle.api.tasks.testing.TestResult
+        ) {
+            if (suite.parent != null) return
+            val total = result.testCount
+            val failed = result.failedTestCount
+            val passed = result.successfulTestCount
+            logger.lifecycle(
+                "Known-bug verification: $total test(s), $failed failed, $passed passed"
+            )
+            if (total == 0L) {
+                throw GradleException("verifyKnownBugs: no known-bug tests found. Add @Tag(\"known-bug\") tests.")
+            }
+            if (passed > 0L) {
+                throw GradleException(
+                    "verifyKnownBugs: $passed known-bug test(s) passed unexpectedly. " +
+                    "If a bug was fixed, remove the @Tag(\"known-bug\") annotation and close the related issue."
+                )
+            }
+            logger.lifecycle("verifyKnownBugs: OK — all $failed known-bug test(s) are still failing as expected.")
+        }
+    })
 }
 
 // JaCoCoレポートの設定（Windows以外でのみ実行）

--- a/streamconverter-core/build.gradle.kts
+++ b/streamconverter-core/build.gradle.kts
@@ -91,8 +91,8 @@ spotless {
 tasks.test {
     // JUnit 5 を使うための設定
     useJUnitPlatform {
-        // ベンチマークテストと known-bug テストを通常のテスト実行から除外
-        excludeTags("benchmark", "large-data", "known-bug")
+        // ベンチマークテストを通常のテスト実行から除外（known-bug は root subprojects で除外）
+        excludeTags("benchmark", "large-data")
     }
 
     // Exclude benchmark-related tests by class name and path patterns as well
@@ -115,54 +115,6 @@ tasks.test {
     }
     // テスト実行後にjavadocを生成
     finalizedBy(tasks.javadoc)
-}
-
-// known-bug タグのテストを実行し、全テストが失敗することを検証する
-// バグが修正された場合（テストがパスした場合）にビルドを失敗させる
-tasks.register<Test>("verifyKnownBugs") {
-    group = "verification"
-    description = "Verify that all known-bug tests fail (proving bugs still exist)"
-    testClassesDirs = sourceSets["test"].output.classesDirs
-    classpath = sourceSets["test"].runtimeClasspath
-    useJUnitPlatform {
-        includeTags("known-bug")
-    }
-    ignoreFailures = true
-    jvmArgs("-Xmx2g", "-Xms1g", "-Dfile.encoding=UTF-8")
-
-    addTestListener(object : org.gradle.api.tasks.testing.TestListener {
-        override fun beforeSuite(suite: org.gradle.api.tasks.testing.TestDescriptor) = Unit
-        override fun beforeTest(testDescriptor: org.gradle.api.tasks.testing.TestDescriptor) = Unit
-        override fun afterTest(
-            testDescriptor: org.gradle.api.tasks.testing.TestDescriptor,
-            result: org.gradle.api.tasks.testing.TestResult
-        ) = Unit
-
-        override fun afterSuite(
-            suite: org.gradle.api.tasks.testing.TestDescriptor,
-            result: org.gradle.api.tasks.testing.TestResult
-        ) {
-            if (suite.parent != null) return
-            val total = result.testCount
-            val failed = result.failedTestCount
-            val passed = result.successfulTestCount
-            val skipped = result.skippedTestCount
-            logger.lifecycle(
-                "Known-bug verification: $total test(s), $failed failed, $passed passed, $skipped skipped"
-            )
-            if (total == 0L) {
-                throw GradleException("verifyKnownBugs: no known-bug tests found. Add @Tag(\"known-bug\") tests.")
-            }
-            if (passed > 0L || skipped > 0L || failed != total) {
-                throw GradleException(
-                    "verifyKnownBugs: expected all known-bug tests to fail, but got " +
-                    "$failed failed, $passed passed, $skipped skipped out of $total. " +
-                    "If a bug was fixed, remove the @Tag(\"known-bug\") annotation and close the related issue."
-                )
-            }
-            logger.lifecycle("verifyKnownBugs: OK — all $failed known-bug test(s) are still failing as expected.")
-        }
-    })
 }
 
 // JaCoCoレポートの設定（Windows以外でのみ実行）

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** CsvValidateCommandクラスのテスト */
@@ -390,5 +391,45 @@ public class CsvValidateCommandTest {
     assertTrue(
         trackingInputStream.getTotalBytes() > 1000,
         "Should have processed substantial amount of data");
+  }
+
+  @Test
+  @Tag("known-bug")
+  @DisplayName("Bug証明 #709: エラーメッセージ切り詰め後にプレフィックスを追加するため例外メッセージが1000文字を超える")
+  void bug_709_errorMessageTruncation_prefixCausesExceedingLimit() throws IOException {
+    String[] requiredColumns = {"id", "name", "email"};
+    CsvValidateCommand command = CsvValidateCommand.create(true, 200, requiredColumns);
+
+    StringBuilder csvBuilder = new StringBuilder();
+    csvBuilder.append("id,name,email\n");
+    for (int i = 1; i <= 40; i++) {
+      csvBuilder.append(String.format("%d,User%d,user%d@example.com,extra_col_%d%n", i, i, i, i));
+    }
+
+    ByteArrayInputStream inputStream =
+        new ByteArrayInputStream(csvBuilder.toString().getBytes(StandardCharsets.UTF_8));
+
+    StreamProcessingException exception =
+        assertThrows(StreamProcessingException.class, () -> command.consume(inputStream));
+
+    String msg = exception.getMessage();
+    String prefix = "CSV validation failed: ";
+    assertTrue(msg.startsWith(prefix));
+    String body = msg.substring(prefix.length());
+    assertTrue(body.endsWith("..."));
+    assertEquals(1000, body.length());
+    assertEquals(prefix.length() + body.length(), msg.length());
+
+    // 仕様: 例外メッセージ全体が 1000 文字以下であるべき
+    // バグが存在する間はこのアサーションで失敗する（1023文字になるため）
+    assertTrue(
+        msg.length() <= 1000,
+        "Exception message should be at most 1000 chars, but was "
+            + msg.length()
+            + " (prefix="
+            + prefix.length()
+            + " + body="
+            + body.length()
+            + ")");
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -417,6 +417,7 @@ public class CsvValidateCommandTest {
     int maxAllowedBodyLength = 1000 - prefix.length();
     assertTrue(msg.startsWith(prefix));
     String body = msg.substring(prefix.length());
+    // 修正後の切り詰め実装に追従できるよう、固定長や末尾記号ではなく公開契約のみを検証する。
     assertTrue(body.contains("CSV validation failed with"));
     assertEquals(prefix.length() + body.length(), msg.length());
     assertTrue(

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -414,11 +414,17 @@ public class CsvValidateCommandTest {
 
     String msg = exception.getMessage();
     String prefix = "CSV validation failed: ";
+    int maxAllowedBodyLength = 1000 - prefix.length();
     assertTrue(msg.startsWith(prefix));
     String body = msg.substring(prefix.length());
-    assertTrue(body.endsWith("..."));
-    assertEquals(1000, body.length());
+    assertTrue(body.contains("CSV validation failed with"));
     assertEquals(prefix.length() + body.length(), msg.length());
+    assertTrue(
+        body.length() <= maxAllowedBodyLength,
+        "Error body should be at most "
+            + maxAllowedBodyLength
+            + " chars when prefixed, but was "
+            + body.length());
 
     // 仕様: 例外メッセージ全体が 1000 文字以下であるべき
     // バグが存在する間はこのアサーションで失敗する（1023文字になるため）


### PR DESCRIPTION
## Summary

- `@Tag("known-bug")` を導入し、バグ証明テストを通常 CI から除外しつつ「バグがまだ存在すること」を継続的に確認できる仕組みを追加
- issue #709 のバグ証明テストを `@Tag("known-bug")` 付きで `CsvValidateCommandTest` に追加
- `verifyKnownBugs` Gradle タスクを追加（`known-bug` タグのテストを実行し、全テストが失敗することを検証する）
- 通常テスト（`./gradlew build`）では `known-bug` タグが除外されるため CI は引き続き通る

## 動作確認

| コマンド | 結果 |
|---------|------|
| `./gradlew :streamconverter-core:test` | 20件パス（`known-bug` テストは除外） |
| `./gradlew :streamconverter-core:verifyKnownBugs` | `known-bug` テストが1件失敗 → `OK` → BUILD SUCCESSFUL |

## ワークフロー変更について（手動対応が必要）

`verify-known-bugs` CI ジョブを `commit-rules.yml` に追加する必要がありますが、ワークフローファイルの変更には GitHub の `workflow` スコープが必要なため、このPRには含めていません。

以下の diff を `.github/workflows/commit-rules.yml` の末尾に手動で適用してください:

```yaml
  verify-known-bugs:
    name: Verify Known Bugs Still Exist
    runs-on: ubuntu-latest
    permissions:
      contents: read
    env:
      JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
    steps:
      - name: Checkout code
        uses: actions/checkout@v4

      - name: Set up JDK 21
        uses: actions/setup-java@v4
        with:
          java-version: '21'
          distribution: 'temurin'
          cache: gradle

      - name: Grant execute permission for gradlew
        run: chmod +x gradlew

      - name: Verify known bugs are not accidentally fixed
        run: ./gradlew :streamconverter-core:verifyKnownBugs
```

## Test plan

- [x] `./gradlew :streamconverter-core:test` — `known-bug` テストが除外されて全件パスすることを確認
- [x] `./gradlew :streamconverter-core:verifyKnownBugs` — バグが存在する間は BUILD SUCCESSFUL になることを確認
- [ ] issue #709 の修正 PR で `verifyKnownBugs` が BUILD FAILED になることを確認（修正の証明）
- [ ] `commit-rules.yml` に `verify-known-bugs` ジョブを手動追加後、CI で動作確認

Closes #710
Related: #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)
