### PR TITLE
test: add known-bug proof test for #758

### DIFF
--- a/streamconverter-core/src/test/java/com/streamconverter/command/rule/impl/casing/SnakeToCamelCaseRuleTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/rule/impl/casing/SnakeToCamelCaseRuleTest.java
@@ -1,0 +1,74 @@
+package com.streamconverter.command.rule.impl.casing;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/** Tests for SnakeToCamelCaseRule transformation logic. */
+class SnakeToCamelCaseRuleTest {
+
+  @Test
+  void testDefaultConfiguration() {
+    SnakeToCamelCaseRule rule = SnakeToCamelCaseRule.create();
+
+    assertEquals("userName", rule.apply("user_name"));
+    assertEquals("firstName", rule.apply("first_name"));
+    assertEquals("xmlHttpRequest", rule.apply("xml_http_request"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "user_name, userName",
+    "first_name, firstName",
+    "user_account_id, userAccountId",
+    "xml_http_request, xmlHttpRequest",
+    "id, id",
+    "a, a",
+    "some_very_long_variable_name, someVeryLongVariableName"
+  })
+  void testBasicConversions(String input, String expected) {
+    SnakeToCamelCaseRule rule = SnakeToCamelCaseRule.create();
+    assertEquals(expected, rule.apply(input));
+  }
+
+  @Test
+  void testNullAndEmptyInputs() {
+    SnakeToCamelCaseRule rule = SnakeToCamelCaseRule.create();
+
+    assertNull(rule.apply(null));
+    assertEquals("", rule.apply(""));
+  }
+
+  @Test
+  void testPascalCase() {
+    SnakeToCamelCaseRule rule = SnakeToCamelCaseRule.createPascalCase();
+
+    assertEquals("UserName", rule.apply("user_name"));
+  }
+
+  @Test
+  @Tag("known-bug") // #758
+  @DisplayName("Preserve leading underscore when preserveUnderscores is enabled")
+  void testPreserveLeadingUnderscore() {
+    // Arrange - preserveUnderscores=true は先頭・末尾のアンダースコアを保持する設定
+    SnakeToCamelCaseRule rule = SnakeToCamelCaseRule.builder().preserveUnderscores(true).build();
+
+    // Act & Assert - 先頭アンダースコアは保持されたまま camelCase 変換されるべき
+    assertEquals("_userName", rule.apply("_user_name"));
+  }
+
+  @Test
+  @Tag("known-bug") // #758
+  @DisplayName("Preserve both leading and trailing underscores when preserveUnderscores is enabled")
+  void testPreserveLeadingAndTrailingUnderscores() {
+    // Arrange
+    SnakeToCamelCaseRule rule = SnakeToCamelCaseRule.builder().preserveUnderscores(true).build();
+
+    // Act & Assert - 末尾は現実装でも保持されるが、先頭が変換で消費される
+    assertEquals("_userName_", rule.apply("_user_name_"));
+  }
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/command/rule/impl/casing/SnakeToCamelCaseRuleTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/rule/impl/casing/SnakeToCamelCaseRuleTest.java
@@ -68,7 +68,7 @@ class SnakeToCamelCaseRuleTest {
     // Arrange
     SnakeToCamelCaseRule rule = SnakeToCamelCaseRule.builder().preserveUnderscores(true).build();
 
-    // Act & Assert - 末尾は現実装でも保持されるが、先頭が変換で消費される
+    // Act & Assert - 先頭・末尾の両方が保持されたまま camelCase 変換されるべき
     assertEquals("_userName_", rule.apply("_user_name_"));
   }
 }


### PR DESCRIPTION
## 概要

#758 のバグ証明テストを追加する。

`SnakeToCamelCaseRule` が `preserveUnderscores=true` で構成されていても、`convertSnakeToCamel()` が先頭のアンダースコア+小文字ペアを無条件に大文字化変換するため、保持されるべき先頭アンダースコアが失われるバグの存在を、`@Tag("known-bug")` 付きテストで記録する。

関連 issue: #758

## 証明方法

方法 A（失敗するテストを書いて実行）。テスト妥当性は **Codex レビュー承認済み**（「承認: バグの存在を証明できている」）。

新規テストクラス `SnakeToCamelCaseRuleTest` を追加（既存の `CamelToSnakeCaseRuleTest` と対になる通常テスト8件 + known-bug 2件）:

- `testPreserveLeadingUnderscore` — `_user_name` → `_userName` を期待
- `testPreserveLeadingAndTrailingUnderscores` — `_user_name_` → `_userName_` を期待

## 失敗ログ（バグの証拠）

```
SnakeToCamelCaseRuleTest > Preserve leading underscore when preserveUnderscores is enabled FAILED
    org.opentest4j.AssertionFailedError: expected: <_userName> but was: <userName>

SnakeToCamelCaseRuleTest > Preserve both leading and trailing underscores when preserveUnderscores is enabled FAILED
    org.opentest4j.AssertionFailedError: expected: <_userName_> but was: <userName_>
```

末尾のアンダースコアは保持され、先頭のみ失われる非対称な挙動。対になる `CamelToSnakeCaseRule` は既存テストで `_userName_` → `_user_name_` と正しく保持しており、ラウンドトリップ整合性も崩れている。

## 確認方法

- 通常テスト（known-bug 除外）: `./gradlew :streamconverter-core:test` → 458件全パス
- バグ存在確認: `./gradlew :streamconverter-core:verifyKnownBugs` → `verifyKnownBugs: OK — all 2 known-bug test(s) are still failing as expected.`

## 修正PRへの引き継ぎ

修正 PR でこのテストがパスするようになると `verifyKnownBugs` が BUILD FAILED となり、それがバグ修正の客観的証明になる。修正時は `@Tag("known-bug")` を除去すること（`/fix-known-bug` スキルのフローに従う）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
