### PR TITLE
test: add known-bug proof test for CsvValidateCommand SPE contract violation (#731)

### DIFF
--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.streamconverter.StreamProcessingException;
 import com.streamconverter.test.StreamingTestUtils.TrackingInputStream;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
@@ -438,5 +439,24 @@ public class CsvValidateCommandTest {
             + " + body="
             + body.length()
             + ")");
+  }
+
+  @Test
+  @Tag("known-bug")
+  @DisplayName(
+      "Bug証明 #731: CsvValidateCommand が CSV バリデーション失敗時に StreamProcessingException を execute() 境界から素通りさせる")
+  void bug_731_csvValidateCommandValidationFailureThrowsStreamProcessingException()
+      throws IOException {
+    CsvValidateCommand command = CsvValidateCommand.create("id", "name");
+    String csvInput = "id,age\n1,30\n";
+
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    ByteArrayInputStream inputStream =
+        new ByteArrayInputStream(csvInput.getBytes(StandardCharsets.UTF_8));
+
+    assertThrows(
+        IOException.class,
+        () -> command.execute(inputStream, outputStream),
+        "CsvValidateCommand.execute() は IOException をスローするべきだが、StreamProcessingException（RuntimeException）が伝播する");
   }
 }


### PR DESCRIPTION
## Summary

- `CsvValidateCommand.execute()` が CSV バリデーション失敗時に `StreamProcessingException`（RuntimeException）を `IOException` にラップせず素通りさせるバグ (#731) の known-bug 証明テストを追加
- `ValidateCommand` の同様バグ (#729) を証明した PR #730 と対称的な位置づけ
- 修正は `ConsumerCommand` への `StreamProcessingException` キャッチ追加で対応（PR #732）

## Test plan

- [ ] `./gradlew :streamconverter-core:verifyKnownBugs` が BUILD SUCCESSFUL（known-bug テストが期待通り FAIL）
- [ ] `./gradlew :streamconverter-core:test` が全件 PASS（known-bug テストは除外）

## 関連

- issue: #731
- 修正 PR: #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)
