### PR TITLE
test: add known-bug proof test for #762

### DIFF
--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/XmlWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/XmlWalkerTest.java
@@ -21,6 +21,7 @@ import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLStreamException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for XmlWalker. */
@@ -110,6 +111,33 @@ class XmlWalkerTest {
     assertTrue(result.contains("<item>ORIGINAL</item>"), "Should apply rule to matched element");
     assertTrue(
         result.contains("<other>unchanged</other>"), "Should not transform non-matched elements");
+  }
+
+  @Test
+  @Tag("known-bug") // #762
+  @DisplayName("Rule is applied to the whole text content even when split by a CDATA boundary")
+  void testRuleAppliedToWholeTextAcrossCdataBoundary() throws IOException {
+    // Arrange - <item> のテキストコンテンツは "userName"（CDATA 境界で2つの
+    // Characters イベントに分割されて届く）
+    String xmlInput =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root><item>user<![CDATA[Name]]></item></root>";
+    XmlWalker snakeCaseCommand =
+        XmlWalker.create(
+            TreePath.fromXml("root/item"),
+            com.streamconverter.command.rule.impl.casing.CamelToSnakeCaseRule.create());
+
+    InputStream inputStream = new ByteArrayInputStream(xmlInput.getBytes(StandardCharsets.UTF_8));
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    // Act
+    snakeCaseCommand.execute(inputStream, outputStream);
+
+    // Assert - テキストコンテンツ全体 "userName" への変換結果 "user_name" が出力されるべき。
+    // 断片ごとに適用されると "user" + "name" = "username" になり語境界が失われる
+    String result = outputStream.toString(StandardCharsets.UTF_8);
+    assertTrue(
+        result.contains("<item>user_name</item>"),
+        "Rule should be applied to the whole text content of the node, but got: " + result);
   }
 
   @Test


### PR DESCRIPTION
## 概要

#762 のバグ証明テストを追加する。

`XmlWalker` が、CDATA 境界等で複数の Characters イベントに分割されたテキストに対して、変換ルールをテキストコンテンツ全体ではなく断片ごとに適用するバグの存在を、`@Tag("known-bug")` 付きテストで記録する。XMLInputFactory に `IS_COALESCING` が設定されていない（StAX デフォルト false）ことと、イベント単位の `rule.apply()` 呼び出しの組み合わせに起因する。

関連 issue: #762

## 証明方法

方法 A（失敗するテストを書いて実行）。テスト妥当性は **Codex レビュー承認済み**（「承認: バグの存在を証明できている」）。

追加テスト（`XmlWalkerTest`）:

- `testRuleAppliedToWholeTextAcrossCdataBoundary` — `<root><item>user<![CDATA[Name]]></item></root>` に `CamelToSnakeCaseRule` を適用

## 失敗ログ（バグの証拠）

```
XmlWalkerTest > Rule is applied to the whole text content even when split by a CDATA boundary FAILED
    org.opentest4j.AssertionFailedError:
    Rule should be applied to the whole text content of the node,
    but got: <?xml version="1.0" encoding="UTF-8"?><root><item>username</item></root>
```

テキストコンテンツ全体 `userName` への変換結果は `user_name` だが、断片 `user` と `Name` への独立変換（`user` → `user`、`Name` → `name`）により `username` が出力され、camelCase の語境界情報が失われている。Javadoc の契約「applies IRule transformations to the text content of matching nodes」に違反する。

## 確認方法

- 通常テスト（known-bug 除外）: `./gradlew :streamconverter-core:test` → 448件全パス
- バグ存在確認: `./gradlew :streamconverter-core:verifyKnownBugs` → `verifyKnownBugs: OK — all 1 known-bug test(s) are still failing as expected.`

## 修正PRへの引き継ぎ

修正 PR でこのテストがパスするようになると `verifyKnownBugs` が BUILD FAILED となり、それがバグ修正の客観的証明になる。修正時は `@Tag("known-bug")` を除去すること（`/fix-known-bug` スキルのフローに従う）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
