### PR TITLE
fix: decrement activeConnections when discarding invalid pooled connection (closes #754)

### DIFF
--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseConnectionPool.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseConnectionPool.java
@@ -90,6 +90,7 @@ public class DatabaseConnectionPool {
       } catch (SQLException e) {
         logger.warn("Failed to close invalid connection: {}", e.getMessage());
       }
+      activeConnections.decrementAndGet();
     }
 
     // 新しい接続を作成（プールサイズ制限内）

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -21,7 +20,6 @@ import org.mockito.Mockito;
 class DatabaseConnectionPoolTest {
 
   @Test
-  @Tag("known-bug") // #754
   @org.junit.jupiter.api.DisplayName("プール内の接続が無効化された後でも新しい接続を取得できる")
   void getConnection_createsNewConnectionAfterPooledConnectionBecomesInvalid() throws SQLException {
     Connection mockConnection1 = mock(Connection.class);


### PR DESCRIPTION
## 概要

#754 で報告された `DatabaseConnectionPool#getConnection()` の `activeConnections` カウンタリークを修正します。

## バグの概要と修正アプローチ

`getConnection()` の即時取得パスで、プールから取り出した接続が無効（`isConnectionValid` が false）と判定されクローズされた際に、`activeConnections.decrementAndGet()` を呼んでいませんでした。このためカウンタが実態より多いまま固定され、`maxPoolSize` 回繰り返されると `activeConnections.get() < maxPoolSize` が恒久的に false となり、新規接続が一切作成されなくなります（プールの実質的な機能停止）。

タイムアウト待機後パスの既存実装（クローズ後にカウンタ減算）と同じ流儀で、無効接続のクローズ後（成否に関わらず）に `activeConnections.decrementAndGet()` を1行追加しました。接続は `connectionPool.poll()` でプール外に出ており、以後プールが管理する対象ではないため、`close()` の成否に関係なく論理カウントを減らすのが正しい挙動です。

## 修正前の動作（known-bug テストが証明したこと）

`maxPoolSize=1` のプールで接続を取得・返却後、プール内接続が無効化された状態で再度 `getConnection()` を呼ぶと、新規接続が作成されず `SQLException("Failed to get connection within timeout")` がスローされていました（証明 PR: #755）。

## 修正後の確認

- `./gradlew :streamconverter-db:verifyKnownBugs` → **BUILD FAILED**（known-bug テストがパスに転換 = バグ修正の客観的証明）
- 上記確認後に `@Tag("known-bug")` の1行を除去し、テストを通常テストに昇格
- `./gradlew :streamconverter-db:test` → 全37件パス（昇格テスト含む）

## レビュー

- plan-review（Codex）: 承認（「修正方針そのものは妥当。#754 を直す最小修正としては十分」）
- code-review（Codex）: 承認（「指摘事項はありません。同じ接続に対して二重減算になる経路もありません」）

## 証明 PR #755 との関係

本ブランチは origin/develop から作成し、証明 PR #755 のテストコミットを cherry-pick した上で修正・タグ除去を行っています。

- **#755 を先にマージする場合（推奨）**: マージ後に本ブランチを `origin/develop` にリベースすると、重複するテストコミットが自動的に落ち、差分が「修正＋タグ除去」のみになります（リベースが必要になったらお知らせください。対応します）
- **本 PR を先にマージする場合**: #755 がコンフリクトするため、#755 側のリベースまたはクローズ判断が必要です

## スコープ外（plan-review で指摘された既存課題）

以下は #754 のスコープ外として本 PR では修正していません（別途 issue 化を検討）。

1. `activeConnections.get() < maxPoolSize` チェックと `incrementAndGet()` が非原子的で、並行アクセス時に `maxPoolSize` を超過しうる
2. タイムアウト待機後パスで無効接続を破棄した後、再試行せずそのまま `SQLException` に落ちる（コメントの「再試行」と実態が不一致）
3. `returnConnection()` では `close()` 成功時のみ減算しており、`close()` 失敗時にカウンタがずれる

## 関連 issue

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)
