### PR TITLE
fix: normalize consecutive CR line endings in LineEndingNormalizeCommand (closes #756)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/LineEndingNormalizeCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/LineEndingNormalizeCommand.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.PushbackReader;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -104,11 +105,12 @@ public class LineEndingNormalizeCommand implements IStreamCommand {
   private static void normalize(Reader reader, Writer writer, String targetSeparator)
       throws IOException {
     // Process character by character for line ending normalization
+    PushbackReader pushbackReader = new PushbackReader(reader);
     int current;
     // Read one code unit at a time so CR, LF, and CRLF can be normalized consistently.
-    while ((current = reader.read()) != -1) {
+    while ((current = pushbackReader.read()) != -1) {
       if (current == '\r') {
-        handleCarriageReturn(reader, writer, targetSeparator);
+        handleCarriageReturn(pushbackReader, writer, targetSeparator);
         continue;
       }
       if (current == '\n') {
@@ -119,20 +121,16 @@ public class LineEndingNormalizeCommand implements IStreamCommand {
     }
   }
 
-  private static void handleCarriageReturn(Reader reader, Writer writer, String targetSeparator)
-      throws IOException {
+  private static void handleCarriageReturn(
+      PushbackReader reader, Writer writer, String targetSeparator) throws IOException {
     // Handle CR - could be CR, CRLF, or standalone CR
     int next = reader.read();
-    if (next == '\n') {
-      // CRLF -> convert to target
-      writer.write(targetSeparator);
-      return;
-    }
-    // Standalone CR -> convert to target
     writer.write(targetSeparator);
-    // Write the next character that wasn't part of line ending
-    if (next != -1) {
-      writer.write(next);
+    if (next != -1 && next != '\n') {
+      // The look-ahead character was not part of the line ending. Push it back so the
+      // main loop processes it; this keeps consecutive CRs (e.g. \r\r) handled as
+      // separate line endings instead of being written through as raw characters.
+      reader.unread(next);
     }
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/LineEndingNormalizeCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/LineEndingNormalizeCommandTest.java
@@ -10,7 +10,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("LineEndingNormalizeCommand Tests")
@@ -301,7 +300,6 @@ class LineEndingNormalizeCommandTest {
   }
 
   @Test
-  @Tag("known-bug") // #756
   @DisplayName("Convert consecutive CR line endings (classic Mac empty line) to Unix")
   void testConsecutiveCarriageReturnsToUnix() throws IOException {
     // Given - classic Mac text with an empty line (CR CR)
@@ -318,7 +316,6 @@ class LineEndingNormalizeCommandTest {
   }
 
   @Test
-  @Tag("known-bug") // #756
   @DisplayName("Convert consecutive CR line endings (classic Mac empty line) to Windows")
   void testConsecutiveCarriageReturnsToWindows() throws IOException {
     // Given - classic Mac text with an empty line (CR CR)


### PR DESCRIPTION
## 概要

`LineEndingNormalizeCommand` が連続する CR（`\r\r`、旧Mac形式の空行）の2つ目を行末として変換せず、生の `\r` のまま出力するバグを修正する。

原因は `handleCarriageReturn()` が CR の次の1文字を先読みし、`\n` 以外を通常文字として `writer.write(next)` で素通ししていたこと。先読みした文字が `\r` の場合も行末として再処理されなかった。

修正では `normalize()` の Reader を `PushbackReader` でラップし、先読み文字が CRLF の一部（`\n`）でない場合は `unread()` でメインループに戻すようにした。これにより `\r\r`・`\r\r\n`・末尾 CR 連続のいずれも各 CR が正しく行末記号に変換される（再帰不要、helper が次文字を書き出す責務を持たない）。

Closes #756

## 修正前の動作

known-bug テスト2件（`testConsecutiveCarriageReturnsToUnix` / `testConsecutiveCarriageReturnsToWindows`）が以下を証明していた:

- 入力 `"line1\r\rline2"` を UNIX に正規化すると、期待 `line1\n\nline2` に対し実際は `line1\n\rline2`（2つ目の CR が生のまま残る）
- WINDOWS への正規化でも同様に2つ目の CR が CRLF に変換されない

事前確認（修正ブランチ作成直後）:

```
./gradlew :streamconverter-core:verifyKnownBugs --rerun-tasks
Known-bug verification (streamconverter-core): 2 test(s), 2 failed, 0 passed, 0 skipped
verifyKnownBugs (streamconverter-core): OK — all 2 known-bug test(s) are still failing as expected.
BUILD SUCCESSFUL
```

## 修正後の確認

実装後の `verifyKnownBugs` は **BUILD FAILED**（known-bug テスト2件がパスに転換 = バグ修正の客観的証明）:

```
> Task :streamconverter-core:verifyKnownBugs FAILED
Known-bug verification (streamconverter-core): 2 test(s), 0 failed, 2 passed, 0 skipped
Test summary: SUCCESS (2 total, 2 passed, 0 failed, 0 skipped)

* What went wrong:
Execution failed for task ':streamconverter-core:verifyKnownBugs'.
> verifyKnownBugs (streamconverter-core): expected all known-bug tests to fail, but got 0 failed, 2 passed, 0 skipped out of 2. If a bug was fixed, remove the @Tag("known-bug") annotation and close the related issue.

BUILD FAILED in 4s
```

その後 `@Tag("known-bug") // #756` を2件除去してテストを通常テストに昇格（未使用になった `import org.junit.jupiter.api.Tag` は spotless が自動除去）:

- `LineEndingNormalizeCommandTest`: 18/18 パス（昇格した2件を含む）
- streamconverter-core 全件: 450/450 パス（リグレッションなし）

## ベースブランチについて

証明 PR #757（`test/known-bug-756-line-ending-normalize`）が未マージのため、本 PR の base は `test/known-bug-756-line-ending-normalize` とする stacked PR 方式。#757 がマージされると GitHub が base を `develop` に自動付け替えする。

## レビュー

- **plan-review（Codex, 実装前）**: 当初の再帰案に対し「方向性は正しいが再帰より `PushbackReader` で先読み文字をメインループに戻す方式が堅い」との改善提案を受け、採用した。
- **code-review（Codex, コミット後）**: 「指摘事項なし。実装は妥当で、既存不具合は素直に解消できている。テストも回帰防止として十分」。軽微な任意提案として「末尾が `\r\r` で終わる EOF ケースのテスト追加で網羅性が上がる（現行ロジックでも問題なく通るはずで必須ではない）」あり。本 PR では known-bug テストの昇格のみとし追加していない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
