### PR TITLE
test: add known-bug proof test for #748

### DIFF
--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -6,8 +6,10 @@ import com.streamconverter.StreamProcessingException;
 import com.streamconverter.test.StreamingTestUtils.TrackingInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** CsvValidateCommandクラスのテスト */
@@ -479,5 +481,34 @@ public class CsvValidateCommandTest {
         IOException.class,
         () -> command.execute(inputStream, outputStream),
         "CsvValidateCommand.execute() は IOException をスローするべき");
+  }
+
+  @Test
+  @Tag("known-bug") // #748
+  @DisplayName("入力ストリームの I/O 障害はパース失敗と区別できるメッセージで報告される")
+  void ioErrorIsNotLabeledAsParseFailure() {
+    // ネットワーク切断・パイプ切断等の I/O 障害は CSV の内容不正とは原因が異なるため、
+    // オペレーターが切り分けられるメッセージで報告されるべき。
+    // close() 時の IOException を使うのは、opencsv の readNext() が読み取り中の
+    // IOException を EOF として扱うため、I/O 障害が IOException として観測できる
+    // 経路がストリームのクローズ時に限られることによる。
+    CsvValidateCommand command = CsvValidateCommand.create(true, 10);
+    byte[] csv = "id,name\n1,Alice\n".getBytes(StandardCharsets.UTF_8);
+    InputStream failingStream =
+        new ByteArrayInputStream(csv) {
+          @Override
+          public void close() throws IOException {
+            throw new IOException("simulated connection loss");
+          }
+        };
+
+    StreamProcessingException exception =
+        assertThrows(StreamProcessingException.class, () -> command.consume(failingStream));
+
+    String msg = exception.getMessage();
+    assertFalse(msg.contains("Failed to parse CSV"), "I/O 障害がパース失敗としてラベルされている。実際のメッセージ: " + msg);
+    assertTrue(
+        msg.contains("Failed to read CSV input"),
+        "I/O 障害は 'Failed to read CSV input' として報告されるべき。実際のメッセージ: " + msg);
   }
 }


### PR DESCRIPTION
## 概要

issue #748（CsvValidateCommand: IOException を 'Failed to parse CSV' と誤ラベルしている）のバグ存在を証明する known-bug テストを追加します。

Refs #748

## 証明方法

方法 A（失敗するテストを書いて実行）。テスト妥当性は Codex によるレビューで**承認済み**です。

## バグの内容

`CsvValidateCommand.readAndValidate()` の `catch (IOException e)` ブロックが、ネットワーク切断・パイプ切断等の I/O 障害を `CsvValidationException`（CSV 内容不正）と同じ「Failed to parse CSV」というメッセージで報告するため、オペレーターが障害原因を切り分けられません。

```java
} catch (IOException e) {
    logger.error("CSV validation failed: {}", e.getMessage(), e);
    throw new StreamProcessingException("Failed to parse CSV: " + e.getMessage(), e);
}
```

## 証明テストと失敗ログ

テスト: `CsvValidateCommandTest.ioErrorIsNotLabeledAsParseFailure`（`@Tag("known-bug") // #748`）

再現条件: 正常な CSV を返し `close()` 時に `IOException` をスローする入力ストリーム

```
org.opentest4j.AssertionFailedError: I/O 障害がパース失敗としてラベルされている。
実際のメッセージ: Failed to parse CSV: simulated connection loss
==> expected: <false> but was: <true>
```

## テスト設計上の補足

プローブにより、opencsv 5.12.0 の `CSVReader.readNext()` は読み取り中の `IOException` を伝播せず EOF（null）として扱うことを確認済みです（JDK の `BufferedReader.readLine()` は同一ストリームで正しく伝播）。このため当該 catch ブロックへの到達経路はストリームの `close()` 時に限られ、テストもその経路を使用しています。

「読み取り中の I/O 障害が EOF として扱われる」問題自体は #748 とは別のバグとして別途起票を検討します。詳細は issue コメント（https://github.com/3211133/StreamConverter/issues/748#issuecomment-4679229614）を参照してください。

## 確認方法

```bash
./gradlew :streamconverter-core:verifyKnownBugs --rerun-tasks --tests "*.CsvValidateCommandTest"
```

`verifyKnownBugs: OK — all 1 known-bug test(s) are still failing as expected.` でバグの存在を継続確認できます。
`@Tag("known-bug")` 付きのため通常 CI（`./gradlew build`）からは除外されます。

## 修正 PR との関係

修正 PR でこのテストが通過する（`verifyKnownBugs` が BUILD FAILED になる）ことがバグ修正の客観的証明になります。修正時は `@Tag("known-bug")` を除去するだけで通常テストに変換できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
