### PR TITLE
fix(security): upgrade Netty to 4.2.13.Final to fix 11 CVEs

### DIFF
--- a/streamconverter-http/build.gradle.kts
+++ b/streamconverter-http/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
 
     // Import Spring Boot BOM to align Spring/Reactor/Netty versions
     implementation(platform("org.springframework.boot:spring-boot-dependencies:4.0.6"))
+    // Override Netty version to 4.2.13.Final (fixes CVE-2026-42577 et al.)
+    implementation(platform("io.netty:netty-bom:4.2.13.Final"))
 
     // Logging (version via BOM)
     implementation("ch.qos.logback:logback-core")
@@ -35,8 +37,8 @@ dependencies {
     implementation("org.springframework:spring-webflux")
     implementation("org.springframework:spring-context")
     implementation("io.projectreactor.netty:reactor-netty-http")
-    implementation("io.netty:netty-handler:4.2.12.Final")
-    implementation("io.netty:netty-common:4.2.12.Final")
+    implementation("io.netty:netty-handler")
+    implementation("io.netty:netty-common")
 
     // IP address validation
     implementation("com.google.guava:guava:33.6.0-jre")


### PR DESCRIPTION
## Summary

- `io.netty:netty-bom:4.2.13.Final` を Spring Boot BOM の後に追加し、Netty の全アーティファクトを一括で 4.2.13.Final にアップグレード
- `netty-handler` と `netty-common` の直接バージョン指定（4.2.12.Final）を削除（BOM に委譲）
- `reactor-netty-http` 経由でトランジティブに引き込まれる `netty-codec-http` 等も同バージョンに統一

## 修正される脆弱性（Dependabot alerts）

| Alert | CVE | 深刻度 | モジュール |
|---|---|---|---|
| #56 | CVE-2026-42577 | High | netty-transport-native-epoll |
| #55/#54 | CVE-2026-42587 | High | netty-codec-http2, netty-codec-http |
| #51 | CVE-2026-42583 | High | netty-codec-compression |
| #50 | CVE-2026-42582 | High | netty-codec-http3 |
| #47 | CVE-2026-42579 | High | netty-codec-dns |
| #52 | CVE-2026-42584 | High | netty-codec-http |
| #53 | CVE-2026-42580 | Moderate | netty-codec-http |
| #48 | CVE-2026-42581 | Moderate | netty-codec-http |
| #49 | CVE-2026-42585 | Moderate | netty-codec-http |
| #44 | CVE-2026-41417 | Moderate | netty-codec-http |
| #46 | CVE-2026-42578 | Low | netty-handler-proxy |

※ Log4j の alerts (#41, #42, #43) は Spring Boot BOM 4.0.6 が log4j2 2.25.4 を管理しており、対応不要。

## Test plan

- [x] `streamconverter-http:test` — 27 tests (19 passed, 8 skipped for network) BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
