### PR TITLE
fix: reject placeholder query with empty input in DatabaseFetchRule (closes #764)

### DIFF
--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
@@ -132,6 +132,15 @@ public class DatabaseFetchRule implements IRule {
    */
   @Override
   public String apply(String input) {
+    // プレースホルダー付きクエリに空/null 入力が来た場合は DB に接続せず拒否する。
+    // PooledDatabaseFetchRule.bindParameters() と同じ挙動に揃え、未バインドのまま executeQuery が
+    // 走って SQLException("Parameter #1 is not set" 相当) になるのを防ぐ。
+    if (query.contains("?") && (input == null || input.isEmpty())) {
+      logger.warn(
+          "Query has a placeholder but input is null or empty. Rejecting to prevent unbound parameter.");
+      return "";
+    }
+
     try (Connection connection = DriverManager.getConnection(databaseUrl);
         PreparedStatement statement = connection.prepareStatement(query)) {
 

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseFetchRuleIntegrationTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseFetchRuleIntegrationTest.java
@@ -10,7 +10,6 @@ import java.sql.Statement;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -221,7 +220,6 @@ public class DatabaseFetchRuleIntegrationTest {
   }
 
   @Test
-  @Tag("known-bug") // #764
   @DisplayName("プレースホルダー付きクエリに空文字列を入力した場合は例外を出さず空文字列を返す")
   public void testEmptyInputWithPlaceholderQueryReturnsEmptyString() {
     DatabaseFetchRule rule = new DatabaseFetchRule(dbUrl, "SELECT name FROM users WHERE id = ?");
@@ -232,7 +230,6 @@ public class DatabaseFetchRuleIntegrationTest {
   }
 
   @Test
-  @Tag("known-bug") // #764
   @DisplayName("プレースホルダー付きクエリにnullを入力した場合は例外を出さず空文字列を返す")
   public void testNullInputWithPlaceholderQueryReturnsEmptyString() {
     DatabaseFetchRule rule = new DatabaseFetchRule(dbUrl, "SELECT name FROM users WHERE id = ?");


### PR DESCRIPTION
## 概要

`DatabaseFetchRule.apply()` が、プレースホルダー（`?`）付きクエリに対して空文字列または `null` 入力を受け取ったとき、`setString` を呼ばないまま `executeQuery()` を実行していたため、`SQLException("Parameter "#1" is not set" 相当)` が `StreamProcessingException` にラップされてスローされていた。

修正アプローチ: `apply()` の冒頭に早期 `return` を追加し、`query.contains("?") && (input == null || input.isEmpty())` の場合は DB 接続も `PreparedStatement` 作成もせず、警告ログを出して空文字列を返す。`PooledDatabaseFetchRule.bindParameters()` と返り値・ログメッセージ・WARN レベルを揃えて両クラス間の挙動の非対称性を解消した（拒否のタイミングは厳密には異なり、Pooled 版は接続取得後に拒否、本クラスは接続取得前に拒否する）。

Closes #764

## 修正前の動作

プレースホルダー付きクエリ `"SELECT name FROM users WHERE id = ?"` に対して `rule.apply("")` または `rule.apply(null)` を呼ぶと、次の例外がスローされていた。

```
StreamProcessingException: Database fetch failed: Parameter "#1" is not set.
  Caused by: org.h2.jdbc.JdbcSQLDataException
```

## 修正後の確認

### verifyKnownBugs BUILD FAILED（修正の客観的証明）

```
> Task :streamconverter-db:verifyKnownBugs FAILED
Known-bug verification (streamconverter-db): 2 test(s), 0 failed, 2 passed, 0 skipped
Test summary: SUCCESS (2 total, 2 passed, 0 failed, 0 skipped)

* What went wrong:
Execution failed for task ':streamconverter-db:verifyKnownBugs'.
> verifyKnownBugs (streamconverter-db): expected all known-bug tests to fail,
  but got 0 failed, 2 passed, 0 skipped out of 2.
```

known-bug テスト 2 件が PASS に転換 = バグが修正されたことの客観的証明。

### `@Tag("known-bug")` 除去後の通常テスト

- `:streamconverter-db:test --tests "*.DatabaseFetchRuleIntegrationTest"` → **14/14 PASS**
- `:streamconverter-db:test`（モジュール全件） → **38/38 PASS**

リグレッションなし。

## ベースブランチについて

証明 PR #765 が未マージのため、本 PR の base は `test/known-bug-764-database-fetch-rule-empty-input`（証明ブランチ）に設定している。#765 が `develop` にマージされた時点で、GitHub の挙動により本 PR の base は自動的に `develop` へ付け替えられる。

## レビュー

### plan-review（Codex）の要旨

- 早期 `return` を `try` ブロックの中ではなく**前**に置く方が望ましい（無駄な DB 接続を回避できる）→ 採用
- ログレベル WARN は `PooledDatabaseFetchRule` との整合性を考慮すると妥当
- 重複ロジック（`PooledDatabaseFetchRule.bindParameters()`）の共通化はフォローアップ可

### code-review（Codex）の要旨

- Blocking な問題なし
- 軽微: 「`PooledDatabaseFetchRule` と同じ挙動」という表現は厳密には返り値・ログ・レベルのみ一致で、拒否のタイミング（接続取得前 vs 後）は異なる旨を本 PR 説明にも反映した
- 手元での再検証も `14/14 PASS` / `38/38 PASS` を確認済み

## フォローアップ

`DatabaseFetchRule` と `PooledDatabaseFetchRule` のプレースホルダー判定ロジックの重複削除（`SqlQueryUtils` 等への切り出し）は refactor として #690 等のフォローアップで扱う方針とした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
