### PR TITLE
fix: account for prefix length when truncating validation error message (closes #709)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
@@ -195,14 +195,16 @@ public class CsvValidateCommand extends ConsumerCommand {
     String errorMessage = errorBuilder.toString();
     logger.error("CSV validation summary: {}", errorMessage);
 
+    String prefix = "CSV validation failed: ";
+    int maxBodyLength = 1000 - prefix.length();
     String finalErrorMessage = errorMessage;
-    if (errorMessage.length() > 1000) {
-      finalErrorMessage = errorMessage.substring(0, 997) + "...";
+    if (errorMessage.length() > maxBodyLength) {
+      finalErrorMessage = errorMessage.substring(0, maxBodyLength - 3) + "...";
       logger.warn(
           "Error message truncated due to length (original: {} chars)", errorMessage.length());
     }
 
-    throw new StreamProcessingException("CSV validation failed: " + finalErrorMessage);
+    throw new StreamProcessingException(prefix + finalErrorMessage);
   }
 
   /**

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -8,7 +8,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** CsvValidateCommandクラスのテスト */
@@ -394,9 +393,8 @@ public class CsvValidateCommandTest {
   }
 
   @Test
-  @Tag("known-bug")
-  @DisplayName("Bug証明 #709: エラーメッセージ切り詰め後にプレフィックスを追加するため例外メッセージが1000文字を超える")
-  void bug_709_errorMessageTruncation_prefixCausesExceedingLimit() throws IOException {
+  @DisplayName("[#709] エラーメッセージ切り詰め後にプレフィックスを付加しても例外メッセージが1000文字以下に収まること")
+  void testErrorMessageTruncation_totalLengthWithinLimit() throws IOException {
     String[] requiredColumns = {"id", "name", "email"};
     CsvValidateCommand command = CsvValidateCommand.create(true, 200, requiredColumns);
 


### PR DESCRIPTION
## 概要

`CsvValidateCommand.handleValidationErrors()` がエラーメッセージを切り詰める際にプレフィックス長を考慮せず、例外メッセージ全体が 1000 文字を超えるバグを修正。

## 修正内容

プレフィックス `"CSV validation failed: "`（23文字）の長さを差し引いて本文の切り詰め上限を計算するよう変更。

- 修正前: 本文1000文字 + プレフィックス23文字 = 1023文字（制限超過）
- 修正後: 本文977文字 + プレフィックス23文字 = 1000文字（制限内）

## 修正前の動作（known-bug テストが証明）

40件の列数不一致エラーがある CSV を処理すると例外メッセージが 1023 文字になり、1000 文字制限を超えていた。

## 修正後の確認

- `verifyKnownBugs` BUILD FAILED（known-bug テストがパスに転換）→ バグ修正証明
- `@Tag("known-bug")` を除去してテスト昇格
- `streamconverter-core` 全 434 件 PASS
- Codex code-review: 問題なし

## 関連

- Closes #709
- Closes #708 (同一バグの重複起票)
