### PR TITLE
fix: wrap StreamProcessingException as IOException in ConsumerCommand (closes #729, closes #731)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/ConsumerCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/ConsumerCommand.java
@@ -1,5 +1,6 @@
 package com.streamconverter.command;
 
+import com.streamconverter.StreamProcessingException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -51,6 +52,8 @@ public abstract class ConsumerCommand implements IStreamCommand {
 
     try (InputStream teeInputStream = new TeeInputStream(inputStream, outputStream)) {
       this.consume(teeInputStream);
+    } catch (StreamProcessingException e) {
+      throw new IOException(e.getMessage(), e);
     } catch (IOException e) {
       throw new IOException("Error while consuming input stream", e);
     }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -8,7 +8,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** CsvValidateCommandクラスのテスト */
@@ -467,11 +466,8 @@ public class CsvValidateCommandTest {
   }
 
   @Test
-  @Tag("known-bug")
-  @DisplayName(
-      "Bug証明 #731: CsvValidateCommand が CSV バリデーション失敗時に StreamProcessingException（RuntimeException）を IStreamCommand.execute() 契約に違反してスローする")
-  void bug_csvValidateCommand_validationFailureThrowsStreamProcessingExceptionNotIOException()
-      throws IOException {
+  @DisplayName("[#731] CSV バリデーション失敗時に execute() が IOException をスローすること")
+  void testCsvValidateCommand_validationFailureThrowsIOException() throws IOException {
     CsvValidateCommand command = CsvValidateCommand.create("id", "name");
     String csvInput = "id,age\n1,30\n";
 
@@ -479,12 +475,6 @@ public class CsvValidateCommandTest {
     ByteArrayInputStream inputStream =
         new ByteArrayInputStream(csvInput.getBytes(StandardCharsets.UTF_8));
 
-    // IStreamCommand.execute() の設計方針は throws IOException のみ。
-    // バグ: CSV バリデーション失敗 → StreamProcessingException（RuntimeException）が伝播。
-    // 期待: IOException がスローされるべき
-    assertThrows(
-        IOException.class,
-        () -> command.execute(inputStream, outputStream),
-        "CsvValidateCommand.execute() は IOException をスローするべきだが、StreamProcessingException（RuntimeException）が伝播する");
+    assertThrows(IOException.class, () -> command.execute(inputStream, outputStream));
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ValidateTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ValidateTest.java
@@ -11,7 +11,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("XMLバリデーションコマンドのテスト")
@@ -75,9 +74,9 @@ class ValidateTest {
             getClass().getClassLoader().getResourceAsStream("invalid-test.xml");
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
 
-      // StreamProcessingExceptionが発生することを期待
+      // execute() 境界では IOException がスローされる（ConsumerCommand が StreamProcessingException をラップ）
       assertThrows(
-          com.streamconverter.StreamProcessingException.class,
+          IOException.class,
           () -> {
             command.execute(inputStream, outputStream);
           });
@@ -156,9 +155,10 @@ class ValidateTest {
     try (InputStream inputStream = new ByteArrayInputStream(new byte[0]);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
 
-      // StreamProcessingExceptionが発生することを期待（空のXMLは無効）
+      // execute() 境界では IOException がスローされる（空XMLは無効、ConsumerCommand が StreamProcessingException
+      // をラップ）
       assertThrows(
-          com.streamconverter.StreamProcessingException.class,
+          IOException.class,
           () -> {
             command.execute(inputStream, outputStream);
           });
@@ -166,24 +166,15 @@ class ValidateTest {
   }
 
   @Test
-  @Tag("known-bug")
-  @DisplayName(
-      "Bug証明 #729: ValidateCommand が XMLバリデーション失敗時に StreamProcessingException（RuntimeException）を IStreamCommand.execute() 契約に違反してスローする")
-  void bug_validateCommand_xmlValidationFailureThrowsStreamProcessingExceptionNotIOException()
-      throws IOException {
+  @DisplayName("[#729] XMLバリデーション失敗時に execute() が IOException をスローすること")
+  void testValidateCommand_xmlValidationFailureThrowsIOException() throws IOException {
     ValidateCommand command = ValidateCommand.create(schemaPath);
 
     try (InputStream inputStream =
             getClass().getClassLoader().getResourceAsStream("invalid-test.xml");
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
 
-      // IStreamCommand.execute() の契約は throws IOException のみ。
-      // バグ: SAXException → StreamProcessingException（RuntimeException）がキャッチされずに伝播。
-      // 期待: IOException がスローされるべき
-      assertThrows(
-          IOException.class,
-          () -> command.execute(inputStream, outputStream),
-          "ValidateCommand.execute() は IOException をスローするべきだが、StreamProcessingException（RuntimeException）が伝播する");
+      assertThrows(IOException.class, () -> command.execute(inputStream, outputStream));
     }
   }
 


### PR DESCRIPTION
## 概要

`ConsumerCommand.execute()` に `StreamProcessingException`（RuntimeException）のキャッチを追加し、`IOException` にラップして再スローするよう修正。これにより `ValidateCommand`（#729）と `CsvValidateCommand`（#731）の両方で `IStreamCommand.execute()` の設計方針（`throws IOException`）が守られる。

## 修正内容

```java
// ConsumerCommand.execute() に追加
} catch (StreamProcessingException e) {
    throw new IOException(e.getMessage(), e);
}
```

`StreamProcessingException` は `core` 中心例外であり、`ConsumerCommand` が依存することは設計上妥当（Codex plan-review 承認）。

## 修正前の動作（known-bug テストが証明）

- `ValidateCommand`: `SAXException` → `StreamProcessingException`（RuntimeException）が `execute()` 境界を素通り
- `CsvValidateCommand`: バリデーション失敗 → `StreamProcessingException`（RuntimeException）が `execute()` 境界を素通り

## 修正後の確認

- `verifyKnownBugs` BUILD FAILED（#729/#731 の known-bug テストが 2件 PASS に転換）
- `@Tag("known-bug")` を除去してテスト昇格
- `streamconverter-core` 全 435 件 PASS
- Codex code-review: 問題なし

## 関連

- Closes #729
- Closes #731
- バグ証明テスト PR: #730
