### PR TITLE
test: add known-bug proof test for ValidateCommand StreamProcessingException (#729)

### DIFF
--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -439,4 +439,26 @@ public class CsvValidateCommandTest {
             + body.length()
             + ")");
   }
+
+  @Test
+  @Tag("known-bug")
+  @DisplayName(
+      "Bug証明 #731: CsvValidateCommand が CSV バリデーション失敗時に StreamProcessingException（RuntimeException）を IStreamCommand.execute() 契約に違反してスローする")
+  void bug_csvValidateCommand_validationFailureThrowsStreamProcessingExceptionNotIOException()
+      throws IOException {
+    CsvValidateCommand command = CsvValidateCommand.create("id", "name");
+    String csvInput = "id,age\n1,30\n";
+
+    java.io.ByteArrayOutputStream outputStream = new java.io.ByteArrayOutputStream();
+    ByteArrayInputStream inputStream =
+        new ByteArrayInputStream(csvInput.getBytes(StandardCharsets.UTF_8));
+
+    // IStreamCommand.execute() の設計方針は throws IOException のみ。
+    // バグ: CSV バリデーション失敗 → StreamProcessingException（RuntimeException）が伝播。
+    // 期待: IOException がスローされるべき
+    assertThrows(
+        IOException.class,
+        () -> command.execute(inputStream, outputStream),
+        "CsvValidateCommand.execute() は IOException をスローするべきだが、StreamProcessingException（RuntimeException）が伝播する");
+  }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ValidateTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ValidateTest.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("XMLバリデーションコマンドのテスト")
@@ -161,6 +162,28 @@ class ValidateTest {
           () -> {
             command.execute(inputStream, outputStream);
           });
+    }
+  }
+
+  @Test
+  @Tag("known-bug")
+  @DisplayName(
+      "Bug証明 #729: ValidateCommand が XMLバリデーション失敗時に StreamProcessingException（RuntimeException）を IStreamCommand.execute() 契約に違反してスローする")
+  void bug_validateCommand_xmlValidationFailureThrowsStreamProcessingExceptionNotIOException()
+      throws IOException {
+    ValidateCommand command = ValidateCommand.create(schemaPath);
+
+    try (InputStream inputStream =
+            getClass().getClassLoader().getResourceAsStream("invalid-test.xml");
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+
+      // IStreamCommand.execute() の契約は throws IOException のみ。
+      // バグ: SAXException → StreamProcessingException（RuntimeException）がキャッチされずに伝播。
+      // 期待: IOException がスローされるべき
+      assertThrows(
+          IOException.class,
+          () -> command.execute(inputStream, outputStream),
+          "ValidateCommand.execute() は IOException をスローするべきだが、StreamProcessingException（RuntimeException）が伝播する");
     }
   }
 


### PR DESCRIPTION
## 概要

`ValidateCommand` および `CsvValidateCommand` が バリデーション失敗時に `StreamProcessingException`（RuntimeException）を `IStreamCommand.execute()` の設計方針に違反してスローするバグを証明するテストを追加。

## バグの内容

両コマンドとも `ConsumerCommand` を継承しており：
- `ValidateCommand.consume()` が `SAXException` → `StreamProcessingException` に変換してスロー
- `CsvValidateCommand.consume()` が バリデーション失敗時に `StreamProcessingException` をスロー
- `ConsumerCommand.execute()` は `IOException` しかキャッチしないため `StreamProcessingException` が素通り
- 結果: 呼び出し元が予期しない RuntimeException を受け取る

## 証明テスト

1. `ValidateTest#bug_validateCommand_xmlValidationFailureThrowsStreamProcessingExceptionNotIOException` (#729)
2. `CsvValidateCommandTest#bug_csvValidateCommand_validationFailureThrowsStreamProcessingExceptionNotIOException` (#731)

## 確認

- `verifyKnownBugs`: BUILD SUCCESSFUL（3件の known-bug テストが期待通り FAIL）
- 通常テスト: 全件 PASS（known-bug 除外）

各修正 PR で `verifyKnownBugs` が BUILD FAILED になることがバグ修正の証明となる。

## 関連

- issue #729: ValidateCommand のバグ
- issue #731: CsvValidateCommand のバグ
