### PR TITLE
test: add known-bug proof test (#754) - DatabaseConnectionPool active connection counter leak

### DIFF
--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
@@ -1,0 +1,58 @@
+package com.streamconverter.command.rule;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * DatabaseConnectionPoolのテストクラス
+ *
+ * <p>データベース接続はモック化されています。
+ */
+class DatabaseConnectionPoolTest {
+
+  @Test
+  @Tag("known-bug") // #754
+  @org.junit.jupiter.api.DisplayName("プール内の接続が無効化された後でも新しい接続を取得できる")
+  void getConnection_createsNewConnectionAfterPooledConnectionBecomesInvalid() throws SQLException {
+    Connection mockConnection1 = mock(Connection.class);
+    Connection mockConnection2 = mock(Connection.class);
+
+    // 1本目は最初は有効だが、プールに返却された後にDB切断などで無効になる
+    when(mockConnection1.isValid(1)).thenReturn(true, false);
+    when(mockConnection1.isClosed()).thenReturn(false);
+    Mockito.doNothing().when(mockConnection1).close();
+
+    when(mockConnection2.isValid(1)).thenReturn(true);
+    when(mockConnection2.isClosed()).thenReturn(false);
+
+    try (MockedStatic<DriverManager> mockedDriverManager =
+        Mockito.mockStatic(DriverManager.class)) {
+      mockedDriverManager
+          .when(() -> DriverManager.getConnection(anyString()))
+          .thenReturn(mockConnection1, mockConnection2);
+
+      DatabaseConnectionPool pool = new DatabaseConnectionPool("jdbc:mock:db", 1, 200);
+
+      // 1回目: 新規接続(mockConnection1)を取得して返却 -> プールに格納される
+      Connection c1 = pool.getConnection();
+      c1.close();
+
+      // この時点でmockConnection1はプール内に存在するが、isValid()がfalseを返すようになる
+      // (DB切断などを想定)。プールに空きがあるため、新規接続(mockConnection2)が
+      // 作成されて返却されるべき。
+      Connection c2 =
+          assertDoesNotThrow(pool::getConnection, "プール内の接続が無効化された後でも、プールには空きがあるため新規接続が作成されるべき");
+      c2.close();
+    }
+  }
+}


### PR DESCRIPTION
## 概要

#754 で報告した `DatabaseConnectionPool#getConnection()` の `activeConnections` カウンタリークについて、
`@Tag("known-bug")` 付きの証明テストを追加します。

## バグの内容

`getConnection()` には、プールから取り出した接続が無効だった場合に `close()` してカウンタを調整するパスが2箇所あります。

- 86〜93行目（即時取得した接続が無効だった場合）: `connection.close()` のみで `activeConnections.decrementAndGet()` を呼んでいない
- 122行目（タイムアウト待機後に取得した接続が無効だった場合）: `connection.close()` 後に `activeConnections.decrementAndGet()` を呼んでいる

この非対称性により、前者のパスを通るたびに `activeConnections` が実態より1多い状態になり、
`maxPoolSize` 回繰り返されると `activeConnections.get() < maxPoolSize` が恒久的に `false` となって
新規接続が一切作成されなくなります（プールの実質的な機能停止）。

## 証明方法

方法A（失敗するテストを書いて実行する）を使用しました。

`maxPoolSize=1` のプールで、接続を取得・返却した後にその接続が `isValid()` で無効と判定されるようにし、
再度 `getConnection()` を呼んだ際に新規接続が作成されることを期待するテストを追加しました。

現行実装では `activeConnections` が減算されないため `SQLException("Failed to get connection within timeout")` が
スローされ、テストは失敗します。

### Codex承認

テスト妥当性についてCodexにレビューを依頼し、承認を得ています。

> 承認: バグの存在を証明できている
>
> プロダクションコードの問題箇所は DatabaseConnectionPool.java の86〜93行目です。プールから poll() した接続が
> 無効だった場合、close() だけで activeConnections を減らしていません。一方、待機後に取得した無効接続では
> 122行目で減算しています。疑いの内容と一致しています。
> （中略）
> 実行結果も整合しています。verifyKnownBugs は当該テスト1件が失敗して BUILD SUCCESSFUL、通常の test は
> known-bug除外により No tests found でした。

## 確認結果

### 通常テスト（known-bug除外、全件パス）

```
Test summary: SUCCESS (36 total, 36 passed, 0 failed, 0 skipped)
```

### verifyKnownBugs（バグの存在を証明）

```
DatabaseConnectionPoolTest > プール内の接続が無効化された後でも新しい接続を取得できる FAILED
    org.opentest4j.AssertionFailedError at DatabaseConnectionPoolTest.java:54
        Caused by: java.sql.SQLException at DatabaseConnectionPoolTest.java:54
Known-bug verification (streamconverter-db): 1 test(s), 1 failed, 0 passed, 0 skipped
verifyKnownBugs (streamconverter-db): OK — all 1 known-bug test(s) are still failing as expected.

BUILD SUCCESSFUL in 3s
```

## 関連issue

- #754

修正PRでこの `DatabaseConnectionPoolTest` がパスし、`@Tag("known-bug")` を除去できることがバグ修正の証明になります。

## Test plan

- [x] `./gradlew :streamconverter-db:test` で通常テスト全件パス（known-bug除外）
- [x] `./gradlew :streamconverter-db:verifyKnownBugs` で BUILD SUCCESSFUL かつ known-bug テストが失敗することを確認
- [x] Codexによるテスト妥当性レビュー承認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
