### PR TITLE
fix: detect XPath operators only within predicates in SecureXPathValidator (closes #768)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/security/SecureXPathValidator.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/security/SecureXPathValidator.java
@@ -53,6 +53,19 @@ public class SecureXPathValidator {
           ".*(union|select|insert|update|delete|drop|create|alter|exec|execute)\\s+.*",
           Pattern.CASE_INSENSITIVE);
 
+  // 厳格モード用の論理演算子トークン検出パターン
+  // XPath の名前（QName）に許容される文字 [\p{L}\p{N}_:.-] を境界に用いることで、
+  // brand / colors / notes・and-node / pre:or-value / not.item のような
+  // 「演算子の部分文字列を含むだけの正当な名前」を演算子と誤検知しないようにする。
+  // CASE_INSENSITIVE は意図的に付けない（XPath の論理演算子は小文字キーワード固定）。
+  private static final String XPATH_NAME_BOUNDARY = "[\\p{L}\\p{N}_:.\\-]";
+  private static final Pattern OPERATOR_AND_PATTERN =
+      Pattern.compile("(?<!" + XPATH_NAME_BOUNDARY + ")and(?!" + XPATH_NAME_BOUNDARY + ")");
+  private static final Pattern OPERATOR_OR_PATTERN =
+      Pattern.compile("(?<!" + XPATH_NAME_BOUNDARY + ")or(?!" + XPATH_NAME_BOUNDARY + ")");
+  private static final Pattern OPERATOR_NOT_PATTERN =
+      Pattern.compile("(?<!" + XPATH_NAME_BOUNDARY + ")not(?!" + XPATH_NAME_BOUNDARY + ")");
+
   private SecureXPathValidator() {
     // ユーティリティクラスのため、インスタンス化を禁止
   }
@@ -236,11 +249,41 @@ public class SecureXPathValidator {
   }
 
   private static void checkOperators(String xpath) {
-    if (xpath.contains("and") && xpath.contains("or") && xpath.contains("not")) {
+    // 論理演算子 and / or / not は predicate [...] 内でのみ式として意味を持つ。
+    // predicate 外（要素名・属性名・ステップ）に現れる and / or / not は常に Name の一部であり、
+    // 演算子として解釈してはならない（例: /root/and、brand/colors/notes、//a[@x='1']/or/@not）。
+    // したがって predicate 内のテキストだけを対象に独立トークンとして検出することで、
+    // 「より長い Name の部分文字列」と「Name そのものが and/or/not」の両ケースを誤検知から除外する。
+    String inPredicate = extractPredicateText(xpath);
+    if (OPERATOR_AND_PATTERN.matcher(inPredicate).find()
+        && OPERATOR_OR_PATTERN.matcher(inPredicate).find()
+        && OPERATOR_NOT_PATTERN.matcher(inPredicate).find()) {
       securityLogger.warn(
           "Complex operator combination in TreePath in strict mode: {}", sanitizeForLogging(xpath));
       throw new SecurityException("Complex operator combinations not allowed in strict mode");
     }
+  }
+
+  /**
+   * XPath 式中の predicate [...] 内のテキストだけを連結して返す。 ネストした角括弧にも対応する。引用符内の角括弧は構文上不正で本来出現しないため、
+   * 構造解析の単純さを優先して特別扱いしない。
+   */
+  private static String extractPredicateText(String xpath) {
+    StringBuilder predicateText = new StringBuilder();
+    int depth = 0;
+    for (int i = 0; i < xpath.length(); i++) {
+      char c = xpath.charAt(i);
+      if (c == '[') {
+        depth++;
+      } else if (c == ']') {
+        if (depth > 0) {
+          depth--;
+        }
+      } else if (depth > 0) {
+        predicateText.append(c);
+      }
+    }
+    return predicateText.toString();
   }
 
   private static void checkWildcards(String xpath) {

--- a/streamconverter-core/src/test/java/com/streamconverter/security/SecureXPathValidatorTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/security/SecureXPathValidatorTest.java
@@ -3,7 +3,6 @@ package com.streamconverter.security;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -183,7 +182,49 @@ class SecureXPathValidatorTest {
   }
 
   @Test
-  @Tag("known-bug") // #768
+  @DisplayName("厳格モードで and/or/not の複合演算子を含むXPathは拒否される")
+  void testStrictModeRejectsComplexOperatorCombinations() {
+    String complexOperatorXPath = "//a[@x='1' and @y='2' or not(@z)]";
+
+    assertThrows(
+        SecurityException.class,
+        () -> SecureXPathValidator.validateXPath(complexOperatorXPath),
+        "and/or/not の複合演算子を含むXPathが受け入れられました");
+  }
+
+  @Test
+  @DisplayName("QName 風要素名（ハイフン・ドット・コロン）に and/or/not を含むパス式は通過する")
+  void testQNameLikeElementNamesContainingOperatorSubstringsAreAccepted() {
+    // XPath の Name には - . : も含まれるため、これらを境界に持つ要素名が
+    // 単純な \b 境界判定では誤検知される。predicate 外限定の判定であることを検証する。
+    String[] qnameLikePaths = {"and-node/orbit/notation-item", "pre:and/sponsor/not.item"};
+
+    for (String xpath : qnameLikePaths) {
+      assertDoesNotThrow(
+          () -> SecureXPathValidator.validateXPath(xpath), "QName 風の正当なパス式でエラーが発生しました: " + xpath);
+      assertTrue(SecureXPathValidator.isXPathSafe(xpath), "QName 風の正当なパス式が安全でないと判定されました: " + xpath);
+    }
+  }
+
+  @Test
+  @DisplayName("要素名・属性名そのものが and/or/not のパス式は通過する")
+  void testElementOrAttributeNamesEqualToOperatorTokensAreAccepted() {
+    // and / or / not は要素名・属性名として合法に使用できる。
+    // predicate [...] 外に現れる and / or / not は常に Name の一部であり、
+    // 演算子として解釈してはならない。
+    String[] nameAsOperatorPaths = {"/root/and/or/not", "//a/or/@not"};
+
+    for (String xpath : nameAsOperatorPaths) {
+      assertDoesNotThrow(
+          () -> SecureXPathValidator.validateXPath(xpath),
+          "要素名・属性名が and/or/not のパス式でエラーが発生しました: " + xpath);
+      assertTrue(
+          SecureXPathValidator.isXPathSafe(xpath),
+          "要素名・属性名が and/or/not のパス式が安全でないと判定されました: " + xpath);
+    }
+  }
+
+  @Test
   @DisplayName("要素名に and/or/not を部分文字列として含む正当なパス式は検証を通過する")
   void testElementNamesContainingOperatorSubstringsAreAccepted() {
     // 演算子 and/or/not をトークンとして一切含まない単純な要素パス。


### PR DESCRIPTION
## 概要

`SecureXPathValidator.checkOperators()` が `String.contains()` の部分文字列一致で `and`/`or`/`not` を判定していたため、要素名に部分文字列を含むだけの正当なパス式（例: `brand/colors/notes`）が SecurityException で誤って拒否されていたバグを修正する。

修正アプローチは、論理演算子 `and`/`or`/`not` が XPath では **predicate `[...]` 内でのみ式として意味を持つ**性質を利用し、predicate 内のテキストのみを検出対象に絞ることで誤検知を原理的に解消する。

Closes #768

## 修正前の動作

```
SecurityException: Complex operator combinations not allowed in strict mode
```

以下のような正当なパス式が拒否されていた:
- `brand/colors/notes`（要素名に `and`/`or`/`not` を部分文字列として含む）
- `/root/and/or/not`（要素名そのものが `and`/`or`/`not`）
- `//a/or/@not`（属性名そのものが `not`）

## 修正後の確認

### verifyKnownBugs BUILD FAILED（修正の客観的証明）

```
> Task :streamconverter-core:verifyKnownBugs FAILED
Known-bug verification (streamconverter-core): 1 test(s), 0 failed, 1 passed, 0 skipped
Test summary: SUCCESS (1 total, 1 passed, 0 failed, 0 skipped)

* What went wrong:
Execution failed for task ':streamconverter-core:verifyKnownBugs'.
> verifyKnownBugs (streamconverter-core): expected all known-bug tests to fail,
  but got 0 failed, 1 passed, 0 skipped out of 1.

BUILD FAILED
```

### タグ除去後の通常テスト

- `SecureXPathValidatorTest`: 28件全パス（既存25件 + 追加3件）
- `streamconverter-core` モジュール全件: 452件全パス（リグレッションなし）

## ベースブランチについて

証明 PR #769 が未マージのため、本 PR の base は `test/known-bug-768-xpath-validator-operator-false-positive`（証明ブランチ）にしています。#769 が `develop` にマージされると GitHub が自動で base を `develop` に付け替えます（stacked PR 方式）。

## 修正詳細

### 採用案の経緯

1. **当初案**: `\b` ベースの単語境界（plan-review で却下）
2. **plan-review 提案**: XPath の Name 文字集合 `[\p{L}\p{N}_:.-]` を境界に持つ Pattern
3. **code-review 指摘**: 上記でも「Name そのものが `and`/`or`/`not` のケース（`/root/and/or/not`）」は誤検知が残る（blocking）
4. **最終案**: predicate `[...]` 内のテキストのみを判定対象にする方針へ転換
   - XPath 文法上、論理演算子 `and`/`or`/`not` は predicate 内でのみ式として意味を持つ
   - predicate 外（要素名・属性名・ステップ）の `and`/`or`/`not` は常に Name の一部
   - したがって predicate 内のみに判定範囲を絞ることで、誤検知を原理的に解消できる

### 実装

- predicate テキスト抽出用ヘルパー `extractPredicateText()` を追加（`[]` ネスト対応）
- `checkOperators()` は `extractPredicateText()` の結果に対して Pattern の AND 評価を行う

### 回帰防止テスト3件追加

1. `testStrictModeRejectsComplexOperatorCombinations`: 真の複合演算子（`//a[@x='1' and @y='2' or not(@z)]`）は引き続き拒否されること
2. `testQNameLikeElementNamesContainingOperatorSubstringsAreAccepted`: ハイフン・ドット・コロンを含む QName 風要素名（`and-node/orbit/notation-item`、`pre:and/sponsor/not.item`）は通過すること
3. `testElementOrAttributeNamesEqualToOperatorTokensAreAccepted`: 要素名・属性名そのものが `and`/`or`/`not` のパス式（`/root/and/or/not`、`//a/or/@not`）も通過すること（code-review 指摘ケース）

## レビュー

- **plan-review (Codex)**: 初期案 `\b` ベース → XPath Name 文字集合 `[\p{L}\p{N}_:.-]` を境界に用いる方式への改善を提案。採用
- **code-review (Codex)**: 「Name そのものが and/or/not のケースは境界判定では解決しない」という blocking 指摘を受け、predicate 内限定方式へ本質的修正。amend で同一コミットに統合

## フォローアップ候補

- `SQL_LIKE_INJECTION_PATTERN`（`SecureXPathValidator.java:51-54`）にも単語境界なしの類似の弱点がある。本 PR の範囲外として別 PR で対応する

🤖 Generated with [Claude Code](https://claude.com/claude-code)
