### PR TITLE
test: add known-bug proof test for #784

### DIFF
--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/FilterCommandBasicTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/FilterCommandBasicTest.java
@@ -604,7 +604,7 @@ class FilterCommandBasicTest {
   @Test
   @Tag("known-bug") // #784
   @DisplayName("CsvFilterCommand: 読み取り中の入力ストリーム I/O 障害は IOException として呼び出し元に伝播する")
-  void testCsvFilterCommand_readIoErrorPropagatesAsIOException() {
+  void testCsvFilterCommand_readIoErrorPropagatesAsIOException() throws IOException {
     // ネットワーク切断・パイプ切断等で読み取り途中に I/O 障害が発生した場合、
     // 途中までの行だけの切り詰められた出力を完全な結果として確定させてはならず、
     // IOException を呼び出し元に伝播させて障害を検知可能にするべき。
@@ -613,7 +613,7 @@ class FilterCommandBasicTest {
     // ヘッダーと Alice 行までを供給した後、Bob 行が届く前に I/O 障害が発生する。
     // 障害が無視されると、後続行を欠いた切り詰め出力が完全な結果として確定してしまう。
     byte[] supplied = "id,name\n1,Alice\n".getBytes(StandardCharsets.UTF_8);
-    InputStream failingStream =
+    try (InputStream failingStream =
         new InputStream() {
           private int position = 0;
 
@@ -638,16 +638,17 @@ class FilterCommandBasicTest {
             }
             return supplied[position++] & 0xFF;
           }
-        };
-    CsvFilterCommand command = CsvFilterCommand.create(CSVPath.of("name"));
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
+        }) {
+      CsvFilterCommand command = CsvFilterCommand.create(CSVPath.of("name"));
+      ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-    assertThrows(
-        IOException.class,
-        () -> command.execute(failingStream, output),
-        () ->
-            "読み取り中の I/O 障害は IOException として伝播し、切り詰められた出力を正常終了として確定させないこと。"
-                + "確定されてしまった切り詰め出力: "
-                + output.toString(StandardCharsets.UTF_8));
+      assertThrows(
+          IOException.class,
+          () -> command.execute(failingStream, output),
+          () ->
+              "読み取り中の I/O 障害は IOException として伝播し、切り詰められた出力を正常終了として確定させないこと。"
+                  + "確定されてしまった切り詰め出力: "
+                  + output.toString(StandardCharsets.UTF_8));
+    }
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/FilterCommandBasicTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/FilterCommandBasicTest.java
@@ -15,6 +15,7 @@ import com.streamconverter.test.StreamingTestUtils.TrackingInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.junit.jupiter.api.DisplayName;
@@ -598,5 +599,55 @@ class FilterCommandBasicTest {
         IllegalArgumentException.class,
         thrown.getCause(),
         "Cause は CsvFilterCommand からの IllegalArgumentException であること");
+  }
+
+  @Test
+  @Tag("known-bug") // #784
+  @DisplayName("CsvFilterCommand: 読み取り中の入力ストリーム I/O 障害は IOException として呼び出し元に伝播する")
+  void testCsvFilterCommand_readIoErrorPropagatesAsIOException() {
+    // ネットワーク切断・パイプ切断等で読み取り途中に I/O 障害が発生した場合、
+    // 途中までの行だけの切り詰められた出力を完全な結果として確定させてはならず、
+    // IOException を呼び出し元に伝播させて障害を検知可能にするべき。
+    //
+    // 失敗ストリーム: 全3行（ヘッダー + Alice 行 + Bob 行）の CSV のうち、
+    // ヘッダーと Alice 行までを供給した後、Bob 行が届く前に I/O 障害が発生する。
+    // 障害が無視されると、後続行を欠いた切り詰め出力が完全な結果として確定してしまう。
+    byte[] supplied = "id,name\n1,Alice\n".getBytes(StandardCharsets.UTF_8);
+    InputStream failingStream =
+        new InputStream() {
+          private int position = 0;
+
+          @Override
+          public int read(byte[] b, int off, int len) throws IOException {
+            // read(byte[], int, int) を直接オーバーライドするのは、JDK のデフォルト実装が
+            // 2バイト目以降の read() の IOException を握りつぶすため。
+            // 読み取り位置を管理し、供給分を返し切った後の読み取りで I/O 障害を発生させる。
+            if (position >= supplied.length) {
+              throw new IOException("simulated I/O failure during read");
+            }
+            int n = Math.min(len, supplied.length - position);
+            System.arraycopy(supplied, position, b, off, n);
+            position += n;
+            return n;
+          }
+
+          @Override
+          public int read() throws IOException {
+            if (position >= supplied.length) {
+              throw new IOException("simulated I/O failure during read");
+            }
+            return supplied[position++] & 0xFF;
+          }
+        };
+    CsvFilterCommand command = CsvFilterCommand.create(CSVPath.of("name"));
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    assertThrows(
+        IOException.class,
+        () -> command.execute(failingStream, output),
+        () ->
+            "読み取り中の I/O 障害は IOException として伝播し、切り詰められた出力を正常終了として確定させないこと。"
+                + "確定されてしまった切り詰め出力: "
+                + output.toString(StandardCharsets.UTF_8));
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/FilterCommandBasicTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/FilterCommandBasicTest.java
@@ -622,6 +622,9 @@ class FilterCommandBasicTest {
             // read(byte[], int, int) を直接オーバーライドするのは、JDK のデフォルト実装が
             // 2バイト目以降の read() の IOException を握りつぶすため。
             // 読み取り位置を管理し、供給分を返し切った後の読み取りで I/O 障害を発生させる。
+            if (len == 0) {
+              return 0;
+            }
             if (position >= supplied.length) {
               throw new IOException("simulated I/O failure during read");
             }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -381,6 +381,9 @@ class CsvWalkerTest {
             // read(byte[], int, int) を直接オーバーライドするのは、JDK のデフォルト実装が
             // 2バイト目以降の read() の IOException を握りつぶすため。
             // 読み取り位置を管理し、供給分を返し切った後の読み取りで I/O 障害を発生させる。
+            if (len == 0) {
+              return 0;
+            }
             if (position >= supplied.length) {
               throw new IOException("simulated I/O failure during read");
             }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -363,7 +363,7 @@ class CsvWalkerTest {
   @Test
   @Tag("known-bug") // #784
   @DisplayName("読み取り中の入力ストリーム I/O 障害は IOException として呼び出し元に伝播する")
-  void testReadIoErrorPropagatesAsIOException() {
+  void testReadIoErrorPropagatesAsIOException() throws IOException {
     // ネットワーク切断・パイプ切断等で読み取り途中に I/O 障害が発生した場合、
     // 途中までの行だけの切り詰められた出力を完全な結果として確定させてはならず、
     // IOException を呼び出し元に伝播させて障害を検知可能にするべき。
@@ -372,7 +372,7 @@ class CsvWalkerTest {
     // ヘッダーと Alice 行までを供給した後、Bob 行が届く前に I/O 障害が発生する。
     // 障害が無視されると、後続行を欠いた切り詰め出力が完全な結果として確定してしまう。
     byte[] supplied = "name,age\nAlice,30\n".getBytes(StandardCharsets.UTF_8);
-    InputStream failingStream =
+    try (InputStream failingStream =
         new InputStream() {
           private int position = 0;
 
@@ -397,17 +397,18 @@ class CsvWalkerTest {
             }
             return supplied[position++] & 0xFF;
           }
-        };
-    CsvWalker testCommand = CsvWalker.create(CSVPath.of("name"), new PassThroughRule());
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
+        }) {
+      CsvWalker testCommand = CsvWalker.create(CSVPath.of("name"), new PassThroughRule());
+      ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-    assertThrows(
-        IOException.class,
-        () -> testCommand.execute(failingStream, output),
-        () ->
-            "読み取り中の I/O 障害は IOException として伝播し、切り詰められた出力を正常終了として確定させないこと。"
-                + "確定されてしまった切り詰め出力: "
-                + output.toString(StandardCharsets.UTF_8));
+      assertThrows(
+          IOException.class,
+          () -> testCommand.execute(failingStream, output),
+          () ->
+              "読み取り中の I/O 障害は IOException として伝播し、切り詰められた出力を正常終了として確定させないこと。"
+                  + "確定されてしまった切り詰め出力: "
+                  + output.toString(StandardCharsets.UTF_8));
+    }
   }
 
   @Test

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for CsvWalker. */
@@ -357,6 +358,56 @@ class CsvWalkerTest {
     // The address field with internal comma should be preserved intact
     assertTrue(result.contains("123 Main St"), "Address should be preserved");
     assertTrue(result.contains("Suite 4"), "Comma-separated part of address should be preserved");
+  }
+
+  @Test
+  @Tag("known-bug") // #784
+  @DisplayName("読み取り中の入力ストリーム I/O 障害は IOException として呼び出し元に伝播する")
+  void testReadIoErrorPropagatesAsIOException() {
+    // ネットワーク切断・パイプ切断等で読み取り途中に I/O 障害が発生した場合、
+    // 途中までの行だけの切り詰められた出力を完全な結果として確定させてはならず、
+    // IOException を呼び出し元に伝播させて障害を検知可能にするべき。
+    //
+    // 失敗ストリーム: 全3行（ヘッダー + Alice 行 + Bob 行）の CSV のうち、
+    // ヘッダーと Alice 行までを供給した後、Bob 行が届く前に I/O 障害が発生する。
+    // 障害が無視されると、後続行を欠いた切り詰め出力が完全な結果として確定してしまう。
+    byte[] supplied = "name,age\nAlice,30\n".getBytes(StandardCharsets.UTF_8);
+    InputStream failingStream =
+        new InputStream() {
+          private int position = 0;
+
+          @Override
+          public int read(byte[] b, int off, int len) throws IOException {
+            // read(byte[], int, int) を直接オーバーライドするのは、JDK のデフォルト実装が
+            // 2バイト目以降の read() の IOException を握りつぶすため。
+            // 読み取り位置を管理し、供給分を返し切った後の読み取りで I/O 障害を発生させる。
+            if (position >= supplied.length) {
+              throw new IOException("simulated I/O failure during read");
+            }
+            int n = Math.min(len, supplied.length - position);
+            System.arraycopy(supplied, position, b, off, n);
+            position += n;
+            return n;
+          }
+
+          @Override
+          public int read() throws IOException {
+            if (position >= supplied.length) {
+              throw new IOException("simulated I/O failure during read");
+            }
+            return supplied[position++] & 0xFF;
+          }
+        };
+    CsvWalker testCommand = CsvWalker.create(CSVPath.of("name"), new PassThroughRule());
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    assertThrows(
+        IOException.class,
+        () -> testCommand.execute(failingStream, output),
+        () ->
+            "読み取り中の I/O 障害は IOException として伝播し、切り詰められた出力を正常終了として確定させないこと。"
+                + "確定されてしまった切り詰め出力: "
+                + output.toString(StandardCharsets.UTF_8));
   }
 
   @Test


### PR DESCRIPTION
## 概要

issue #784 のバグ証明テストを `@Tag("known-bug")` 付きで追加する。

`CsvFilterCommand` と `CsvWalker` は `while ((row = csvReader.readNext()) != null)` ループで入力を読むが、opencsv 5.12.0 の `CSVReader.readNext()` は下位 InputStream の `IOException` を伝播せず EOF（null）として扱う。このため読み取り中の I/O 障害（ネットワーク切断・パイプ切断等）が発生すると、`execute()` は例外を出さずに正常終了し、途中までの行だけの切り詰められた出力を完全な結果として確定させる。

関連 issue: #784

## 証明方法（方法 A: 失敗するテスト）

失敗ストリーム（`read(byte[],int,int)` / `read()` を位置管理付きでオーバーライドし、ヘッダーと1行目（Alice 行）までを供給した後、2行目（Bob 行）が届く前に `IOException` をスローする。`close()` は何もスローしない＝ #748 の close 経路とは分離）を入力に `execute()` を実行し、`assertThrows(IOException.class, ...)` で例外伝播を検証する。

追加テスト:
- `FilterCommandBasicTest.testCsvFilterCommand_readIoErrorPropagatesAsIOException`
- `CsvWalkerTest.testReadIoErrorPropagatesAsIOException`

**Codex によるテスト妥当性レビューで「承認: バグの存在を証明できている」を取得済み**（1回目の非承認指摘＝切り詰めの直接観測・ストリーム位置管理の脆弱性を反映の上、2回目で承認）。

## 失敗ログ（現行コードでの実行結果）

```
FilterCommandBasicTest > CsvFilterCommand: 読み取り中の入力ストリーム I/O 障害は IOException として呼び出し元に伝播する FAILED
org.opentest4j.AssertionFailedError: 読み取り中の I/O 障害は IOException として伝播し、切り詰められた出力を正常終了として確定させないこと。確定されてしまった切り詰め出力: name\r\nAlice\r\n ==> Expected java.io.IOException to be thrown, but nothing was thrown.

CsvWalkerTest > 読み取り中の入力ストリーム I/O 障害は IOException として呼び出し元に伝播する FAILED
org.opentest4j.AssertionFailedError: 読み取り中の I/O 障害は IOException として伝播し、切り詰められた出力を正常終了として確定させないこと。確定されてしまった切り詰め出力: name,age\r\nAlice,30\r\n ==> Expected java.io.IOException to be thrown, but nothing was thrown.
```

失敗メッセージ中の「確定されてしまった切り詰め出力」が、Bob 行欠落のまま出力が完全な結果として確定したことを直接示している。

## 確認方法

`known-bug` タグ付きのため通常の test タスクからは除外され、以下で確認できる:

```bash
./gradlew :streamconverter-core:verifyKnownBugs --rerun-tasks --tests "*.CsvWalkerTest" --tests "*.FilterCommandBasicTest"
```

→ 2件 FAIL で `verifyKnownBugs: OK — all 2 known-bug test(s) are still failing as expected.`（BUILD SUCCESSFUL）

## 修正 PR への引き継ぎ

修正 PR では、修正実装後に `verifyKnownBugs` が BUILD FAILED（known-bug テストがパス）になることがバグ修正の客観的証明となる。その後 `@Tag("known-bug")` の除去のみで本テストを通常テストに昇格できる（テスト内コメントは現行挙動に言及していないため陳腐化しない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
