### PR TITLE
test: add known-bug proof test for CsvFilterCommand IllegalArgumentException (#722)

### DIFF
--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/FilterCommandBasicTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/FilterCommandBasicTest.java
@@ -392,6 +392,32 @@ class FilterCommandBasicTest {
   }
 
   @Test
+  @Tag("known-bug")
+  @DisplayName(
+      "Bug証明 #722: CsvFilterCommand が存在しない列を指定したとき IOException の代わりに IllegalArgumentException をスローする")
+  void bug_csvFilterCommand_unknownColumnThrowsIllegalArgumentException() throws IOException {
+    String csvInput = "name,age\nAlice,30\n";
+    CsvFilterCommand command = CsvFilterCommand.create(CSVPath.of("nonexistent"));
+
+    ByteArrayInputStream input =
+        new ByteArrayInputStream(csvInput.getBytes(StandardCharsets.UTF_8));
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    // IStreamCommand.execute() は throws IOException 契約だが、
+    // CsvFilterCommand は列未検出時に IllegalArgumentException をスローする（契約違反）
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> command.execute(input, output),
+            "存在しない列の指定は IOException にラップされるべきだが、CsvFilterCommand は IllegalArgumentException をスローする");
+    assertNotNull(thrown.getCause(), "IOException は元の例外を cause として保持すること");
+    assertInstanceOf(
+        IllegalArgumentException.class,
+        thrown.getCause(),
+        "Cause は CsvFilterCommand からの IllegalArgumentException であること");
+  }
+
+  @Test
   @Tag("large-data")
   @DisplayName("[#549] JsonExtractCommand processes JSON larger than 10MB without IOException")
   void testJsonExtractCommand_LargeJsonNoMemoryLimit() throws IOException {


### PR DESCRIPTION
## 解決した課題

issue #722 のバグを客観的に証明するテストを追加しました。

`CsvFilterCommand.execute()` に存在しない列名（例: `"nonexistent"`）を指定したとき、`IStreamCommand.execute()` の `throws IOException` 契約に反して `IllegalArgumentException` が直接上位へ伝播します。

### バグの根本原因

`CsvFilterCommand.mapColumnSelectorsToIndices()` が列未検出時に `throw new IllegalArgumentException(...)` をスローしますが、この例外が `execute()` 内の `catch (CsvValidationException e)` をバイパスするため、`IOException` にラップされずそのまま呼び出し元へ伝播します。

**影響:** `IStreamCommand` インタフェースの契約違反。呼び出し元が `IOException` のみを catch していた場合、`IllegalArgumentException` が予期せず漏れる。

詳細は issue #722 を参照してください。

## 解決方法

バグの存在を証明する `@Tag("known-bug")` テストを追加しました。

**追加テスト:** `bug_csvFilterCommand_unknownColumnThrowsIllegalArgumentException`
- `CSVPath.of("nonexistent")` で存在しない列を指定
- `assertThrows(IOException.class, ...)` が失敗（代わりに `IllegalArgumentException` が伝播）することでバグを証明

バグ修正 PR では、このテストが `IOException` を正しく受け取り `PASS` に変わることで修正の完了を証明します。

## テスト

### バグ証明の確認方法

```
./gradlew verifyKnownBugs
```

`verifyKnownBugs`: **BUILD SUCCESSFUL** — known-bug テストが期待通り FAIL することを確認済みです。

- Codex によるテスト妥当性レビュー: **承認済み**

### 通常 CI との関係

`@Tag("known-bug")` により、通常の CI テストスイート（`test` タスク）からは除外されます。`verifyKnownBugs` タスクでのみ実行されます。

## その他

- `Closes #722` は含みません。このPRはバグ証明テストの追加のみです。issue はバグ修正 PR でクローズされます。
- バグ修正 PR で `@Tag("known-bug")` を除去し、このテストが通過することが修正完了の証明となります。

---

@codex この解決方法は、課題に対してクリティカルな解法でしょうか？
`IStreamCommand.execute()` の `throws IOException` 契約を破る `IllegalArgumentException` 伝播というバグを証明するにあたって、`assertThrows(IOException.class, ...)` を用いたこのテストアプローチは最も適切でしょうか。より効果的な証明方法や、見落としがある場合はご指摘をお願いします。
