### PR TITLE
fix: preserve numeric literals in JsonValueCopier (closes #760)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonValueCopier.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonValueCopier.java
@@ -31,8 +31,9 @@ final class JsonValueCopier {
       case START_OBJECT -> copyObject(parser, generator);
       case START_ARRAY -> copyArray(parser, generator);
       case VALUE_STRING -> generator.writeString(parser.getText());
-      case VALUE_NUMBER_INT -> generator.writeNumber(parser.getLongValue());
-      case VALUE_NUMBER_FLOAT -> generator.writeNumber(parser.getDoubleValue());
+      // Write the original numeric literal verbatim to avoid overflow on integers
+      // beyond long range and precision loss on decimals beyond double precision (#760).
+      case VALUE_NUMBER_INT, VALUE_NUMBER_FLOAT -> generator.writeNumber(parser.getText());
       case VALUE_TRUE -> generator.writeBoolean(true);
       case VALUE_FALSE -> generator.writeBoolean(false);
       default -> generator.writeNull();

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonExtractCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonExtractCommandTest.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 class JsonExtractCommandTest {
@@ -202,7 +201,6 @@ class JsonExtractCommandTest {
   // ---- 数値リテラルの保全（#760）----
 
   @Test
-  @Tag("known-bug") // #760
   @DisplayName("long 範囲を超える整数値も例外なくそのまま抽出される")
   void testExtractIntegerBeyondLongRange() throws IOException {
     // Arrange - Long.MAX_VALUE + 1 は有効な JSON 数値（RFC 8259 は大きさを制限しない）
@@ -215,7 +213,6 @@ class JsonExtractCommandTest {
   }
 
   @Test
-  @Tag("known-bug") // #760
   @DisplayName("double で表現できない高精度の小数も丸めずにそのまま抽出される")
   void testExtractHighPrecisionDecimal() throws IOException {
     // Arrange - double に丸めると末尾の精度が失われる小数


### PR DESCRIPTION
## 概要

`JsonValueCopier.copyValue()` は数値コピーを固定幅プリミティブ変換（`getLongValue()` / `getDoubleValue()`）で行っていたため、JsonExtractCommand が以下の不具合を起こしていました。

- long 範囲を超える整数（有効な JSON 数値）で `InputCoercionException` をスロー
- double 精度を超える小数を丸めた値で出力

本 PR では `VALUE_NUMBER_INT` / `VALUE_NUMBER_FLOAT` の両ケースを `generator.writeNumber(parser.getText())` に変更し、入力の数値リテラルをそのまま（字句保持で）出力します。入力は Jackson パーサが妥当な JSON 数値として検証済みのため安全です。

Closes #760

## 修正前の動作

known-bug テスト（PR #761 で追加、`@Tag("known-bug") // #760`）が証明した内容:

- `{"value":9223372036854775808}` の `$.value` 抽出 → `com.fasterxml.jackson.core.exc.InputCoercionException` がスロー
- `{"value":0.12345678901234567890123456789}` の `$.value` 抽出 → `0.12345678901234568` に丸められて出力

## 修正後の確認

`./gradlew :streamconverter-core:verifyKnownBugs --rerun-tasks` が **BUILD FAILED**（known-bug テスト2件がパスに転換 = 修正の客観的証明）:

```
> Task :streamconverter-core:verifyKnownBugs FAILED
Known-bug verification (streamconverter-core): 2 test(s), 0 failed, 2 passed, 0 skipped
Test summary: SUCCESS (2 total, 2 passed, 0 failed, 0 skipped)

* What went wrong:
Execution failed for task ':streamconverter-core:verifyKnownBugs'.
> verifyKnownBugs (streamconverter-core): expected all known-bug tests to fail, but got 0 failed, 2 passed, 0 skipped out of 2. If a bug was fixed, remove the @Tag("known-bug") annotation and close the related issue.

BUILD FAILED in 4s
```

確認後に `@Tag("known-bug") // #760` を2件除去してテストを通常テストに昇格（未使用となった `Tag` import は spotless が除去）。

- `JsonExtractCommandTest`: 19/19 パス
- streamconverter-core 全件: 450/450 パス

## ベースブランチについて

証明 PR #761 が未マージのため、base は `test/known-bug-760-json-extract-number-corruption` です（stacked PR）。#761 マージ後に base は `develop` へ自動付け替えされます。

## レビュー

- **plan-review（Codex）**: 当初案の `getBigIntegerValue()` / `getDecimalValue()` は値の精度は保持するが、`1e2` → `1E+2` や `-0` の符号落ち等の正規化が起き「リテラル不変」を満たさないと指摘。`copyCurrentEventExact()`（Jackson 2.15+）も整数を int/long/BigInteger に寄せるため字句保持にならない。JsonExtractCommand は抽出コマンド（「変換は行わない」契約）であるため `writeNumber(parser.getText())` による字句保持案を推奨 → 採用。
- **code-review（Codex）**: 重大な問題なし。「変換は行わない」契約と整合し、正当性・セキュリティ上の懸念なしと評価。テストも 19/19 パスを独立に再確認。軽微提案として `$` ルート抽出での巨大整数/高精度小数や指数表記（`1e1000` 等）の回帰テスト追加が挙げられた（本 PR では未対応、必要なら後続で追加）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
