### PR TITLE
test: add known-bug proof test for #768

### DIFF
--- a/streamconverter-core/src/test/java/com/streamconverter/security/SecureXPathValidatorTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/security/SecureXPathValidatorTest.java
@@ -3,6 +3,7 @@ package com.streamconverter.security;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -179,6 +180,22 @@ class SecureXPathValidatorTest {
         SecurityException.class,
         () -> SecureXPathValidator.validateXPath(deepNestedXPath.toString()),
         "深いネストを持つXPath式が受け入れられました");
+  }
+
+  @Test
+  @Tag("known-bug") // #768
+  @DisplayName("要素名に and/or/not を部分文字列として含む正当なパス式は検証を通過する")
+  void testElementNamesContainingOperatorSubstringsAreAccepted() {
+    // 演算子 and/or/not をトークンとして一切含まない単純な要素パス。
+    // 要素名の一部（brand/colors/notes、operand/sponsor/notation）に
+    // 演算子と同じ文字列が含まれるだけであり、検証を通過することが期待される。
+    String[] legitimatePaths = {"brand/colors/notes", "operand/sponsor/notation"};
+
+    for (String xpath : legitimatePaths) {
+      assertDoesNotThrow(
+          () -> SecureXPathValidator.validateXPath(xpath), "正当なパス式でエラーが発生しました: " + xpath);
+      assertTrue(SecureXPathValidator.isXPathSafe(xpath), "正当なパス式が安全でないと判定されました: " + xpath);
+    }
   }
 
   @Test


### PR DESCRIPTION
## 概要

公開 API `com.streamconverter.security.SecureXPathValidator`（streamconverter-core）の `checkOperators()`（`SecureXPathValidator.java:238-244`）が、XPath 演算子 `and` / `or` / `not` の検出を `String.contains()` の部分文字列一致で行っているため、演算子を一切含まない正当なパス式（例: `brand/colors/notes`、`operand/sponsor/notation`）が SecurityException「Complex operator combinations not allowed in strict mode」で誤って拒否される false positive のバグ証明 PR です。

- issue: #768
- `checkOperators()` は `validateStrictMode()` 経由で `validateXPath()` から無条件に呼ばれるため、ライブラリ利用者に回避手段がない公開 API の false positive です。

## 証明方法

方法A: 失敗するテストによる証明（Codex によるテスト妥当性レビュー承認済み）。

追加テスト: `SecureXPathValidatorTest#testElementNamesContainingOperatorSubstringsAreAccepted`（`@Tag("known-bug") // #768` 付き）

- `assertDoesNotThrow(() -> SecureXPathValidator.validateXPath(...))` と `assertTrue(SecureXPathValidator.isXPathSafe(...))` で、修正後の期待動作（演算子を含まない正当なパス式は検証を通過する）を表現。
- 検証対象パスは他の検証ルール（インジェクション・危険関数・外部参照・SQLライク・長さ・ネスト・ワイルドカード）に該当しないことを確認済みで、失敗は `checkOperators()` のみに起因します。

## 失敗ログ

```
SecureXPathValidatorTest > 要素名に and/or/not を部分文字列として含む正当なパス式は検証を通過する FAILED
    org.opentest4j.AssertionFailedError at SecureXPathValidatorTest.java:195
        Caused by: java.lang.SecurityException at SecureXPathValidatorTest.java:196
Known-bug verification (streamconverter-core): 1 test(s), 1 failed, 0 passed, 0 skipped
verifyKnownBugs (streamconverter-core): OK — all 1 known-bug test(s) are still failing as expected.
```

test-results XML の失敗メッセージ:

```
org.opentest4j.AssertionFailedError: 正当なパス式でエラーが発生しました: brand/colors/notes ==> Unexpected exception thrown: java.lang.SecurityException: Complex operator combinations not allowed in strict mode
```

## 確認方法

- 通常テスト: `bash gradle-test-terse.sh streamconverter-core` で 448 件全件パス（known-bug テストは通常の test タスクから除外）。

```
Test summary: SUCCESS (448 total, 448 passed, 0 failed, 0 skipped)
```

- known-bug 検証: `./gradlew :streamconverter-core:verifyKnownBugs --rerun-tasks` で「verifyKnownBugs (streamconverter-core): OK — all 1 known-bug test(s) are still failing as expected.」を確認。

## 修正PRへの引き継ぎ

- 修正 PR でバグが修正されるとこのテストがパスし、`verifyKnownBugs` が BUILD FAILED となることがバグ修正の客観的証明になります。
- 修正時は `@Tag("known-bug") // #768` を除去して通常テスト化してください。
- 修正作業は `/fix-known-bug` スキルのフロー（plan-review → 実装 → verifyKnownBugs FAILED 確認 → タグ除去 → 通常テスト全件パス → PR作成）に従ってください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
