### PR TITLE
test: add known-bug proof test for #760

### DIFF
--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonExtractCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonExtractCommandTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 class JsonExtractCommandTest {
@@ -196,6 +197,36 @@ class JsonExtractCommandTest {
     JsonExtractCommand cmd = JsonExtractCommand.create(TreePath.fromJson("$.tags"));
     String result = execute(cmd, json);
     assertEquals("{\"tags\":[[\"java\",\"json\"]]}", result);
+  }
+
+  // ---- 数値リテラルの保全（#760）----
+
+  @Test
+  @Tag("known-bug") // #760
+  @DisplayName("long 範囲を超える整数値も例外なくそのまま抽出される")
+  void testExtractIntegerBeyondLongRange() throws IOException {
+    // Arrange - Long.MAX_VALUE + 1 は有効な JSON 数値（RFC 8259 は大きさを制限しない）
+    String json = "{\"value\":9223372036854775808}";
+    JsonExtractCommand cmd = JsonExtractCommand.create(TreePath.fromJson("$.value"));
+
+    // Act & Assert - 値はそのまま抽出されるべき（現状は InputCoercionException がスローされる）
+    String result = execute(cmd, json);
+    assertEquals("{\"value\":[9223372036854775808]}", result);
+  }
+
+  @Test
+  @Tag("known-bug") // #760
+  @DisplayName("double で表現できない高精度の小数も丸めずにそのまま抽出される")
+  void testExtractHighPrecisionDecimal() throws IOException {
+    // Arrange - double に丸めると末尾の精度が失われる小数
+    String json = "{\"value\":0.12345678901234567890123456789}";
+    JsonExtractCommand cmd = JsonExtractCommand.create(TreePath.fromJson("$.value"));
+
+    // Act
+    String result = execute(cmd, json);
+
+    // Assert - 「変換は行わない」契約どおり数値リテラルが変化しないこと
+    assertEquals("{\"value\":[0.12345678901234567890123456789]}", result);
   }
 
   // ---- TreePath ワイルドカードセグメント解析 ----

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonExtractCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonExtractCommandTest.java
@@ -209,7 +209,7 @@ class JsonExtractCommandTest {
     String json = "{\"value\":9223372036854775808}";
     JsonExtractCommand cmd = JsonExtractCommand.create(TreePath.fromJson("$.value"));
 
-    // Act & Assert - 値はそのまま抽出されるべき（現状は InputCoercionException がスローされる）
+    // Act & Assert - 値は例外なくそのまま抽出されるべき
     String result = execute(cmd, json);
     assertEquals("{\"value\":[9223372036854775808]}", result);
   }


### PR DESCRIPTION
## 概要

#760 のバグ証明テストを追加する。

`JsonExtractCommand` が内部で使用する `JsonValueCopier.copyValue()` が数値コピーを `getLongValue()` / `getDoubleValue()` の固定幅プリミティブ変換で行うため、long 範囲超の整数（有効な JSON）で `InputCoercionException` がスローされ、高精度小数が double に丸められて出力されるバグの存在を、`@Tag("known-bug")` 付きテストで記録する。

関連 issue: #760

## 証明方法

方法 A（失敗するテストを書いて実行）。テスト妥当性は **Codex レビュー承認済み**（「承認: バグの存在を証明できている」— スタックトレースが `JsonValueCopier.copyValue(JsonValueCopier.java:34)` 起点であることまで確認済み）。

追加テスト（`JsonExtractCommandTest`）:

- `testExtractIntegerBeyondLongRange` — `{"value":9223372036854775808}`（Long.MAX_VALUE+1）から `$.value` を抽出
- `testExtractHighPrecisionDecimal` — `{"value":0.12345678901234567890123456789}` から `$.value` を抽出

## 失敗ログ（バグの証拠）

```
JsonExtractCommandTest > long 範囲を超える整数値も例外なくそのまま抽出される FAILED
    com.fasterxml.jackson.core.exc.InputCoercionException:
    Numeric value (9223372036854775808) out of range of long (-9223372036854775808 - 9223372036854775807)

JsonExtractCommandTest > double で表現できない高精度の小数も丸めずにそのまま抽出される FAILED
    org.opentest4j.AssertionFailedError:
    expected: <{"value":[0.12345678901234567890123456789]}> but was: <{"value":[0.12345678901234568]}>
```

クラス Javadoc の契約「指定パスにマッチした JSON 値を抽出して出力する。変換は行わない。」に違反する。なお `JsonWalker` は `copyCurrentEvent()` を使用しており同じ問題はない。

## 確認方法

- 通常テスト（known-bug 除外）: `./gradlew :streamconverter-core:test` → 448件全パス
- バグ存在確認: `./gradlew :streamconverter-core:verifyKnownBugs` → `verifyKnownBugs: OK — all 2 known-bug test(s) are still failing as expected.`

## 修正PRへの引き継ぎ

修正 PR でこのテストがパスするようになると `verifyKnownBugs` が BUILD FAILED となり、それがバグ修正の客観的証明になる。修正時は `@Tag("known-bug")` を除去すること（`/fix-known-bug` スキルのフローに従う）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
