### PR TITLE
fix: preserve leading underscores in SnakeToCamelCaseRule (closes #758)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/casing/SnakeToCamelCaseRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/casing/SnakeToCamelCaseRule.java
@@ -55,9 +55,24 @@ public class SnakeToCamelCaseRule implements IRule {
       return input;
     }
     String result = normalizeUnderscores(input);
+    String leadingUnderscores = "";
+    String trailingUnderscores = "";
+    if (preserveUnderscores) {
+      int start = 0;
+      while (start < result.length() && result.charAt(start) == '_') {
+        start++;
+      }
+      int end = result.length();
+      while (end > start && result.charAt(end - 1) == '_') {
+        end--;
+      }
+      leadingUnderscores = result.substring(0, start);
+      trailingUnderscores = result.substring(end);
+      result = result.substring(start, end);
+    }
     result = convertSnakeToCamel(result);
     result = trimUnderscores(result);
-    return adjustFirstLetterCase(result);
+    return leadingUnderscores + adjustFirstLetterCase(result) + trailingUnderscores;
   }
 
   private String normalizeUnderscores(String value) {

--- a/streamconverter-core/src/test/java/com/streamconverter/command/rule/impl/casing/SnakeToCamelCaseRuleTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/rule/impl/casing/SnakeToCamelCaseRuleTest.java
@@ -3,7 +3,6 @@ package com.streamconverter.command.rule.impl.casing;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -51,7 +50,6 @@ class SnakeToCamelCaseRuleTest {
   }
 
   @Test
-  @Tag("known-bug") // #758
   @DisplayName("Preserve leading underscore when preserveUnderscores is enabled")
   void testPreserveLeadingUnderscore() {
     // Arrange - preserveUnderscores=true は先頭・末尾のアンダースコアを保持する設定
@@ -62,7 +60,6 @@ class SnakeToCamelCaseRuleTest {
   }
 
   @Test
-  @Tag("known-bug") // #758
   @DisplayName("Preserve both leading and trailing underscores when preserveUnderscores is enabled")
   void testPreserveLeadingAndTrailingUnderscores() {
     // Arrange


### PR DESCRIPTION
## 概要

`SnakeToCamelCaseRule` が `preserveUnderscores=true` でも先頭のアンダースコアを除去するバグを修正する。

原因は `convertSnakeToCamel()` の正規表現 `_([a-z])` が設定に関係なく先頭の `_u` ペアを消費していたこと（末尾アンダースコアは後続小文字がないため保持される非対称動作だった）。

修正アプローチ: `apply()` で `preserveUnderscores=true` の場合、先頭・末尾の連続アンダースコアを変換前に切り出し、本体のみに `convertSnakeToCamel()` / `adjustFirstLetterCase()` を適用してから再付与する。境界アンダースコアを変換ロジックから完全に隔離することで、`capitalizeFirst=true`（PascalCase）との組み合わせや全部アンダースコア入力（`"___"`）でも整合する。`preserveUnderscores=false` 時は新しい分岐に入らないため既存挙動は不変。

Closes #758

## 修正前の動作

known-bug テスト2件（PR #759 で追加）が以下の失敗で証明:

- `testPreserveLeadingUnderscore`: `rule.apply("_user_name")` → expected `<_userName>` but was `<userName>`
- `testPreserveLeadingAndTrailingUnderscores`: `rule.apply("_user_name_")` → expected `<_userName_>` but was `<userName_>`

修正着手前の `./gradlew :streamconverter-core:verifyKnownBugs --rerun-tasks` は BUILD SUCCESSFUL（`2 test(s), 2 failed ... failing as expected`）。

## 修正後の確認

実装後・タグ除去前の `verifyKnownBugs` が **BUILD FAILED**（known-bug テスト2件がパスに転換 = バグ修正の客観的証明）:

```
> Task :streamconverter-core:verifyKnownBugs FAILED
Known-bug verification (streamconverter-core): 2 test(s), 0 failed, 2 passed, 0 skipped
Test summary: SUCCESS (2 total, 2 passed, 0 failed, 0 skipped)

* What went wrong:
Execution failed for task ':streamconverter-core:verifyKnownBugs'.
> verifyKnownBugs (streamconverter-core): expected all known-bug tests to fail, but got 0 failed, 2 passed, 0 skipped out of 2. If a bug was fixed, remove the @Tag("known-bug") annotation and close the related issue.

BUILD FAILED in 4s
```

その後 `@Tag("known-bug") // #758` の2行を除去（テスト本体・`@DisplayName` は不変更、未使用 import は spotless が自動除去）:

- `SnakeToCamelCaseRuleTest` 単体: 12件全パス
- `streamconverter-core` モジュール全件: 460件全パス（リグレッションなし）

## ベースブランチについて

証明 PR #759 が未マージのため、base は `test/known-bug-758-snake-to-camel-preserve-underscores`（stacked PR）。#759 が develop にマージされたら base は develop へ自動付け替えされる。

## レビュー

- **plan-review（Codex）**: 方針承認。「先頭のみ退避」案に対し「先頭・末尾の両方を切り出して core のみ変換する方が、境界文字を変換ロジックから隔離でき設計として堅い」との改善案があり採用。`CamelToSnakeCaseRule`（preserveUnderscores=true で boundary cleanup をスキップする実装）との整合性も確認済み。
- **code-review（Codex）**: ブロッカーなし。`preserveUnderscores=false` 側の既存挙動不変・余計な変更なし・既存設計パターンとの整合を確認。jshell でエッジケース（`"___"` → `"___"`、`"_user_name"` + PascalCase → `"_UserName"`、`"__user__name__"` + preserve=false → `"userName"`）の動作も検証済み。
- **非ブロッキング指摘（フォローアップ候補）**: エッジケースの自動テスト追加（`preserveUnderscores=true` で `"___"`、`"__user_name"`、`capitalizeFirst=true` との組み合わせ）。本 PR は known-bug 修正証明を明確にするため diff を最小限に保っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
