### PR TITLE
docs: fix stale class names pre-Maven-Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ Java 21 &nbsp;|&nbsp; [📚 完全なドキュメント一覧](docs/INDEX.md) &n
 
 ```java
 import com.streamconverter.StreamConverter;
-import com.streamconverter.command.impl.csv.CsvNavigateCommand;
+import com.streamconverter.command.impl.csv.CsvWalker;
 import com.streamconverter.command.rule.impl.string.TrimRule;
 import com.streamconverter.path.CSVPath;
 
 StreamConverter converter = StreamConverter.create(
-    CsvNavigateCommand.create(CSVPath.of("name"), new TrimRule()));
+    CsvWalker.create(CSVPath.of("name"), new TrimRule()));
 
 converter.run(inputStream, outputStream);
 ```
@@ -52,9 +52,9 @@ converter.run(inputStream, outputStream);
 
 | カテゴリ | クラス | 概要 |
 | --- | --- | --- |
-| CSV | `CsvNavigateCommand`, `CsvFilterCommand`, `CsvValidateCommand` | 列変換・行フィルタ・構造検証 |
-| JSON | `JsonNavigateCommand`, `JsonFilterCommand` | JSONPath 変換・フィルタ |
-| XML | `XmlNavigateCommand`, `XmlFilterCommand`, `ValidateCommand` | XPath ナビゲーションと XSD 検証 |
+| CSV | `CsvWalker`, `CsvFilterCommand`, `CsvValidateCommand` | 列変換・行フィルタ・構造検証 |
+| JSON | `JsonWalker`, `JsonExtractCommand` | JSONPath 変換・抽出 |
+| XML | `XmlWalker`, `XmlExtractCommand`, `ValidateCommand` | XPath ナビゲーション・抽出と XSD 検証 |
 | 文字列 | `LineEndingNormalizeCommand`, `CharacterConvertCommand` | 改行正規化・エンコーディング変換 |
 
 ---
@@ -97,7 +97,7 @@ converter.run(inputStream, outputStream);
 - DNS 解決後のアドレスも検査されます（DNS リバインディング攻撃への対策）
 - HTTP/HTTPS スキームのみ許可されます
 
-### XML コマンド（XmlNavigateCommand, XmlFilterCommand, ValidateCommand）
+### XML コマンド（XmlWalker, XmlExtractCommand, ValidateCommand）
 - XXE（XML External Entity）対策として外部エンティティ参照を無効化しています
 - DOCTYPE 宣言は処理されません
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,9 +33,9 @@ This simplified architecture removes factory complexity while maintaining all fu
 ┌─────────────────────────────────────────────────────────────────┐
 │              Direct Instantiation Pattern                      │
 ├─────────────────────────────────────────────────────────────────┤
-│  new CsvNavigateCommand(new CSVPath("column"), new Rule())     │
-│  new JsonNavigateCommand(new JSONPath("$.path"), new Rule())   │
-│  new XmlNavigateCommand(new XPath("//xpath"), new Rule())      │
+│  CsvWalker.create(CSVPath.of("column"), rule)                  │
+│  JsonWalker.create(TreePath.fromJson("$.path"), rule)          │
+│  XmlWalker.create(TreePath.fromXml("element/child"), rule)     │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -43,12 +43,12 @@ This simplified architecture removes factory complexity while maintaining all fu
 
 ### 1. Direct Command Instantiation
 
-Commands are created directly with explicit parameters. For detailed examples, see [Command Examples](reference/COMMAND_EXAMPLES.md).
+Commands are created via static factory methods with explicit parameters. For detailed examples, see [Command Examples](reference/COMMAND_EXAMPLES.md).
 
 ```java
 // Example: CSV command
-IStreamCommand csvCommand = new CsvNavigateCommand(
-    new CSVPath("name"),
+IStreamCommand csvCommand = CsvWalker.create(
+    CSVPath.of("name"),
     new PassThroughRule()
 );
 ```
