### PR TITLE
fix: wrap rule RuntimeException as IOException in CsvWalker (closes #720)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
@@ -109,7 +109,9 @@ public class CsvWalker implements IStreamCommand {
     }
   }
 
-  /** Apply transformation rule to specific column while preserving CSV structure */
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  // IRule.apply() declares no checked exceptions; any RuntimeException must be caught and
+  // re-thrown as IOException so the caller's error-handling path is not bypassed.
   private void applyRuleToColumn(CSVReader csvReader, CSVWriter csvWriter)
       throws IOException, CsvValidationException {
     String[] headers = csvReader.readNext();
@@ -130,7 +132,13 @@ public class CsvWalker implements IStreamCommand {
     while ((row = csvReader.readNext()) != null) {
       for (int idx : indices) {
         if (idx < row.length) {
-          row[idx] = rule.apply(row[idx]);
+          String transformed;
+          try {
+            transformed = rule.apply(row[idx]);
+          } catch (RuntimeException ruleEx) {
+            throw new IOException("Rule application failed at column index " + idx, ruleEx);
+          }
+          row[idx] = transformed;
         }
       }
       // applyQuotesToAll=false: only quote fields that contain delimiters or quotes

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for CsvWalker. */

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -316,6 +316,35 @@ class CsvWalkerTest {
   }
 
   @Test
+  @Tag("known-bug")
+  @DisplayName(
+      "Bug証明 #720: CsvWalker は rule が RuntimeException をスローしたとき IOException にラップしない（JsonWalker/XmlWalker と不一致）")
+  void bug_csvWalkerRuleRuntimeExceptionNotWrappedAsIOException() throws IOException {
+    RuntimeException ruleEx = new RuntimeException("rule failure");
+    CsvWalker failingRuleCommand =
+        CsvWalker.create(
+            CSVPath.of("name"),
+            v -> {
+              throw ruleEx;
+            });
+    String csvInput = "name,age\nAlice,30\n";
+    ByteArrayInputStream inputStream =
+        new ByteArrayInputStream(csvInput.getBytes(StandardCharsets.UTF_8));
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    // JsonWalker/XmlWalker は RuntimeException を IOException でラップするが
+    // CsvWalker はラップせずに RuntimeException をそのまま伝播させる（バグ）
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> failingRuleCommand.execute(inputStream, outputStream),
+            "Rule の RuntimeException は IOException にラップされるべきだが、CsvWalker はラップしない");
+    assertNotNull(thrown.getCause(), "IOException は元の例外を cause として保持すること");
+    assertInstanceOf(
+        RuntimeException.class, thrown.getCause(), "Cause は rule からの RuntimeException であること");
+  }
+
+  @Test
   @DisplayName("[#546] RFC 4180: comma inside quoted field is not split")
   void testRfc4180CommaInsideQuotedField() throws IOException {
     String csvInput = "name,address\nAlice,\"123 Main St, Suite 4\"\n";

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for CsvWalker. */
@@ -316,10 +315,9 @@ class CsvWalkerTest {
   }
 
   @Test
-  @Tag("known-bug")
   @DisplayName(
-      "Bug証明 #720: CsvWalker は rule が RuntimeException をスローしたとき IOException にラップしない（JsonWalker/XmlWalker と不一致）")
-  void bug_csvWalkerRuleRuntimeExceptionNotWrappedAsIOException() throws IOException {
+      "[#720] rule が RuntimeException をスローしたとき IOException にラップされること（JsonWalker/XmlWalker と一致）")
+  void testRuleRuntimeExceptionWrappedAsIOException() throws IOException {
     RuntimeException ruleEx = new RuntimeException("rule failure");
     CsvWalker failingRuleCommand =
         CsvWalker.create(

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for CsvWalker. */
@@ -358,31 +357,6 @@ class CsvWalkerTest {
     // The address field with internal comma should be preserved intact
     assertTrue(result.contains("123 Main St"), "Address should be preserved");
     assertTrue(result.contains("Suite 4"), "Comma-separated part of address should be preserved");
-  }
-
-  @Test
-  @Tag("known-bug")
-  @DisplayName("Bug証明 #720: CsvWalker は rule が RuntimeException をスローしたとき IOException にラップしない")
-  void bug_720_csvWalkerRuleRuntimeExceptionNotWrappedAsIOException() {
-    RuntimeException ruleEx = new RuntimeException("rule failure");
-    CsvWalker failingRuleCommand =
-        CsvWalker.create(
-            CSVPath.of("name"),
-            v -> {
-              throw ruleEx;
-            });
-    String csvInput = "name,age\nAlice,30\n";
-    ByteArrayInputStream inputStream =
-        new ByteArrayInputStream(csvInput.getBytes(StandardCharsets.UTF_8));
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
-    IOException thrown =
-        assertThrows(
-            IOException.class,
-            () -> failingRuleCommand.execute(inputStream, outputStream),
-            "Rule の RuntimeException は IOException にラップされるべきだが、CsvWalker はラップしない");
-    assertNotNull(thrown.getCause());
-    assertInstanceOf(RuntimeException.class, thrown.getCause());
   }
 
   @DisplayName("Bug証明 #726: 存在しない列を指定したとき IllegalArgumentException が IOException にラップされずに伝播する")


### PR DESCRIPTION
## 解決した課題

issue #720: `CsvWalker` の `applyRuleToColumn()` において、`rule.apply()` が `RuntimeException` をスローした場合にそれを捕捉せず、`IStreamCommand.execute()` の `throws IOException` 契約を破っていた。

### 背景

`JsonWalker`・`XmlWalker` は `rule.apply()` の `RuntimeException` を `IOException` にラップする実装になっているが、`CsvWalker` はラップ処理が欠落していた。この非一貫性により、`CsvWalker` を使う呼び出し元では `RuntimeException` が予期しない形で伝播し、適切なエラーハンドリングが行われないリスクがあった。

- `verifyKnownBugs` タスクの BUILD FAILED によりバグの存在を証明済み
- @codex による plan-review・code-review の両方で承認済み

## 解決方法

`applyRuleToColumn()` 内の `rule.apply(row[idx])` 呼び出しを `try-catch (RuntimeException)` で囲み、`IOException("Rule application failed at column index " + idx, ruleEx)` としてラップするよう修正した。これにより `JsonWalker`・`XmlWalker` との動作が一致する。

### 変更ファイル

**`streamconverter-core/.../CsvWalker.java`**
- `applyRuleToColumn()` に `@SuppressWarnings("PMD.AvoidCatchingGenericException")` を追加（意図的なキャッチであることを明示）
- `rule.apply(row[idx])` を `try-catch (RuntimeException)` で囲み `IOException` にラップ

**`streamconverter-core/.../CsvWalkerTest.java`**
- `@Tag("known-bug")` を除去（バグ修正により通常テストに昇格）
- `@DisplayName` を「Bug証明 #720: ...」から修正後の正常系表現に変更
- メソッド名を `bug_csvWalkerRuleRuntimeExceptionNotWrappedAsIOException` から `testRuleRuntimeExceptionWrappedAsIOException` に変更
- 不要になった `import org.junit.jupiter.api.Tag` を削除

## テスト

- `verifyKnownBugs` BUILD FAILED（修正前）→ 修正後はテストがパスに転換したことでバグ修正を証明
- `@Tag("known-bug")` を除去し、通常の CI テストスイートに組み込み済み
- 既存テスト全件パス確認済み

## その他

- 破壊的変更なし
- `JsonWalker`・`XmlWalker` との動作一貫性を確保

---

@codex この解決方法は、課題に対してクリティカルな解法でしょうか？

Closes #720
