### PR TITLE
test: add known-bug proof test for #747

### DIFF
--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -427,8 +427,21 @@ public class CsvValidateCommandTest {
     // 空セルを含むヘッダー行のみ（データ行なし）の入力では、
     // ヘッダー検証エラーと「データ行なし」エラーの2系統の追加経路が同時に発生する。
     // maxErrorsToReport=1 のとき、報告されるエラーは経路によらず1件に制限されるべき。
-    CsvValidateCommand command = CsvValidateCommand.create(true, 1);
     String csv = "id,\n";
+
+    // 前提確認: 上限が十分大きければこの入力は2系統のエラーを2件とも報告する。
+    // ヘッダー検証仕様の変更で前提が崩れた場合、上限迂回の検証が成立しなくなるため
+    // ここで検出する。
+    CsvValidateCommand uncapped = CsvValidateCommand.create(true, 10);
+    ByteArrayInputStream uncappedInput =
+        new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8));
+    StreamProcessingException uncappedException =
+        assertThrows(StreamProcessingException.class, () -> uncapped.consume(uncappedInput));
+    assertTrue(
+        uncappedException.getMessage().contains("2 error(s)"),
+        "前提: この入力は上限が十分大きいとき2件のエラーを報告するはず。実際のメッセージ: " + uncappedException.getMessage());
+
+    CsvValidateCommand command = CsvValidateCommand.create(true, 1);
     ByteArrayInputStream inputStream =
         new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8));
 

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** CsvValidateCommandクラスのテスト */
@@ -417,6 +418,30 @@ public class CsvValidateCommandTest {
     assertFalse(
         msg.contains("3 error(s)"),
         "maxErrorsToReport=2 なのに '3 error(s)' が含まれていた。実際のメッセージ: " + msg);
+  }
+
+  @Test
+  @Tag("known-bug") // #747
+  @DisplayName("ヘッダーのみのCSVでも maxErrorsToReport の上限を超えてエラーが報告されない")
+  void maxErrorsToReport_headerOnlyCsvDoesNotExceedLimit() throws IOException {
+    // 空セルを含むヘッダー行のみ（データ行なし）の入力では、
+    // ヘッダー検証エラーと「データ行なし」エラーの2系統の追加経路が同時に発生する。
+    // maxErrorsToReport=1 のとき、報告されるエラーは経路によらず1件に制限されるべき。
+    CsvValidateCommand command = CsvValidateCommand.create(true, 1);
+    String csv = "id,\n";
+    ByteArrayInputStream inputStream =
+        new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8));
+
+    StreamProcessingException exception =
+        assertThrows(StreamProcessingException.class, () -> command.consume(inputStream));
+
+    String msg = exception.getMessage();
+    assertTrue(
+        msg.contains("1 error(s)"),
+        "maxErrorsToReport=1 なのに '1 error(s)' が含まれていない。実際のメッセージ: " + msg);
+    assertFalse(
+        msg.contains("2 error(s)"),
+        "maxErrorsToReport=1 なのに '2 error(s)' が含まれていた。実際のメッセージ: " + msg);
   }
 
   @Test


### PR DESCRIPTION
## 概要

issue #747（CsvValidateCommand: validateDataRows が maxErrorsToReport の上限を迂回して errors.add() を直接呼んでいる）のバグ存在を証明する known-bug テストを追加します。

Refs #747

## 証明方法

方法 A（失敗するテストを書いて実行）。テスト妥当性は Codex によるレビューで**承認済み**です。

## バグの内容

エラー件数の上限管理は `CsvRowValidator.addError()`（`errors.size() < maxErrorsToReport` のときのみ追加）に集約されていますが、`CsvValidateCommand.validateDataRows()` の「ヘッダーのみ・データ行なし」エラーだけが `errors.add()` を直接呼ぶため、上限到達後でもエラーが追加されます。

```java
if (hasHeader && !hasDataRows) {
    errors.add("CSV file contains only header, no data rows found");  // 上限チェックを迂回
}
```

## 証明テストと失敗ログ

テスト: `CsvValidateCommandTest.maxErrorsToReport_headerOnlyCsvDoesNotExceedLimit`（`@Tag("known-bug") // #747`）

再現条件: `maxErrorsToReport=1`、入力 `"id,\n"`（空セルを含むヘッダー行のみ・データ行なし）

```
org.opentest4j.AssertionFailedError: maxErrorsToReport=1 なのに '1 error(s)' が含まれていない。
実際のメッセージ: CSV validation failed: CSV validation failed with 2 error(s):
  1. Header contains empty or null column
  2. CSV file contains only header, no data rows found
==> expected: <true> but was: <false>
```

## 確認方法

```bash
./gradlew :streamconverter-core:verifyKnownBugs --rerun-tasks --tests "*.CsvValidateCommandTest"
```

`verifyKnownBugs: OK — all 1 known-bug test(s) are still failing as expected.` でバグの存在を継続確認できます。
`@Tag("known-bug")` 付きのため通常 CI（`./gradlew build`）からは除外されます。

## 修正 PR との関係

修正 PR でこのテストが通過する（`verifyKnownBugs` が BUILD FAILED になる）ことがバグ修正の客観的証明になります。修正時は `@Tag("known-bug")` を除去するだけで通常テストに変換できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
