### PR TITLE
test: add known-bug proof test for #764

### DIFF
--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseFetchRuleIntegrationTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseFetchRuleIntegrationTest.java
@@ -10,6 +10,7 @@ import java.sql.Statement;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -217,6 +218,28 @@ public class DatabaseFetchRuleIntegrationTest {
     assertTrue(
         duration < 5000,
         "100 queries should complete within 5 seconds, but took: " + duration + "ms");
+  }
+
+  @Test
+  @Tag("known-bug") // #764
+  @DisplayName("プレースホルダー付きクエリに空文字列を入力した場合は例外を出さず空文字列を返す")
+  public void testEmptyInputWithPlaceholderQueryReturnsEmptyString() {
+    DatabaseFetchRule rule = new DatabaseFetchRule(dbUrl, "SELECT name FROM users WHERE id = ?");
+
+    // プレースホルダーをバインドできない空入力ではクエリを実行せず空文字列を返すこと
+    // （PooledDatabaseFetchRule の bindParameters と同じ動作）
+    assertEquals("", rule.apply(""));
+  }
+
+  @Test
+  @Tag("known-bug") // #764
+  @DisplayName("プレースホルダー付きクエリにnullを入力した場合は例外を出さず空文字列を返す")
+  public void testNullInputWithPlaceholderQueryReturnsEmptyString() {
+    DatabaseFetchRule rule = new DatabaseFetchRule(dbUrl, "SELECT name FROM users WHERE id = ?");
+
+    // プレースホルダーをバインドできない null 入力ではクエリを実行せず空文字列を返すこと
+    // （PooledDatabaseFetchRule の bindParameters と同じ動作）
+    assertEquals("", rule.apply(null));
   }
 
   @Test


### PR DESCRIPTION
## 概要

`DatabaseFetchRule.apply()`（`DatabaseFetchRule.java:142-145`）は、プレースホルダー（`?`）付きクエリで入力が空文字列または null の場合に `setString` をスキップしたまま `executeQuery()` を実行するため、プレースホルダー未設定の SQLException が発生し `StreamProcessingException` をスローする。

- issue: #764
- 兄弟クラスとの非対称性: `PooledDatabaseFetchRule.bindParameters()`（`PooledDatabaseFetchRule.java:136-149`）は同条件を「Rejecting to prevent unbound parameter」と明示して拒否し、クエリを実行せず `""` を返す。期待動作は「空/null 入力ではクエリを実行せず `""` を返す」である。

## 証明方法

方法A: 失敗するテスト（Codex によるテスト妥当性レビュー承認済み）

追加テスト2件（いずれも `@Tag("known-bug") // #764` 付き）:

- `testEmptyInputWithPlaceholderQueryReturnsEmptyString`
- `testNullInputWithPlaceholderQueryReturnsEmptyString`

## 失敗ログ

```
DatabaseFetchRuleIntegrationTest > プレースホルダー付きクエリにnullを入力した場合は例外を出さず空文字列を返す FAILED
    com.streamconverter.StreamProcessingException at DatabaseFetchRuleIntegrationTest.java:242
        Caused by: org.h2.jdbc.JdbcSQLDataException at DatabaseFetchRuleIntegrationTest.java:242

DatabaseFetchRuleIntegrationTest > プレースホルダー付きクエリに空文字列を入力した場合は例外を出さず空文字列を返す FAILED
    com.streamconverter.StreamProcessingException at DatabaseFetchRuleIntegrationTest.java:231
        Caused by: org.h2.jdbc.JdbcSQLDataException at DatabaseFetchRuleIntegrationTest.java:231
```

```
com.streamconverter.StreamProcessingException: データベースフェッチに失敗しました: Parameter "#1" is not set; SQL statement:
SELECT name FROM users WHERE id = ? [90012-240]
```

## 確認方法

- 通常テスト全パス: `bash ~/dev/tools/reviewed/gradle-test-terse.sh streamconverter-db --tail 30 --rerun`
  - `Test summary: SUCCESS (36 total, 36 passed, 0 failed, 0 skipped)`（known-bug テストは除外）
- known-bug テストの失敗確認: `./gradlew :streamconverter-db:verifyKnownBugs --rerun-tasks`
  - `Known-bug verification (streamconverter-db): 2 test(s), 2 failed, 0 passed, 0 skipped`
  - `verifyKnownBugs (streamconverter-db): OK — all 2 known-bug test(s) are still failing as expected.`

## 修正PRへの引き継ぎ

修正 PR でこのテストがパスするようになると `verifyKnownBugs` が BUILD FAILED となり、バグ修正の客観的証明になる。修正時は `@Tag("known-bug")` を除去すること。`/fix-known-bug` スキルのフローに従う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
