### PR TITLE
test: add known-bug proof test for #766

### DIFF
--- a/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandTest.java
+++ b/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandTest.java
@@ -6,10 +6,14 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 /** SendHttpCommandの包括的なテスト */
 class SendHttpCommandTest {
@@ -103,6 +107,48 @@ class SendHttpCommandTest {
     System.out.println("📥 レスポンス長: " + response.length() + " bytes");
     System.out.println(
         "📋 レスポンス例: " + response.substring(0, Math.min(200, response.length())) + "...");
+  }
+
+  @Test
+  @Tag("known-bug") // #766
+  @DisplayName("リクエスト失敗時の例外メッセージにクエリ文字列の資格情報を含めない")
+  void testExceptionMessageDoesNotLeakCredentialsOnRequestFailure() {
+    // 資格情報（api_key）をクエリ文字列に含むURL
+    String urlWithCredentials = "https://api.example.com/data?api_key=secret123";
+
+    // パブリックIPを返すモックリゾルバ（SSRF検証をパスさせる）
+    InetAddressResolver publicIpResolver =
+        host -> new InetAddress[] {InetAddress.getByName("93.184.216.34")};
+
+    // ネットワークを使わずにリクエストを失敗させる ExchangeFunction スタブ
+    WebClient failingWebClient =
+        WebClient.builder()
+            .exchangeFunction(request -> Mono.error(new RuntimeException("connection refused")))
+            .build();
+
+    SendHttpCommand command =
+        new SendHttpCommand(urlWithCredentials, failingWebClient, publicIpResolver);
+
+    ByteArrayInputStream inputStream =
+        new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8));
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> command.execute(inputStream, outputStream),
+            "リクエスト失敗時はIOExceptionをスローするべき");
+
+    // 期待動作: 例外メッセージには sanitizeUrl() 適用後のURLのみが含まれ、
+    // クエリ文字列の資格情報は漏洩しない
+    assertFalse(
+        thrown.getMessage().contains("api_key=secret123"),
+        "例外メッセージにクエリ文字列の資格情報（api_key=secret123）を含めるべきではない: " + thrown.getMessage());
+
+    // URL自体への言及（サニタイズ済み）は維持される
+    assertTrue(
+        thrown.getMessage().contains("https://api.example.com"),
+        "例外メッセージにはサニタイズ済みURLへの言及が含まれるべき: " + thrown.getMessage());
   }
 
   @Test


### PR DESCRIPTION
## 概要

`com.streamconverter.command.impl.SendHttpCommand`（streamconverter-http モジュール）の `execute()` 最終 catch ブロック（SendHttpCommand.java:287-291）が、**生の URL**（クエリ文字列・資格情報を含む）を `logger.error` と IOException メッセージに連結するバグの証明テストを追加する。

- 対象 issue: #766
- `sanitizeUrl()`（SendHttpCommand.java:302-316）の Javadoc には「URLのクエリ文字列とユーザー情報を除去してログ・例外メッセージへの資格情報漏洩を防ぐ」と明記されている
- `onStatus`（同:250）と `doOnNext`（同:267）のエラーメッセージには `sanitizeUrl(url)` が適用されているが、最終 catch ブロックだけは生の `url` を連結しており非対称
- `https://api.example.com/data?api_key=secret123` のような URL でリクエストが失敗すると資格情報が漏洩する

## 証明方法

方法A: 失敗するテスト（`@Tag("known-bug") // #766` 付き、Codex によるテスト妥当性レビュー承認済み）

- 追加テスト: `SendHttpCommandTest#testExceptionMessageDoesNotLeakCredentialsOnRequestFailure`
- パブリック IP（93.184.216.34）を返すモック `InetAddressResolver` で SSRF 再検証をパスさせ、`WebClient.builder().exchangeFunction(request -> Mono.error(new RuntimeException("connection refused")))` の ExchangeFunction スタブでリクエストを失敗させるため、**ネットワーク接続は不要**
- `assertFalse(thrown.getMessage().contains("api_key=secret123"))` で期待動作（資格情報を含めない）を検証

## 失敗ログ

```
SendHttpCommandTest > リクエスト失敗時の例外メッセージにクエリ文字列の資格情報を含めない FAILED
    org.opentest4j.AssertionFailedError at SendHttpCommandTest.java:144
Known-bug verification (streamconverter-http): 1 test(s), 1 failed, 0 passed, 0 skipped
verifyKnownBugs (streamconverter-http): OK — all 1 known-bug test(s) are still failing as expected.
```

```
org.opentest4j.AssertionFailedError: 例外メッセージにクエリ文字列の資格情報（api_key=secret123）を含めるべきではない: HTTP request failed: https://api.example.com/data?api_key=secret123 - connection refused ==> expected: <false> but was: <true>
```

## 確認方法

- 通常テスト全パス: `bash gradle-test-terse.sh streamconverter-http` → `Test summary: SUCCESS (28 total, 20 passed, 0 failed, 8 skipped)`（skipped はネットワーク依存テスト。known-bug タグ付きテストは通常 test タスクから除外される）
- バグ証明: `./gradlew :streamconverter-http:verifyKnownBugs --rerun-tasks` → `verifyKnownBugs (streamconverter-http): OK — all 1 known-bug test(s) are still failing as expected.`

## 修正PRへの引き継ぎ

- 修正 PR でバグが直るとこのテストがパスし、`verifyKnownBugs` が BUILD FAILED となる。これがバグ修正の客観的証明になる
- 修正時は `@Tag("known-bug") // #766` を除去して通常テスト化すること
- `/fix-known-bug` スキルのフロー（plan-review → 実装 → verifyKnownBugs FAILED 確認 → タグ除去 → 通常テスト全件パス → PR作成）に従うこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)
