### PR TITLE
fix: throw IOException directly for unknown column in CsvWalker (closes #726)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
@@ -121,7 +121,7 @@ public class CsvWalker implements IStreamCommand {
 
     List<Integer> indices = columnSelector.resolve(headers);
     if (indices.isEmpty()) {
-      throw new IllegalArgumentException("Column not found: " + columnSelector.toString());
+      throw new IOException("Column not found: " + columnSelector.toString());
     }
 
     // Write header (unchanged); applyQuotesToAll=false: only quote when RFC 4180 requires

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -359,21 +359,18 @@ class CsvWalkerTest {
     assertTrue(result.contains("Suite 4"), "Comma-separated part of address should be preserved");
   }
 
-  @DisplayName("Bug証明 #726: 存在しない列を指定したとき IllegalArgumentException が IOException にラップされずに伝播する")
-  void bug_csvWalker_unknownColumnThrowsIllegalArgumentException() throws IOException {
+  @Test
+  @DisplayName("[#726] 存在しない列を指定したとき IOException がスローされること")
+  void testCsvWalker_unknownColumnThrowsIOException() throws IOException {
     String csvInput = "name,age\nAlice,30\n";
     CsvWalker csvWalker = CsvWalker.create(CSVPath.of("nonexistent"), new PassThroughRule());
     ByteArrayInputStream input =
         new ByteArrayInputStream(csvInput.getBytes(StandardCharsets.UTF_8));
     ByteArrayOutputStream output = new ByteArrayOutputStream();
-    IOException thrown =
-        assertThrows(
-            IOException.class,
-            () -> csvWalker.execute(input, output),
-            "存在しない列の指定は IOException にラップされるべきだが、CsvWalker は IllegalArgumentException をスローする");
-    assertInstanceOf(
-        IllegalArgumentException.class,
-        thrown.getCause(),
-        "Cause は CsvWalker からの IllegalArgumentException であること");
+
+    assertThrows(
+        IOException.class,
+        () -> csvWalker.execute(input, output),
+        "存在しない列の指定は IOException をスローするべきだが、IStreamCommand.execute() 契約に違反する例外が伝播する");
   }
 }


### PR DESCRIPTION
## 概要

`CsvWalker.applyRuleToColumn()` が列未検出時に `IllegalArgumentException` をスローしていたが、`execute()` の catch ブロックでキャッチされず `IStreamCommand.execute()` の `throws IOException` 契約を破っていた。

`applyRuleToColumn()` 内の列未検出箇所で直接 `IOException` をスローするよう修正。これにより：
- `execute()` 全体で広く `IllegalArgumentException` をキャッチして誤分類するリスクを回避（Codex plan-review 指摘）
- `rule.apply()` 由来の例外と列未検出例外が混同されない

## 修正内容

```
- throw new IllegalArgumentException("Column not found: " + columnSelector.toString());
+ throw new IOException("Column not found: " + columnSelector.toString());
```

## 修正前の動作（known-bug テストが証明）

`CSVPath.of("nonexistent")` で存在しない列を指定すると `IllegalArgumentException` が直接スローされ、`IStreamCommand.execute()` の `throws IOException` 契約を破っていた。

## 修正後の確認

- `verifyKnownBugs` BUILD FAILED（known-bug テストがパスに転換）→ バグ修正証明
- `@Tag("known-bug")` を除去してテスト昇格
- `streamconverter-core` 全 434 件 PASS
- Codex code-review: 問題なし

## 関連

- Closes #726
- バグ証明テスト PR: #727
