### PR TITLE
fix: apply sanitizeUrl in SendHttpCommand error path and info log (closes #766)

### DIFF
--- a/streamconverter-http/src/main/java/com/streamconverter/command/impl/SendHttpCommand.java
+++ b/streamconverter-http/src/main/java/com/streamconverter/command/impl/SendHttpCommand.java
@@ -215,7 +215,8 @@ public class SendHttpCommand implements IStreamCommand {
 
     revalidateHostForSsrf();
 
-    logger.info("Sending HTTP POST request to: {}", url);
+    String safeUrl = sanitizeUrl(url);
+    logger.info("Sending HTTP POST request to: {}", safeUrl);
 
     try {
       // Track total bytes written for better error reporting
@@ -285,8 +286,12 @@ public class SendHttpCommand implements IStreamCommand {
       // with CompletableFuture for true async, but would break command interface contract.
 
     } catch (RuntimeException e) {
-      // WebClient error responses are wrapped in RuntimeException
-      String errorMessage = "HTTP request failed: " + url + " - " + e.getMessage();
+      // WebClient error responses are wrapped in RuntimeException.
+      // 例外メッセージには sanitizeUrl 適用後のURLのみを含め、e.getMessage() の連結は避ける。
+      // WebClient の下位例外メッセージに生 URL が含まれるケース（クエリ文字列・資格情報）でも
+      // 公開される IOException メッセージから漏洩しないようにするため。
+      // 原因の詳細は cause として保持し、診断性を維持する。
+      String errorMessage = "HTTP request failed: " + safeUrl;
       logger.error(errorMessage, e);
       throw new IOException(errorMessage, e);
     }

--- a/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandTest.java
+++ b/streamconverter-http/src/test/java/com/streamconverter/command/impl/SendHttpCommandTest.java
@@ -9,7 +9,6 @@ import java.io.InputStream;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -110,7 +109,6 @@ class SendHttpCommandTest {
   }
 
   @Test
-  @Tag("known-bug") // #766
   @DisplayName("リクエスト失敗時の例外メッセージにクエリ文字列の資格情報を含めない")
   void testExceptionMessageDoesNotLeakCredentialsOnRequestFailure() {
     // 資格情報（api_key）をクエリ文字列に含むURL


### PR DESCRIPTION
## 概要

`SendHttpCommand.execute()` の冒頭 info ログと最終 catch ブロックが `sanitizeUrl` 未適用の生 URL を出力していたため、クエリ文字列の資格情報（`api_key=...` 等）がログと `IOException` メッセージに漏洩していた。

`onStatus` / `doOnNext` で既に確立されている `sanitizeUrl` 防御方針との一貫性を取り戻す最小修正に加え、`e.getMessage()` 連結を外して WebClient 下位例外メッセージに生 URL が含まれるケースでも公開メッセージから漏洩しないようにする多層防御を入れた。

Closes #766

## 修正内容

1. `execute()` 冒頭で `String safeUrl = sanitizeUrl(url);` を導入し、info ログでも `safeUrl` を使用
2. 最終 catch ブロックで `IOException` メッセージから `e.getMessage()` の連結を外し、`safeUrl` のみを含める
3. 原因は cause として保持し、診断性を維持

## 修正前の動作

`IOException` メッセージに `api_key=secret123` のような資格情報が含まれ、リクエスト失敗時の例外伝搬・上位ログを通じて漏洩していた。

## 修正後の確認

### 1. verifyKnownBugs BUILD FAILED（バグ修正の証明）

```
> Task :streamconverter-http:verifyKnownBugs FAILED
Known-bug verification (streamconverter-http): 1 test(s), 0 failed, 1 passed, 0 skipped
Test summary: SUCCESS (1 total, 1 passed, 0 failed, 0 skipped)

* What went wrong:
Execution failed for task ':streamconverter-http:verifyKnownBugs'.
> verifyKnownBugs (streamconverter-http): expected all known-bug tests to fail, but got 0 failed, 1 passed, 0 skipped out of 1.

BUILD FAILED in 2s
```

### 2. `@Tag("known-bug")` 除去後の通常テスト全件パス

`streamconverter-http` モジュール全件: `29 total, 21 passed, 0 failed, 8 skipped`（skipped はネットワーク依存テスト）。

## ベースブランチについて

証明 PR #767 が未マージのため、本 PR の base は `test/known-bug-766-send-http-raw-url-leak`（stacked PR 方式）。#767 マージ後に `develop` へ自動付け替えされる。

## レビュー

### plan-review（Codex）の要旨

- `info` ログの `sanitizeUrl` 化は妥当
- catch ブロックでは `e.getMessage()` 連結を外して `IOException` 公開メッセージから下位例外文字列を排除すべき（本 PR で採用）
- 代替案として `safeUrl` を一度作って一貫使用するパターンを提案（本 PR で採用）

### code-review（Codex）の要旨

- 設計判断（`e.getMessage()` 連結を外し公開メッセージはサニタイズ済み URL のみに）は妥当
- 軽微（スコープ外）: `logger.error(errorMessage, e)` で throwable を渡しているため、WebClient/Reactor Netty の下位例外が生 URL を含む場合スタックトレース経由でログに残るリスクがある。上位の共通ラッパー `IStreamCommand.withLogging()` も `logger.error(..., e)` を呼ぶため、根本的な防御は別 issue でのフォローアップとする

## フォローアップ候補

- ログ出力経路（`logger.error(..., e)` のスタックトレースおよび `IStreamCommand.withLogging()`）における下位例外メッセージの URL 漏洩対策（cause のメッセージにも `sanitizeUrl` を適用するヘルパー or throwable をログから外して sanitized サマリーのみ出力する設計の検討）。本 PR とは独立した脅威モデル（運用ログへの漏洩）に対する追加の多層防御として別 issue で対応する

🤖 Generated with [Claude Code](https://claude.com/claude-code)
