### PR TITLE
test: add known-bug proof test for issue 712

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -360,8 +360,8 @@ repositories {
 tasks.test {
     // JUnit 5 を使うための設定
     useJUnitPlatform {
-        // ベンチマークテストを通常のテスト実行から除外
-        excludeTags("benchmark", "large-data")
+        // ベンチマークテストと known-bug テストを通常のテスト実行から除外
+        excludeTags("benchmark", "large-data", "known-bug")
     }
 
     // クラス名・パスパターンでもベンチマーク系テストを除外

--- a/streamconverter-core/build.gradle.kts
+++ b/streamconverter-core/build.gradle.kts
@@ -91,8 +91,8 @@ spotless {
 tasks.test {
     // JUnit 5 を使うための設定
     useJUnitPlatform {
-        // ベンチマークテストを通常のテスト実行から除外
-        excludeTags("benchmark", "large-data")
+        // ベンチマークテストと known-bug テストを通常のテスト実行から除外
+        excludeTags("benchmark", "large-data", "known-bug")
     }
 
     // Exclude benchmark-related tests by class name and path patterns as well
@@ -115,6 +115,52 @@ tasks.test {
     }
     // テスト実行後にjavadocを生成
     finalizedBy(tasks.javadoc)
+}
+
+// known-bug タグのテストを実行し、全テストが失敗することを検証する
+// バグが修正された場合（テストがパスした場合）にビルドを失敗させる
+tasks.register<Test>("verifyKnownBugs") {
+    group = "verification"
+    description = "Verify that all known-bug tests fail (proving bugs still exist)"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    useJUnitPlatform {
+        includeTags("known-bug")
+    }
+    ignoreFailures = true
+    jvmArgs("-Xmx2g", "-Xms1g", "-Dfile.encoding=UTF-8")
+
+    addTestListener(object : org.gradle.api.tasks.testing.TestListener {
+        override fun beforeSuite(suite: org.gradle.api.tasks.testing.TestDescriptor) = Unit
+        override fun beforeTest(testDescriptor: org.gradle.api.tasks.testing.TestDescriptor) = Unit
+        override fun afterTest(
+            testDescriptor: org.gradle.api.tasks.testing.TestDescriptor,
+            result: org.gradle.api.tasks.testing.TestResult
+        ) = Unit
+
+        override fun afterSuite(
+            suite: org.gradle.api.tasks.testing.TestDescriptor,
+            result: org.gradle.api.tasks.testing.TestResult
+        ) {
+            if (suite.parent != null) return
+            val total = result.testCount
+            val failed = result.failedTestCount
+            val passed = result.successfulTestCount
+            logger.lifecycle(
+                "Known-bug verification: $total test(s), $failed failed, $passed passed"
+            )
+            if (total == 0L) {
+                throw GradleException("verifyKnownBugs: no known-bug tests found. Add @Tag(\"known-bug\") tests.")
+            }
+            if (passed > 0L) {
+                throw GradleException(
+                    "verifyKnownBugs: $passed known-bug test(s) passed unexpectedly. " +
+                    "If a bug was fixed, remove the @Tag(\"known-bug\") annotation and close the related issue."
+                )
+            }
+            logger.lifecycle("verifyKnownBugs: OK — all $failed known-bug test(s) are still failing as expected.")
+        }
+    })
 }
 
 // JaCoCoレポートの設定（Windows以外でのみ実行）

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** CsvValidateCommandクラスのテスト */
@@ -390,5 +391,36 @@ public class CsvValidateCommandTest {
     assertTrue(
         trackingInputStream.getTotalBytes() > 1000,
         "Should have processed substantial amount of data");
+  }
+
+  @Test
+  @Tag("known-bug")
+  @DisplayName("Bug証明 #712: CsvRowValidator が maxErrorsToReport + 1 件のエラーを返す")
+  void bug_maxErrorsToReport_returnsTooManyErrors() throws IOException {
+    int maxErrors = 2;
+    String[] requiredColumns = {};
+    CsvValidateCommand command = CsvValidateCommand.create(true, maxErrors, requiredColumns);
+
+    // ヘッダー行2列 + データ行3行（各行が1列しかなく、列不足エラーになる）
+    // addError() が maxErrors=2 件目に達した後、3件目として "... and more errors" を追加するバグを再現
+    String csv = "id,name\n" + "1\n" + "2\n" + "3\n";
+
+    ByteArrayInputStream inputStream =
+        new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8));
+
+    StreamProcessingException exception =
+        assertThrows(StreamProcessingException.class, () -> command.consume(inputStream));
+
+    String msg = exception.getMessage();
+
+    // 仕様: maxErrorsToReport=2 なので、例外メッセージには "2 error(s)" と報告されるべき
+    // バグが存在する間は addError() が N+1 件目に "... and more errors (limit reached)" を追加するため
+    // "3 error(s)" と表示され、かつ "... and more errors (limit reached)" も含まれる
+    assertTrue(
+        msg.contains("2 error(s)"),
+        "maxErrorsToReport=2 なのに '2 error(s)' が含まれていない。実際のメッセージ: " + msg);
+    assertFalse(
+        msg.contains("... and more errors (limit reached)"),
+        "maxErrorsToReport=2 のとき '... and more errors' は含まれるべきでないが、含まれていた。" + "実際のメッセージ: " + msg);
   }
 }


### PR DESCRIPTION
## バグの概要

`CsvRowValidator.addError()` が `maxErrorsToReport` で設定した最大エラー件数より1件多くエラーを返すバグの証明テストを追加します。

関連 issue: #712

## 変更内容

- `CsvValidateCommandTest` に `@Tag("known-bug")` 付きの証明テストを追加
- `streamconverter-core/build.gradle.kts` に以下を追加（PR #711 未マージのため本PRでも追加）:
  - `excludeTags` に `"known-bug"` を追加（通常 CI から除外）
  - `verifyKnownBugs` Gradle タスクを追加
- `build.gradle.kts`（ルート）の `excludeTags` にも `"known-bug"` を追加

## verifyKnownBugs での確認方法

```bash
./gradlew :streamconverter-core:verifyKnownBugs
```

出力例:
```
CsvValidateCommand Tests > Bug証明 #712: CsvRowValidator が maxErrorsToReport + 1 件のエラーを返す FAILED
Known-bug verification: 1 test(s), 1 failed, 0 passed
verifyKnownBugs: OK — all 1 known-bug test(s) are still failing as expected.
```

`BUILD SUCCESSFUL` + `verifyKnownBugs: OK` でバグの存在が継続確認できます。

## バグ修正 PR との連携

issue #712 を修正する PR で `verifyKnownBugs` が `BUILD FAILED`（パスするテストが出る）になることがバグ修正の証明になります。修正完了後は `@Tag("known-bug")` を削除して issue #712 をクローズしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