@@ -63,14 +63,13 @@ IStreamCommand csvCommand = new CsvNavigateCommand(
 
 ```java
 // Single command
-StreamConverter converter = new StreamConverter(new IStreamCommand[]{command});
+StreamConverter converter = StreamConverter.create(command);
 
 // Multiple commands pipeline
-IStreamCommand[] pipeline = {command1, command2, command3};
-StreamConverter converter = new StreamConverter(pipeline);
+StreamConverter converter = StreamConverter.create(command1, command2, command3);
 
 // Execute processing
-List<CommandResult> results = converter.run(inputStream, outputStream);
+converter.run(inputStream, outputStream);
 ```
 
 ### 3. Automatic Logging
@@ -79,8 +78,8 @@ All commands extending `AbstractStreamCommand` automatically include comprehensi
 
 ```java
 // All standard commands have built-in logging
-IStreamCommand csvCommand = new CsvNavigateCommand(new CSVPath("name"), new PassThroughRule());
-StreamConverter converter = new StreamConverter(new IStreamCommand[]{csvCommand});
+IStreamCommand csvCommand = CsvWalker.create(CSVPath.of("name"), new PassThroughRule());
+StreamConverter converter = StreamConverter.create(csvCommand);
 
 // Logs automatically include:
 // - Execution time, data sizes, memory usage
@@ -98,9 +97,9 @@ See [AUTO_LOGGING.md](AUTO_LOGGING.md) for details on the automatic logging infr
 **Direct Instantiation Approach**:
 ```java
 // Explicit, readable command creation
-IStreamCommand csvCommand = new CsvNavigateCommand(new CSVPath("name"), new PassThroughRule());
-StreamConverter converter = new StreamConverter(new IStreamCommand[]{csvCommand});
-List<CommandResult> results = converter.run(inputStream, outputStream);
+IStreamCommand csvCommand = CsvWalker.create(CSVPath.of("name"), new PassThroughRule());
+StreamConverter converter = StreamConverter.create(csvCommand);
+converter.run(inputStream, outputStream);
 ```
 
 **Benefits**:
@@ -115,7 +114,7 @@ Add logging only where needed with minimal overhead:
 
 ```java
 // Commands automatically include comprehensive logging
-IStreamCommand command = new CsvNavigateCommand(new CSVPath("email"), new PassThroughRule());
+IStreamCommand command = CsvWalker.create(CSVPath.of("email"), new PassThroughRule());
 // Logs: execution time, data sizes, memory usage, performance warnings
 ```
 
@@ -126,8 +125,8 @@ IStreamCommand command = new CsvNavigateCommand(new CSVPath("email"), new PassTh
 try (FileInputStream input = new FileInputStream("data.csv");
      FileOutputStream output = new FileOutputStream("result.txt")) {
     
-    IStreamCommand command = new CsvNavigateCommand(new CSVPath("name"), new PassThroughRule());
-    StreamConverter converter = new StreamConverter(new IStreamCommand[]{command});
+    IStreamCommand command = CsvWalker.create(CSVPath.of("name"), new PassThroughRule());
+    StreamConverter converter = StreamConverter.create(command);
     converter.run(input, output);
 }
 ```
@@ -135,12 +134,11 @@ try (FileInputStream input = new FileInputStream("data.csv");
 **Pipeline Processing**:
 ```java
 // Multi-stage processing pipeline (all commands auto-logged)
-IStreamCommand[] pipeline = {
-    new CsvNavigateCommand(new CSVPath("data"), new PassThroughRule()),
+StreamConverter converter = StreamConverter.create(
+    CsvWalker.create(CSVPath.of("data"), new PassThroughRule()),
     new CharacterConvertCommand("UTF-8", "UTF-16"),
     new LineEndingNormalizeCommand(LineEndingNormalizeCommand.LineEndingType.UNIX)
-};
-StreamConverter converter = new StreamConverter(pipeline);
+);
 ```
 
 ## Usage Examples
@@ -148,28 +146,28 @@ StreamConverter converter = new StreamConverter(pipeline);
 ### Basic CSV Processing
 ```java
 // Extract a specific column from CSV data
-IStreamCommand command = new CsvNavigateCommand(new CSVPath("email"), new PassThroughRule());
-StreamConverter converter = new StreamConverter(new IStreamCommand[]{command});
-List<CommandResult> results = converter.run(csvInputStream, outputStream);
+IStreamCommand command = CsvWalker.create(CSVPath.of("email"), new PassThroughRule());
+StreamConverter converter = StreamConverter.create(command);
+converter.run(csvInputStream, outputStream);
 ```
 
-### JSON Processing with Validation
+### JSON Processing
 ```java
 // JSON property extraction (auto-logged)
-IStreamCommand jsonCommand = new JsonNavigateCommand(new JSONPath("user.profile.name"), new PassThroughRule());
-StreamConverter converter = new StreamConverter(new IStreamCommand[]{jsonCommand});
-List<CommandResult> results = converter.run(jsonInputStream, outputStream);
+IStreamCommand jsonCommand = JsonWalker.create(
+    TreePath.fromJson("user.profile.name"), new PassThroughRule());
+StreamConverter converter = StreamConverter.create(jsonCommand);
+converter.run(jsonInputStream, outputStream);
 ```
 
 ### XML Processing Pipeline
 ```java
 // XML transformation pipeline (all commands auto-logged)
-IStreamCommand[] pipeline = {
-    new XmlNavigateCommand(new XPath("//users/user/name"), new PassThroughRule()),
+StreamConverter converter = StreamConverter.create(
+    XmlWalker.create(TreePath.fromXml("users/user/name"), new PassThroughRule()),
     new CharacterConvertCommand("UTF-8", "UTF-16")
-};
-StreamConverter converter = new StreamConverter(pipeline);
-List<CommandResult> results = converter.run(xmlInputStream, outputStream);
+);
+converter.run(xmlInputStream, outputStream);
 ```
 
 ## Key Improvements After Factory Elimination
@@ -210,13 +208,13 @@ List<CommandResult> results = converter.run(xmlInputStream, outputStream);
 ## Implementation Details
 
 ### Command Creation Pattern
-Direct instantiation with explicit parameters:
+Direct instantiation via static factory methods with explicit parameters:
 
 ```java
 // Clear, readable command creation
-IStreamCommand csvCommand = new CsvNavigateCommand(
-    new CSVPath("columnName"),    // Path specification
-    new PassThroughRule()         // Transformation rule
+IStreamCommand csvCommand = CsvWalker.create(
+    CSVPath.of("columnName"),    // Path specification
+    new PassThroughRule()        // Transformation rule
 );
 // Logging is automatically included via AbstractStreamCommand
 ```
@@ -259,43 +257,46 @@ Direct Instantiation (After):
 
 ## Available Commands
 
-### Data Navigation Commands
-- **CsvNavigateCommand**: Navigate CSV data using CSVPath
-- **JsonNavigateCommand**: Navigate JSON data using JSONPath  
-- **XmlNavigateCommand**: Navigate XML data using XPath
+### Data Navigation / Transformation Commands
+- **CsvWalker**: Navigate and transform CSV columns using `CSVPath`
+- **JsonWalker**: Navigate and transform JSON values using `TreePath.fromJson()`
+- **XmlWalker**: Navigate and transform XML elements using `TreePath.fromXml()`
+- **CsvFilterCommand**: Filter CSV rows by column values
 
-### Data Transformation Commands
-- **CharacterConvertCommand**: Convert character encodings
-- **LineEndingNormalizeCommand**: Normalize line endings
-- **SendHttpCommand**: Send HTTP requests (with security validation)
+### Data Extraction Commands
+- **JsonExtractCommand**: Extract JSON data using JSONPath expressions
+- **XmlExtractCommand**: Extract XML elements using XPath expressions
 
-### Data Validation Commands  
+### Data Validation Commands
 - **CsvValidateCommand**: Validate CSV structure and content
-- **JsonValidateCommand**: Validate JSON against schema
 - **ValidateCommand**: Validate XML against XSD schema
 
-### Utility Commands
-- **SampleStreamCommand**: Basic stream copying and processing
+### Data Conversion Commands
+- **CharacterConvertCommand**: Convert character encodings
+- **LineEndingNormalizeCommand**: Normalize line endings
+
+### HTTP Integration Commands (streamconverter-http)
+- **SendHttpCommand**: Send HTTP requests (with security validation)
 
 ## Path Specifications
 
 ### CSVPath
 ```java
-new CSVPath("columnName")     // Extract by column name
-new CSVPath("0")              // Extract by column index
+CSVPath.of("columnName")  // Extract by column name
+CSVPath.of("0")           // Extract by column index
 ```
 
-### JSONPath  
+### TreePath (JSON)
 ```java
-new JSONPath("user.name")        // Simple property access
-new JSONPath("users[0].email")   // Array access
-new JSONPath("$.data.items[*]")  // Wildcard access
+TreePath.fromJson("user.name")        // Simple property access
+TreePath.fromJson("users[0].email")   // Array access
+TreePath.fromJson("$.data.items[*]")  // Wildcard access
 ```
 
-### XPath
+### TreePath (XML)
 ```java
-new XPath("//user/name")         // XPath expression
-new XPath("/root/users/user[1]") // Specific element access
+TreePath.fromXml("user/name")          // Element path
+TreePath.fromXml("root/users/user[1]") // Specific element access
 ```
 
 ## Rule Specifications

--- a/docs/reference/CLAUDE_ARCHITECTURE.md
+++ b/docs/reference/CLAUDE_ARCHITECTURE.md
@@ -11,10 +11,24 @@
 - Log sync filter: `PipelineContextTurboFilter`
 
 ## Available built-in commands (core)
-- CSV: `CsvNavigateCommand`, `CsvFilterCommand`, `CsvValidateCommand`
-- JSON: `JsonNavigateCommand`, `JsonFilterCommand`
-- XML: `XmlNavigateCommand`, `XmlFilterCommand`, `ValidateCommand`
+- CSV: `CsvWalker`, `CsvFilterCommand`, `CsvValidateCommand`
+- JSON: `JsonWalker`, `JsonExtractCommand`
+- XML: `XmlWalker`, `XmlExtractCommand`, `ValidateCommand`
 - Text: `LineEndingNormalizeCommand`, `CharacterConvertCommand`
+
+## Path Specifications
+- CSV: `CSVPath.of("columnName")`
+- JSON: `TreePath.fromJson("$.path.to.value")`
+- XML: `TreePath.fromXml("element/child")`
 
 ## Important
 旧 API (`ExecutionContext`, `createWithContext`, `CommandResult`, `JsonValidateCommand`, `JsonStreamingValidateCommand`, `SampleStreamCommand`) を前提にした実装は現行コードと一致しません。
+
+また以下のリネームが実施済みです（旧名は存在しません）：
+- `CsvNavigateCommand` → `CsvWalker`
+- `JsonNavigateCommand` → `JsonWalker`
+- `XmlNavigateCommand` → `XmlWalker`
+- `JsonFilterCommand` → `JsonExtractCommand`
+- `XmlFilterCommand` → `XmlExtractCommand`
+- `new CSVPath(...)` → `CSVPath.of(...)`
+- `new JSONPath(...)` / `new XPath(...)` → `TreePath.fromJson(...)` / `TreePath.fromXml(...)`

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -2,10 +2,10 @@
 <FindBugsFilter>
     <!-- Exclude example and demo classes from analysis -->
     <Match>
-        <Package name="com.streamConverter.examples" />
+        <Package name="com.streamconverter.examples" />
     </Match>
     <Match>
-        <Package name="com.streamConverter.demo" />
+        <Package name="com.streamconverter.demo" />
     </Match>
     
     <!-- Exclude test utility classes that may have intentional patterns -->

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -347,7 +347,7 @@ class CsvWalkerTest {
     ByteArrayInputStream inputStream =
         new ByteArrayInputStream(csvInput.getBytes(StandardCharsets.UTF_8));
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-  
+
     IOException thrown =
         assertThrows(
             IOException.class,
@@ -356,6 +356,7 @@ class CsvWalkerTest {
     assertNotNull(thrown.getCause());
     assertInstanceOf(RuntimeException.class, thrown.getCause());
   }
+
   @DisplayName("Bug証明 #726: 存在しない列を指定したとき IllegalArgumentException が IOException にラップされずに伝播する")
   void bug_csvWalker_unknownColumnThrowsIllegalArgumentException() throws IOException {
     String csvInput = "name,age\nAlice,30\n";


### PR DESCRIPTION
## Summary

Maven Central 公開前の「片付け」として、コードと乖離していたドキュメントおよびメタファイルを修正します。

- `spotbugs-exclude.xml`: パッケージ名の大文字小文字ミスを修正（`com.streamConverter` → `com.streamconverter`）。これにより examples/demo パッケージの SpotBugs 除外が正しく機能するようになります。
- `docs/ARCHITECTURE.md`: 削除済み・リネーム済みのクラス名を全修正（20+ 箇所）
  - `*NavigateCommand` → `*Walker`
  - `JsonFilterCommand` / `XmlFilterCommand` → `JsonExtractCommand` / `XmlExtractCommand`
  - `JsonValidateCommand`・`SampleStreamCommand` の記述を削除
  - `new XPath(...)` / `new JSONPath(...)` → `TreePath.fromXml(...)` / `TreePath.fromJson(...)`
  - `new CSVPath(...)` → `CSVPath.of(...)`
  - `List<CommandResult> run(...)` → `void run(...)`
  - `new StreamConverter(array)` → `StreamConverter.create(...)`
- `docs/reference/CLAUDE_ARCHITECTURE.md`: コマンド一覧を最新化し、リネーム履歴を追記
- `README.md`: クイックスタート例とコマンド一覧テーブルを最新化

## 対象外（別途対応）

GitHub Actions ワークフローファイル（`reviewdog.yml` の Java 17→21、`commit-rules.yml` の master ブランチ削除）は PAT の `workflow` スコープが必要なため、このPRには含まれていません。別途 Slack 経由で依頼します。

## Test plan

- [ ] `./gradlew build` が通ること（CI で確認）
- [ ] ドキュメント内のクラス名が実際に存在するクラスと一致していること
