### PR TITLE
chore: known-bug ワークフローの整備

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "env": {
+    "ENABLE_CODE_SECURITY_REVIEW": "0",
+    "ENABLE_COMMIT_REVIEW": "0",
+    "ENABLE_STOP_REVIEW": "0"
+  },
   "permissions": {
     "allow": [
       "Bash(./gradlew:*)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,11 @@ Always start with the **[Documentation Index](docs/INDEX.md)** for comprehensive
 - Module-specific test execution patterns
 - Security vulnerability management with explicit version overrides
 
+### バグ証明ワークフロー
+- バグ修正: `/fix-known-bug` スキル必須
+- バグ起票: `/detect-and-report-bug` スキル必須
+- verifyKnownBugs BUILD FAILED がバグ修正の客観的証明
+
 ### Security Focus
 - Proactive security vulnerability patching with explicit dependency versions
 - XML External Entity (XXE) prevention in XML processing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,24 @@ This repository includes configuration files for AI coding assistants. The follo
 
 Personal customizations (e.g., additional agents or commands for your own workflow) should be placed in `.claude/settings.local.json`, which is excluded from git via `.gitignore`.
 
+## Bug Reporting and Proof Workflow
+
+Bugs must be proven before a fix is attempted. The workflow is:
+
+1. **Open an issue** when you suspect a bug — suspicion alone is enough to open one.
+2. **Write a failing test** tagged `@Tag("known-bug") // #<issue number>` that reproduces the bug.
+3. **Submit a proof PR** (`test: add known-bug proof test for #<issue number>`) with the test still failing. This PR is the objective record that the bug exists.
+4. **Fix the bug** in a separate PR. The fix is proven when `./gradlew :<module>:verifyKnownBugs` returns `BUILD FAILED` (meaning the known-bug test now passes).
+5. **Remove the `@Tag("known-bug")` line** (one line only) after confirming the above.
+
+If the bug cannot be reproduced, comment the investigation result on the issue and leave it open.
+
+### `@Tag("known-bug")` and `verifyKnownBugs`
+
+- Tests tagged `@Tag("known-bug")` are **excluded from the normal build** (`./gradlew build`). They do not break CI while the bug is unfixed.
+- `./gradlew :<module>:verifyKnownBugs` checks that all known-bug tests **still fail**. `BUILD SUCCESSFUL` means the bug still exists. `BUILD FAILED` means a known-bug test passed — i.e., the bug has been fixed.
+- The comment `// #<issue number>` on the tag line is the link back to the issue. It disappears with the tag when the bug is fixed; use `git log` for historical traceability.
+
 ## Pull Request Process
 
 1. Ensure your code follows the style guidelines of this project

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ Bugs must be proven before a fix is attempted. The workflow is:
 
 If the bug cannot be reproduced, comment the investigation result on the issue and leave it open.
 
-> **For Claude Code users:** The skills `detect-and-report-bug` and `fix-known-bug` automate this workflow. Ask your AI assistant to create them based on the workflow description above.
+> **For Claude Code users:** The skills `detect-and-report-bug` and `fix-known-bug` automate this workflow. They are not part of this repository; create them as local Claude Code skills based on the workflow above.
 
 ### `@Tag("known-bug")` and `verifyKnownBugs`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,8 @@ Bugs must be proven before a fix is attempted. The workflow is:
 
 If the bug cannot be reproduced, comment the investigation result on the issue and leave it open.
 
+> **For Claude Code users:** The skills `detect-and-report-bug` and `fix-known-bug` automate this workflow. See `~/.claude/skills/` or ask your AI assistant to create them from the workflow description above.
+
 ### `@Tag("known-bug")` and `verifyKnownBugs`
 
 - Tests tagged `@Tag("known-bug")` are **excluded from the normal build** (`./gradlew build`). They do not break CI while the bug is unfixed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ Bugs must be proven before a fix is attempted. The workflow is:
 
 If the bug cannot be reproduced, comment the investigation result on the issue and leave it open.
 
-> **For Claude Code users:** The skills `detect-and-report-bug` and `fix-known-bug` automate this workflow. See `~/.claude/skills/` or ask your AI assistant to create them from the workflow description above.
+> **For Claude Code users:** The skills `detect-and-report-bug` and `fix-known-bug` automate this workflow. Ask your AI assistant to create them based on the workflow description above.
 
 ### `@Tag("known-bug")` and `verifyKnownBugs`
 

--- a/docs/reference/TESTING.md
+++ b/docs/reference/TESTING.md
@@ -73,6 +73,27 @@ StreamConverterプロジェクトでは、以下の包括的なテストアプ�
   - `streamconverter-core/src/test/java/com/streamconverter/command/contract/CommandImplementationDiscovery.java`
   - `streamconverter-core/src/test/java/com/streamconverter/command/contract/StreamingExpectation.java`
 
+#### 7. **既知バグ証明テスト (Known-Bug Proof Tests)**
+
+バグの存在を機械的に証明・継続確認するためのテスト群。
+
+- `@Tag("known-bug") // #<issue番号>` を付与する
+- 通常ビルド（`./gradlew build`）では除外され、CIを壊さない
+- `verifyKnownBugs` タスクで全件が「まだ失敗する（バグが残っている）」ことを確認できる
+
+**`verifyKnownBugs` の読み方:**
+
+| 結果 | 意味 |
+|------|------|
+| `BUILD SUCCESSFUL` | 全 known-bug テストが FAIL = バグがまだ存在する |
+| `BUILD FAILED` | いずれかの known-bug テストが PASS = **バグが修正された証明** |
+
+```bash
+./gradlew :<module>:verifyKnownBugs
+```
+
+バグ報告・修正の全手順は [CONTRIBUTING.md の Bug Reporting and Proof Workflow](../../CONTRIBUTING.md#bug-reporting-and-proof-workflow) を参照。
+
 ## 📁 テスト構造
 
 ### ディレクトリ構成

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -467,9 +467,9 @@ public class CsvValidateCommandTest {
   }
 
   @Test
-  @Tag("known-bug")
+  @Tag("known-bug") // #731
   @DisplayName(
-      "Bug証明 #731: CsvValidateCommand が CSV バリデーション失敗時に StreamProcessingException（RuntimeException）を IStreamCommand.execute() 契約に違反してスローする")
+      "CsvValidateCommand は CSV バリデーション失敗時に IOException をスローする（StreamProcessingException を外に出さない）")
   void bug_csvValidateCommand_validationFailureThrowsStreamProcessingExceptionNotIOException()
       throws IOException {
     CsvValidateCommand command = CsvValidateCommand.create("id", "name");

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -470,8 +470,7 @@ public class CsvValidateCommandTest {
   @Tag("known-bug") // #731
   @DisplayName(
       "CsvValidateCommand は CSV バリデーション失敗時に IOException をスローする（StreamProcessingException を外に出さない）")
-  void bug_csvValidateCommand_validationFailureThrowsStreamProcessingExceptionNotIOException()
-      throws IOException {
+  void bug_csvValidateCommand_validationFailureThrowsIOException() throws IOException {
     CsvValidateCommand command = CsvValidateCommand.create("id", "name");
     String csvInput = "id,age\n1,30\n";
 

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -359,7 +359,7 @@ class CsvWalkerTest {
     assertTrue(result.contains("Suite 4"), "Comma-separated part of address should be preserved");
   }
 
-  @DisplayName("Bug証明 #726: 存在しない列を指定したとき IllegalArgumentException が IOException にラップされずに伝播する")
+  @DisplayName("存在しない列を指定したとき IllegalArgumentException が IOException にラップされる")
   void bug_csvWalker_unknownColumnThrowsIllegalArgumentException() throws IOException {
     String csvInput = "name,age\nAlice,30\n";
     CsvWalker csvWalker = CsvWalker.create(CSVPath.of("nonexistent"), new PassThroughRule());

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for CsvWalker. */
@@ -359,8 +360,10 @@ class CsvWalkerTest {
     assertTrue(result.contains("Suite 4"), "Comma-separated part of address should be preserved");
   }
 
+  @Test
+  @Tag("known-bug") // #726
   @DisplayName("存在しない列を指定したとき IllegalArgumentException が IOException にラップされる")
-  void bug_csvWalker_unknownColumnThrowsIllegalArgumentException() throws IOException {
+  void bug_csvWalker_unknownColumnThrowsIOException() throws IOException {
     String csvInput = "name,age\nAlice,30\n";
     CsvWalker csvWalker = CsvWalker.create(CSVPath.of("nonexistent"), new PassThroughRule());
     ByteArrayInputStream input =

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ValidateTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ValidateTest.java
@@ -166,9 +166,9 @@ class ValidateTest {
   }
 
   @Test
-  @Tag("known-bug")
+  @Tag("known-bug") // #729
   @DisplayName(
-      "Bug証明 #729: ValidateCommand が XMLバリデーション失敗時に StreamProcessingException（RuntimeException）を IStreamCommand.execute() 契約に違反してスローする")
+      "ValidateCommand は XMLバリデーション失敗時に IOException をスローする（StreamProcessingException を外に出さない）")
   void bug_validateCommand_xmlValidationFailureThrowsStreamProcessingExceptionNotIOException()
       throws IOException {
     ValidateCommand command = ValidateCommand.create(schemaPath);

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ValidateTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/ValidateTest.java
@@ -169,8 +169,7 @@ class ValidateTest {
   @Tag("known-bug") // #729
   @DisplayName(
       "ValidateCommand は XMLバリデーション失敗時に IOException をスローする（StreamProcessingException を外に出さない）")
-  void bug_validateCommand_xmlValidationFailureThrowsStreamProcessingExceptionNotIOException()
-      throws IOException {
+  void bug_validateCommand_xmlValidationFailureThrowsIOException() throws IOException {
     ValidateCommand command = ValidateCommand.create(schemaPath);
 
     try (InputStream inputStream =


### PR DESCRIPTION
## Summary

- `@Tag("known-bug")` ワークフローの運用ルールを整備し、人間・AI 双方が参照できるドキュメントを追加
- 既存 known-bug テストの `@DisplayName` を「修正後の正しい動作を表す名前」に変更し、`@Tag` 行に issue 番号コメント `// #XXX` を付与
- スキル（`detect-and-report-bug` / `fix-known-bug`）はこの PR に含まれない（スキルは `~/.claude/skills/` に存在し git 管理外）

## 変更内容

### ドキュメント
- **CLAUDE.md**: `### バグ証明ワークフロー` セクションを追加（Claude 向けスキル参照指示）
- **CONTRIBUTING.md**: `Bug Reporting and Proof Workflow` セクションを追加。起票→証明PR→修正PRの2PR体制、`verifyKnownBugs` の読み方を記載
- **docs/reference/TESTING.md**: `既知バグ証明テスト` をテスト戦略の一種として追加

### テストコード
- `ValidateTest.java`: `@Tag("known-bug") // #729`、`@DisplayName` を修正後の動作を表す名前に変更
- `CsvValidateCommandTest.java`: `@Tag("known-bug") // #731`、`@DisplayName` を同様に変更
- `CsvWalkerTest.java`: `@Test` + `@Tag("known-bug") // #726` を追加、メソッド名を期待挙動ベースに修正

### 設定
- **.claude/settings.json**: `env` ブロックに `ENABLE_CODE_SECURITY_REVIEW`・`ENABLE_COMMIT_REVIEW`・`ENABLE_STOP_REVIEW` を `"0"` で追加
  - **経緯**: security-guidance プラグインの Stop/PreToolUse フックが意図せず Anthropic API への呼び出しを発生させるバグがあり、その暫定対応として無効化している。セキュリティレビュー機能を意図的に無効化したいわけではなく、バグ解消まで維持する設定。

## Test plan

- [ ] `./gradlew :streamconverter-core:verifyKnownBugs` が `BUILD SUCCESSFUL` になること（#726・#729・#731 のバグがまだ存在する）
- [ ] `./gradlew build` が全件パスすること（known-bug テストが除外される）
