### PR TITLE
fix: add DNS rebinding revalidation in execute() to prevent TOCTOU SSRF (closes #715)

### DIFF
--- a/streamconverter-http/src/main/java/com/streamconverter/command/impl/SendHttpCommand.java
+++ b/streamconverter-http/src/main/java/com/streamconverter/command/impl/SendHttpCommand.java
@@ -125,6 +125,34 @@ public class SendHttpCommand implements IStreamCommand {
     }
   }
 
+  /**
+   * execute()直前にホスト名を再DNS解決してSSRF（DNS rebinding）を検出する。
+   *
+   * <p>リテラルIPはDNS rebindingの対象外なのでスキップする。ホスト名の場合のみ再解決を行い、 localhost判定またはプライベートIP判定に変化していれば {@link
+   * IOException} をスローする。
+   */
+  private void revalidateHostForSsrf() throws IOException {
+    try {
+      URI uri = new URI(url);
+      String host = uri.getHost();
+      if (host == null || InetAddresses.isInetAddress(host)) {
+        return;
+      }
+      if (isLocalhost(host)) {
+        throw new IOException("DNS rebinding detected: host resolved to localhost: " + host);
+      }
+      InetAddress[] addresses = inetAddressResolver.getAllByName(host);
+      for (InetAddress address : addresses) {
+        if (isNonRoutable(address)) {
+          throw new IOException(
+              "DNS rebinding detected: host resolved to non-routable address: " + address);
+        }
+      }
+    } catch (URISyntaxException | UnknownHostException e) {
+      throw new IOException("SSRF revalidation failed: " + e.getMessage(), e);
+    }
+  }
+
   /** ローカルホストかどうかを判定する */
   private boolean isLocalhost(String host) {
     if (host == null) {
@@ -172,14 +200,20 @@ public class SendHttpCommand implements IStreamCommand {
   /**
    * ストリームを指定されたURLに送信します。
    *
+   * <p>SSRF防御のため、送信直前にURLのホスト名を再度DNS解決し、プライベートIPへの変化を検出した場合は {@link IOException} をスローします（DNS
+   * rebinding対策）。カスタム {@link WebClient} を注入する場合は、 接続再利用（keep-alive / connection
+   * pool）を無効にしてください。接続再利用が有効な場合、 この再検証をパスしても既存接続がプライベートIPへ転送されるリスクが残ります。
+   *
    * @param inputStream 入力ストリーム
    * @param outputStream 出力ストリーム
-   * @throws IOException 入出力エラーが発生した場合
+   * @throws IOException DNS rebindingを検出した場合、または入出力エラーが発生した場合
    */
   @Override
   public void execute(InputStream inputStream, OutputStream outputStream) throws IOException {
     Objects.requireNonNull(inputStream, "inputStream must not be null");
     Objects.requireNonNull(outputStream, "outputStream must not be null");
+
+    revalidateHostForSsrf();
 
     logger.info("Sending HTTP POST request to: {}", url);
 

--- a/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandSecurityTest.java
+++ b/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandSecurityTest.java
@@ -169,9 +169,8 @@ class SendHttpCommandSecurityTest {
   }
 
   @Test
-  @Tag("known-bug")
-  @DisplayName("Bug証明 #715: DNS rebinding TOCTOU - 2回目のDNS解決がプライベートIPを返す状態でexecute()が例外をスローしない")
-  void bug_715_dnsRebinding_executeSucceedsWhenSecondResolutionReturnsPrivateIp() throws Exception {
+  @DisplayName("DNS rebinding TOCTOU: execute()はDNS rebinding後のプライベートIPへの接続をブロックする（#715）")
+  void dnsRebinding_executeThrowsWhenSecondResolutionReturnsPrivateIp() throws Exception {
     // Arrange: 1回目=外部IP（コンストラクタ検証をパス）、2回目=プライベートIP（DNS rebinding後）
     RebindingDnsStub stub = new RebindingDnsStub();
 
@@ -200,6 +199,6 @@ class SendHttpCommandSecurityTest {
         java.io.IOException.class,
         () ->
             command.execute(new ByteArrayInputStream("x".getBytes()), new ByteArrayOutputStream()),
-        "【バグ #715】execute()はDNS rebinding後のプライベートIPへの接続をブロックすべきだが、例外をスローしない");
+        "execute()はDNS rebinding後のプライベートIPへの接続をブロックしてIOExceptionをスローするべき");
   }
 }


### PR DESCRIPTION
## Summary

- `SendHttpCommand.execute()` の先頭で `revalidateHostForSsrf()` を呼び出し、送信直前にホスト名を再DNS解決するよう修正
- DNS rebinding（TTL=0でコンストラクタ検証後にプライベートIPへ差し替え）を検出した場合は `IOException` をスロー
- リテラルIPはDNS rebindingの対象外のためスキップ、ホスト名のみ再検証
- カスタム `WebClient` 注入時の接続再利用リスクをJavadocに明記

## 修正前の動作（known-bugテストが証明）

`verifyKnownBugs` で以下のテストが期待通りFAIL（バグ存在確認済み）:

```
Bug証明 #715: DNS rebinding TOCTOU - 2回目のDNS解決がプライベートIPを返す状態でexecute()が例外をスローしない
→ assertThrows(IOException.class) がFAIL（= execute()が例外をスローしない = 再検証していない）
```

## 修正後の確認

```
verifyKnownBugs: BUILD FAILED
Known-bug verification (streamconverter-http): 1 test(s), 0 failed, 1 passed, 0 skipped
→ known-bugテストがPASSに転換 = バグ修正の客観的証明
```

`@Tag("known-bug")` を除去し、通常テストとして昇格:

```
Test summary: SUCCESS (28 total, 20 passed, 0 failed, 8 skipped)
```

## Test plan

- [ ] `./gradlew :streamconverter-http:verifyKnownBugs` が `BUILD FAILED`（テストがPASSに転換）
- [ ] `bash ~/dev/tools/reviewed/gradle-test-terse.sh streamconverter-http` が全件パス

Note: このブランチは PR #716（バグ証明テスト追加）をベースにしています。

Closes #715
Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)

