### PR TITLE
fix: route header-only CSV error through error limit in CsvValidateCommand (closes #747)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvRowValidator.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvRowValidator.java
@@ -64,6 +64,10 @@ final class CsvRowValidator {
     }
   }
 
+  void reportHeaderOnlyCsv(List<String> errors) {
+    addError(errors, "CSV file contains only header, no data rows found");
+  }
+
   void validateDataRow(String[] row, int rowNum, String[] headers, List<String> errors) {
     int expectedColumnCount = headers != null ? headers.length : -1;
 

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
@@ -181,7 +181,7 @@ public class CsvValidateCommand extends ConsumerCommand {
     }
 
     if (hasHeader && !hasDataRows) {
-      errors.add("CSV file contains only header, no data rows found");
+      rowValidator.reportHeaderOnlyCsv(errors);
     }
     return !hasHeader && !hasDataRows;
   }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -422,7 +422,6 @@ public class CsvValidateCommandTest {
   }
 
   @Test
-  @Tag("known-bug") // #747
   @DisplayName("ヘッダーのみのCSVでも maxErrorsToReport の上限を超えてエラーが報告されない")
   void maxErrorsToReport_headerOnlyCsvDoesNotExceedLimit() throws IOException {
     // 空セルを含むヘッダー行のみ（データ行なし）の入力では、


### PR DESCRIPTION
## 概要

issue #747 の修正。`CsvValidateCommand.validateDataRows()` の「ヘッダーのみ・データ行なし」エラーが、エラー件数上限（`maxErrorsToReport`）を管理する `CsvRowValidator.addError()` を経由せず `errors.add()` を直接呼んでいたため、上限到達後もエラーが追加され報告件数が上限を超えていました。

Closes #747

## 修正アプローチ

`CsvRowValidator` に `reportHeaderOnlyCsv()` を追加し、エラー追加と上限管理の責務を `CsvRowValidator` に閉じ込めました。`CsvValidateCommand.validateDataRows()` は同メソッドを呼ぶだけにしています（plan-review で Codex が推奨した「専用メソッド追加」案。`addError` の可視性開放より再発防止に優れるため採用）。

## 修正前の動作（known-bug テストが証明したこと）

`maxErrorsToReport=1`・入力 `"id,\n"`（空セルを含むヘッダー行のみ）で 2 件のエラーが報告されていました:

```
CSV validation failed: CSV validation failed with 2 error(s):
  1. Header contains empty or null column
  2. CSV file contains only header, no data rows found
```

## 修正後の確認

1. **verifyKnownBugs BUILD FAILED を確認**（#747 の known-bug テスト `maxErrorsToReport_headerOnlyCsvDoesNotExceedLimit` がパスに転換 = バグ修正の客観的証明）
   - 同時に #748 の known-bug テストは期待通り FAIL を維持（未修正バグの存在を継続確認）
2. その後 `@Tag("known-bug")` を除去し、通常テストに昇格（`@DisplayName`・メソッド名・テスト本体は不変更）
3. `streamconverter-core` 通常テスト **443 件全件パス**
4. 実装は Codex コードレビューで**承認済み**（Codex 自身も対象テストを再実行し 24/24 パスを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
