### PR TITLE
fix: distinguish I/O failures from CSV parse errors in CsvValidateCommand (closes #748)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
@@ -1,6 +1,7 @@
 package com.streamconverter.command.impl.csv;
 
 import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvMalformedLineException;
 import com.opencsv.exceptions.CsvValidationException;
 import com.streamconverter.StreamProcessingException;
 import com.streamconverter.command.ConsumerCommand;
@@ -159,12 +160,14 @@ public class CsvValidateCommand extends ConsumerCommand {
 
       return validateDataRows(csvReader, rowValidator, headers, validationErrors);
 
-    } catch (CsvValidationException e) {
+    } catch (CsvValidationException | CsvMalformedLineException e) {
+      // CsvMalformedLineException は IOException のサブクラスだが、
+      // 未閉鎖クォート等のパース失敗を表すため I/O 障害と区別して扱う
       logger.error("CSV parsing error: {}", e.getMessage(), e);
       throw new StreamProcessingException("Failed to parse CSV: " + e.getMessage(), e);
     } catch (IOException e) {
-      logger.error("CSV validation failed: {}", e.getMessage(), e);
-      throw new StreamProcessingException("Failed to parse CSV: " + e.getMessage(), e);
+      logger.error("I/O error while reading CSV input: {}", e.getMessage(), e);
+      throw new StreamProcessingException("Failed to read CSV input: " + e.getMessage(), e);
     }
   }
 

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -521,7 +521,6 @@ public class CsvValidateCommandTest {
   }
 
   @Test
-  @Tag("known-bug") // #748
   @DisplayName("入力ストリームの I/O 障害はパース失敗と区別できるメッセージで報告される")
   void ioErrorIsNotLabeledAsParseFailure() {
     // ネットワーク切断・パイプ切断等の I/O 障害は CSV の内容不正とは原因が異なるため、


### PR DESCRIPTION
## 概要

issue #748 の修正。`CsvValidateCommand.readAndValidate()` の `catch (IOException e)` ブロックが、ネットワーク切断・パイプ切断等の I/O 障害を CSV 内容不正と同じ「Failed to parse CSV」というメッセージで報告し、ログメッセージのラベルも原因と一致していませんでした。

Closes #748

## 修正アプローチ

- IOException 経路のメッセージを「Failed to read CSV input」、ログを「I/O error while reading CSV input」に変更し、パース失敗と I/O 障害を切り分け可能にしました。
- **実装中に判明した追加考慮**: opencsv 5.12.0 は未閉鎖クォート等のパース失敗を `CsvMalformedLineException`（**IOException のサブクラス**）として投げるため、IOException を一括で I/O 障害扱いするとパース失敗が逆方向に誤ラベルされます（既存テスト `testMalformedCsvWithUnclosedQuotes` の失敗で検出）。`CsvValidationException | CsvMalformedLineException` のマルチキャッチでパース失敗系をまとめ、「Failed to parse CSV」ラベルを維持しました。
- plan-review で Codex が提案した `catch (StreamProcessingException e) { throw e; }` の防御的追加は、PMD ルールセットで `AvoidRethrowingException` が有効であり新規違反を生むため見送りました（#638 の違反削減方針と整合。Codex も最終レビューでこの判断を妥当と承認）。

## 修正前の動作（known-bug テストが証明したこと）

`close()` 時に IOException をスローする入力ストリーム（パイプ切断等で現実に発生）に対し:

```
Failed to parse CSV: simulated connection loss
```

## 修正後の確認

1. **verifyKnownBugs BUILD FAILED を確認**（#748 の known-bug テスト `ioErrorIsNotLabeledAsParseFailure` がパスに転換 = バグ修正の客観的証明。#747 のテストはこのブランチに修正が含まれないため期待通り FAIL を維持）
2. その後 `@Tag("known-bug")` を除去し、通常テストに昇格（`@DisplayName`・メソッド名・テスト本体は不変更）
3. `streamconverter-core` 通常テスト **443 件全件パス**（`testMalformedCsvWithUnclosedQuotes` 含む）
4. 実装は Codex コードレビューで**承認済み**（Codex 自身もテスト再実行で 24/24 パスを確認）

## スコープ外（参考）

`CsvWalker` と `CsvFilterCommand` にも同様の「IOException → Failed to parse CSV」パターンが存在しますが、issue #748 の対象は `CsvValidateCommand` のみのため本 PR では変更していません。必要なら別 issue で対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
