### PR TITLE
fix: apply rules to whole text content in XmlWalker (closes #762)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlWalker.java
@@ -136,6 +136,11 @@ public class XmlWalker implements IStreamCommand {
 
   private XMLEventReader createXMLEventReader(InputStream inputStream) throws XMLStreamException {
     XMLInputFactory inputFactory = SecureXmlConfiguration.createSecureXMLInputFactory();
+    // テキスト断片化防止のため coalescing を有効化する。CDATA 境界やパーサ内部バッファで
+    // 分割された連続テキストを 1 つの Characters イベントに結合し、ルールがテキスト
+    // コンテンツ全体に適用されることを保証する (#762)。XmlWalker ローカルの設定であり、
+    // SecureXmlConfiguration を共有する他コマンドには影響しない。
+    inputFactory.setProperty(XMLInputFactory.IS_COALESCING, true);
     XMLEventReader reader = inputFactory.createXMLEventReader(inputStream);
     if (!reader.hasNext()) {
       try {

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlWalker.java
@@ -28,8 +28,15 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The full XML event stream — including the XML declaration, all elements, attributes, and text
  * nodes — is written to the output. Only character data at nodes whose path exactly matches the
- * configured {@link TreePath} is transformed by the rule; all other events are passed through
- * unchanged.
+ * configured {@link TreePath} is transformed by the rule; all other events are passed through with
+ * their XML information set (infoset) preserved.
+ *
+ * <p>Note on text handling: the underlying StAX reader is configured with {@code
+ * XMLInputFactory.IS_COALESCING}, so adjacent text fragments and CDATA sections are coalesced into
+ * a single character event before rules are applied. This guarantees that a rule sees the whole
+ * text content of a node even when the parser would otherwise split it (e.g. at CDATA boundaries).
+ * As a consequence, CDATA sections are written to the output as escaped character data — an
+ * infoset-equivalent representation — rather than being preserved verbatim.
  */
 public class XmlWalker implements IStreamCommand {
   private static final Logger logger = LoggerFactory.getLogger(XmlWalker.class);

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/XmlWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/XmlWalkerTest.java
@@ -139,6 +139,30 @@ class XmlWalkerTest {
   }
 
   @Test
+  @DisplayName("CDATA in non-matched nodes is emitted as infoset-equivalent escaped text")
+  void testCdataInNonMatchedNodeEmittedAsEscapedText() throws IOException {
+    // Arrange - coalescing により非対象ノードの CDATA もテキストイベントに正規化されるため、
+    // 字面は <![CDATA[x<y]]> のままではなく infoset 等価なエスケープ済みテキストになる
+    String xmlInput =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<root><item>target</item><other><![CDATA[x<y]]></other></root>";
+    InputStream inputStream = new ByteArrayInputStream(xmlInput.getBytes(StandardCharsets.UTF_8));
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    // Act
+    command.execute(inputStream, outputStream);
+
+    // Assert - CDATA の内容はエスケープ済みテキストとして保存される（infoset 等価）
+    String result = outputStream.toString(StandardCharsets.UTF_8);
+    assertTrue(
+        result.contains("<other>x&lt;y</other>"),
+        "CDATA content should be preserved as infoset-equivalent escaped text, but got: " + result);
+    assertFalse(
+        result.contains("<![CDATA["),
+        "CDATA sections are not preserved verbatim under coalescing, but got: " + result);
+  }
+
+  @Test
   @DisplayName("Complex XML structure is preserved")
   void testComplexXmlProcessing() throws IOException {
     String xmlInput =

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/XmlWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/XmlWalkerTest.java
@@ -21,7 +21,6 @@ import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLStreamException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for XmlWalker. */
@@ -114,7 +113,6 @@ class XmlWalkerTest {
   }
 
   @Test
-  @Tag("known-bug") // #762
   @DisplayName("Rule is applied to the whole text content even when split by a CDATA boundary")
   void testRuleAppliedToWholeTextAcrossCdataBoundary() throws IOException {
     // Arrange - <item> のテキストコンテンツは "userName"（CDATA 境界で2つの


### PR DESCRIPTION
## 概要

XmlWalker が CDATA 境界等で分割されたテキストにルールを断片ごとに適用し誤変換するバグ（#762）を修正します。

- 原因: StAX の `IS_COALESCING` がデフォルト false のため、`user<![CDATA[Name]]>` のようなテキストが複数の Characters イベントとして届き、`XmlWalker.navigateXmlWithRule()` がイベント単位で `rule.apply()` を呼んでいた
- 修正: `XmlWalker.createXMLEventReader()` で `IS_COALESCING=true` をローカルに設定し、連続するテキスト断片・CDATA を 1 つの Characters イベントに結合してからルールを適用する

採用案と理由: plan-review（Codex）の結論に従い、共有設定 `SecureXmlConfiguration` への追加（案A）ではなく **XmlWalker ローカルで coalescing を有効化する案（案C）** を採用しました。`XmlExtractCommand` や tools 側コマンド（`PmdXmlToViolationsCommand` / `JacocoXmlToModuleSlocCommand`）への意味的波及を避けつつ、問題の発生箇所に対してのみ最小限の修正で対処できるためです。

Closes #762

## 修正前の動作

入力 `<root><item>user<![CDATA[Name]]></item></root>` に CamelToSnakeCaseRule を適用すると、テキストが断片 "user" と "Name" に分割されたままルールが個別適用され、`<item>username</item>` に誤変換されていました（期待は `<item>user_name</item>`。語境界が失われる）。

## 修正後の確認

修正実装後、`./gradlew :streamconverter-core:verifyKnownBugs --rerun-tasks` が **BUILD FAILED**（known-bug テスト 1 件がパスに転換 = バグ修正の客観的証明）:

```
> Task :streamconverter-core:verifyKnownBugs FAILED
Known-bug verification (streamconverter-core): 1 test(s), 0 failed, 1 passed, 0 skipped
Test summary: SUCCESS (1 total, 1 passed, 0 failed, 0 skipped)

* What went wrong:
Execution failed for task ':streamconverter-core:verifyKnownBugs'.
> verifyKnownBugs (streamconverter-core): expected all known-bug tests to fail, but got 0 failed, 1 passed, 0 skipped out of 1. If a bug was fixed, remove the @Tag("known-bug") annotation and close the related issue.

BUILD FAILED in 5s
```

- 上記確認後に `@Tag("known-bug")` を除去し、テストを通常テストに昇格（未使用 import は spotlessApply で整理）
- タグ除去後: `XmlWalkerTest` 全件パス（レビュー対応テスト追加後 16 件）
- streamconverter-core モジュール全件パス（最終 450 件、リグレッションなし）

影響評価:
- `ValidateCommand` は `SchemaFactory` 系であり `createSecureXMLInputFactory()` を使用していないため影響なし
- `XmlExtractCommand` および tools 側 2 コマンドは共有設定を変更しない本修正の影響を受けない
- XmlWalker 自身の出力では、非対象ノードの CDATA も infoset 等価なエスケープ済みテキストとして出力される字面変化があるため、クラス Javadoc を infoset 保存ベースの契約に更新し、挙動を固定するテストを追加

## ベースブランチについて

証明 PR #763 が未マージのため、base は `test/known-bug-762-xml-walker-split-text` です（stacked PR）。#763 マージ後に base は develop へ自動付け替えされます。

## レビュー

- plan-review（Codex / gpt-5.4）: 案A（共有設定変更）はバグには効くが修正範囲が広すぎる・セキュリティ設定クラスにパース意味論を載せるのは責務混在、案B（バッファリング）は過剰、と評価。**案C（XmlWalker ローカルで IS_COALESCING 有効化）を推奨**。IS_COALESCING に XXE/DTD 防御を弱める性質はないことも確認。本 PR は案Cで実装
- code-review（Codex / gpt-5.4）: 方針自体は妥当・タグ除去も運用に沿うと評価。Medium 指摘 1 件「クラス Javadoc の "passed through unchanged" が coalescing 後の実態とずれる。infoset 保存ベースの契約に修正し、字面変化を固定するテストを追加すべき」→ 2 コミット目（9eb596c3）で対応済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
