### PR TITLE
feat: 例外規定の共通機構を実装する (#786 Phase 2)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/CommandStageRunner.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/CommandStageRunner.java
@@ -86,7 +86,7 @@ final class CommandStageRunner {
       closeStageOutput(stageIo, commandLabel);
     } catch (Throwable throwable) {
       abortAllPipes(pipes);
-      sneakyThrow(toStageFailure(throwable, commandLabel));
+      throw toStageFailure(throwable, commandLabel);
     }
   }
 
@@ -108,27 +108,32 @@ final class CommandStageRunner {
   }
 
   /**
-   * Converts a stage failure into the exception type surfaced by the pipeline.
+   * Classifies a stage failure per the exception policy (docs/reference/EXCEPTION_POLICY.md) and
+   * returns it as an unchecked throwable suitable for the async stage boundary.
+   *
+   * <p>The propagated exception keeps its original type: input-data and I/O failures travel as
+   * their own {@link IOException} subtype (carried across the {@code Runnable} boundary by {@link
+   * UncheckedStreamException}), and runtime exceptions — implementation bugs by classification —
+   * are returned as-is. The failing command is recorded as a suppressed {@link StageFailureContext}
+   * instead of being embedded in a wrapper message.
    *
    * @throws Error when the stage failed with an unrecoverable JVM error
    */
-  private StreamProcessingException toStageFailure(Throwable throwable, String commandLabel) {
-    if (throwable instanceof StreamProcessingException streamProcessingException) {
-      return streamProcessingException;
-    }
+  private RuntimeException toStageFailure(Throwable throwable, String commandLabel) {
     if (throwable instanceof Error error) {
       throw error;
     }
-    if (throwable instanceof IOException || throwable instanceof RuntimeException) {
-      return new StreamProcessingException(
-          "Command execution failed: " + commandLabel + " - " + throwable.getMessage(), throwable);
+    Throwable failure =
+        throwable instanceof UncheckedStreamException carrier ? carrier.getCause() : throwable;
+    failure.addSuppressed(new StageFailureContext(commandLabel));
+    if (failure instanceof RuntimeException runtimeException) {
+      return runtimeException;
     }
-    return new StreamProcessingException("Command execution failed: " + commandLabel, throwable);
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T extends Throwable> void sneakyThrow(Throwable t) throws T {
-    throw (T) t;
+    if (failure instanceof IOException ioException) {
+      return new UncheckedStreamException(ioException);
+    }
+    return new UncheckedStreamException(
+        new StreamProcessingException("Command execution failed: " + commandLabel, failure));
   }
 
   /** Aborts every intermediate pipe so dependent stages stop waiting on stream activity. */

--- a/streamconverter-core/src/main/java/com/streamconverter/InvalidInputDataException.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/InvalidInputDataException.java
@@ -1,0 +1,43 @@
+package com.streamconverter;
+
+/**
+ * Indicates invalid input data (classification A in the exception policy): failures that are
+ * resolved by fixing the input, such as parse errors and validation failures.
+ *
+ * <p>This exception is intended for failures caused by the content of the data being processed (for
+ * example, malformed CSV rows, values that fail validation rules, or unparsable fields). The remedy
+ * for such failures is to correct the input data, not the runtime environment.
+ *
+ * <p>Environmental I/O failures must NOT be wrapped in this type; propagate the original {@link
+ * java.io.IOException} instead. Mixing environmental failures into this classification would
+ * obscure the distinction the exception policy relies on between "fix the input" and "fix the
+ * environment" failures.
+ *
+ * <p>See docs/reference/EXCEPTION_POLICY.md for the full exception classification policy.
+ *
+ * <p>Extends {@link StreamProcessingException}, and therefore {@link java.io.IOException}, so that
+ * callers of {@link com.streamconverter.command.IStreamCommand#execute} can continue to handle all
+ * stream-level failures with a single {@code catch (IOException)} block.
+ */
+public class InvalidInputDataException extends StreamProcessingException {
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Constructs a new InvalidInputDataException with the specified detail message.
+   *
+   * @param message the detail message
+   */
+  public InvalidInputDataException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new InvalidInputDataException with the specified detail message and cause.
+   *
+   * @param message the detail message
+   * @param cause the cause of the exception
+   */
+  public InvalidInputDataException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/streamconverter-core/src/main/java/com/streamconverter/PipelineFailureHandler.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/PipelineFailureHandler.java
@@ -24,7 +24,8 @@ final class PipelineFailureHandler {
     List<Throwable> rootCauses = collectRootCauses(futures);
     if (rootCauses.isEmpty()) {
       throw new StreamProcessingException(
-          "Unexpected error during command execution", executionException.getCause());
+          "Unexpected error during command execution",
+          unwrapCarrier(executionException.getCause()));
     }
 
     Throwable primary = rootCauses.get(0);
@@ -62,7 +63,7 @@ final class PipelineFailureHandler {
       try {
         future.get();
       } catch (ExecutionException executionException) {
-        Throwable cause = executionException.getCause();
+        Throwable cause = unwrapCarrier(executionException.getCause());
         if (!isPipeAbortedCause(cause)) {
           rootCauses.add(cause);
         }
@@ -72,6 +73,17 @@ final class PipelineFailureHandler {
       }
     }
     return rootCauses;
+  }
+
+  /**
+   * Unwraps the async-boundary carrier so callers see the original checked failure.
+   *
+   * <p>{@link CommandStageRunner} moves {@link IOException} failures across the {@code Runnable}
+   * boundary inside an {@link UncheckedStreamException}; root-cause inspection must look at the
+   * carried exception, not the carrier.
+   */
+  private static Throwable unwrapCarrier(Throwable cause) {
+    return cause instanceof UncheckedStreamException carrier ? carrier.getCause() : cause;
   }
 
   /**

--- a/streamconverter-core/src/main/java/com/streamconverter/StageFailureContext.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/StageFailureContext.java
@@ -1,0 +1,21 @@
+package com.streamconverter;
+
+/**
+ * Lightweight marker attached as a suppressed exception to a stage failure so the failing command
+ * can be identified without changing the type or message of the propagated exception.
+ *
+ * <p>The exception policy (docs/reference/EXCEPTION_POLICY.md) requires the pipeline boundary to
+ * propagate environmental I/O failures and implementation bugs with their original type. This
+ * marker carries the command label that the previous wrapping behavior used to embed in the message
+ * of a {@link StreamProcessingException}.
+ *
+ * <p>The stack trace is intentionally disabled: the marker only contributes its message and is
+ * created on a failure path where the original exception already records the relevant frames.
+ */
+final class StageFailureContext extends Exception {
+  private static final long serialVersionUID = 1L;
+
+  StageFailureContext(String commandLabel) {
+    super("Command execution failed: " + commandLabel, null, false, false);
+  }
+}

--- a/streamconverter-core/src/main/java/com/streamconverter/UncheckedStreamException.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/UncheckedStreamException.java
@@ -1,0 +1,41 @@
+package com.streamconverter;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Wraps an {@link IOException} as an unchecked exception so it can be carried through functional
+ * interfaces, such as {@link com.streamconverter.command.rule.IRule#apply}, that do not declare
+ * checked exceptions.
+ *
+ * <p>This is an internal carrier type only; it must not escape public command boundaries. Code at a
+ * command boundary (for example, a {@code CommandStageRunner}) must catch this exception, unwrap it
+ * via {@link #getCause()}, and rethrow the underlying {@link IOException} (or a {@link
+ * StreamProcessingException} wrapping it) so that callers continue to observe the checked exception
+ * contract.
+ *
+ * <p>This class follows the same design as {@link java.io.UncheckedIOException}.
+ */
+public final class UncheckedStreamException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Constructs a new UncheckedStreamException with the specified cause.
+   *
+   * @param cause the {@link IOException} to wrap
+   * @throws NullPointerException if {@code cause} is {@code null}
+   */
+  public UncheckedStreamException(IOException cause) {
+    super(Objects.requireNonNull(cause));
+  }
+
+  /**
+   * Returns the cause of this exception.
+   *
+   * @return the {@link IOException} that was passed to the constructor
+   */
+  @Override
+  public IOException getCause() {
+    return (IOException) super.getCause();
+  }
+}

--- a/streamconverter-core/src/main/java/com/streamconverter/UncheckedStreamException.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/UncheckedStreamException.java
@@ -8,9 +8,11 @@ import java.util.Objects;
  * interfaces, such as {@link com.streamconverter.command.rule.IRule#apply}, that do not declare
  * checked exceptions.
  *
- * <p>This is an internal carrier type only; it must not escape public command boundaries. Code at a
- * command boundary (for example, a {@code CommandStageRunner}) must catch this exception, unwrap it
- * via {@link #getCause()}, and rethrow the underlying {@link IOException} (or a {@link
+ * <p>This type is {@code public} because rule implementations live in other packages and modules
+ * (for example, the database rules in {@code streamconverter-db}) and need to throw it. Its role is
+ * still strictly that of a carrier: it must not escape public command boundaries. Code at a command
+ * boundary (for example, a {@code CommandStageRunner}) must catch this exception, unwrap it via
+ * {@link #getCause()}, and rethrow the underlying {@link IOException} (or a {@link
  * StreamProcessingException} wrapping it) so that callers continue to observe the checked exception
  * contract.
  *

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/FaultReportingReader.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/FaultReportingReader.java
@@ -98,6 +98,11 @@ final class FaultReportingReader extends FilterReader {
    * itself completes normally. If {@code super.close()} also fails, the recorded fault (if any) is
    * attached to the close failure as a suppressed exception.
    *
+   * <p>A recorded fault is reported only once: closing an already-closed reader does not rethrow
+   * it. This keeps {@code close()} idempotent when the reader is registered both as its own
+   * try-with-resources resource and as the delegate of a closeable consumer (such as {@code
+   * CSVReader}) that closes it first.
+   *
    * @throws IOException if the underlying reader fails to close, or if a read operation previously
    *     failed and was not propagated by the caller
    */
@@ -108,12 +113,17 @@ final class FaultReportingReader extends FilterReader {
     } catch (IOException closeFailure) {
       if (fault != null) {
         closeFailure.addSuppressed(fault);
+        fault = null;
       }
       throw closeFailure;
     }
     if (fault != null) {
-      throw new IOException(
-          "I/O read failure was suppressed by a downstream consumer: " + fault.getMessage(), fault);
+      IOException reported =
+          new IOException(
+              "I/O read failure was suppressed by a downstream consumer: " + fault.getMessage(),
+              fault);
+      fault = null;
+      throw reported;
     }
   }
 }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/FaultReportingReader.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/FaultReportingReader.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 final class FaultReportingReader extends FilterReader {
 
   private IOException fault;
+  private boolean faultReported;
 
   /**
    * Constructs a new FaultReportingReader wrapping the given reader.
@@ -111,19 +112,16 @@ final class FaultReportingReader extends FilterReader {
     try {
       super.close();
     } catch (IOException closeFailure) {
-      if (fault != null) {
+      if (fault != null && !faultReported) {
+        faultReported = true;
         closeFailure.addSuppressed(fault);
-        fault = null;
       }
       throw closeFailure;
     }
-    if (fault != null) {
-      IOException reported =
-          new IOException(
-              "I/O read failure was suppressed by a downstream consumer: " + fault.getMessage(),
-              fault);
-      fault = null;
-      throw reported;
+    if (fault != null && !faultReported) {
+      faultReported = true;
+      throw new IOException(
+          "I/O read failure was suppressed by a downstream consumer: " + fault.getMessage(), fault);
     }
   }
 }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/FaultReportingReader.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/FaultReportingReader.java
@@ -1,0 +1,119 @@
+package com.streamconverter.command.impl.csv;
+
+import java.io.FilterReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A {@link Reader} wrapper that records {@link IOException}s raised by read operations and rethrows
+ * them when the reader is closed.
+ *
+ * <p>opencsv 5.x's {@code CSVReader.readNext()} does not propagate an {@link IOException} thrown by
+ * the underlying {@link Reader}; instead it treats the failure as end-of-stream and returns {@code
+ * null}, as if the input ended normally. This makes a genuine I/O failure indistinguishable from a
+ * normal end-of-file from the caller's perspective.
+ *
+ * <p>This wrapper records the first {@link IOException} raised by any read operation. When the
+ * reader is closed (for example, via try-with-resources), it rethrows a new {@link IOException}
+ * wrapping the recorded failure, ensuring that a suppressed I/O failure is surfaced rather than
+ * silently treated as a normal end-of-stream.
+ */
+final class FaultReportingReader extends FilterReader {
+
+  private IOException fault;
+
+  /**
+   * Constructs a new FaultReportingReader wrapping the given reader.
+   *
+   * @param in the underlying reader
+   */
+  FaultReportingReader(Reader in) {
+    super(in);
+  }
+
+  /**
+   * Creates a FaultReportingReader that decodes the given input stream as UTF-8.
+   *
+   * @param in the underlying input stream
+   * @return a FaultReportingReader wrapping a UTF-8 {@link InputStreamReader} over {@code in}
+   */
+  static FaultReportingReader forUtf8(InputStream in) {
+    return new FaultReportingReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+  }
+
+  @Override
+  public int read() throws IOException {
+    try {
+      return super.read();
+    } catch (IOException e) {
+      recordFault(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public int read(char[] cbuf, int off, int len) throws IOException {
+    try {
+      return super.read(cbuf, off, len);
+    } catch (IOException e) {
+      recordFault(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    try {
+      return super.skip(n);
+    } catch (IOException e) {
+      recordFault(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean ready() throws IOException {
+    try {
+      return super.ready();
+    } catch (IOException e) {
+      recordFault(e);
+      throw e;
+    }
+  }
+
+  private void recordFault(IOException e) {
+    if (fault == null) {
+      fault = e;
+    }
+  }
+
+  /**
+   * Closes the underlying reader.
+   *
+   * <p>If a read operation previously failed with an {@link IOException}, that failure is rethrown
+   * here as a new {@link IOException} wrapping the recorded fault, even if {@code super.close()}
+   * itself completes normally. If {@code super.close()} also fails, the recorded fault (if any) is
+   * attached to the close failure as a suppressed exception.
+   *
+   * @throws IOException if the underlying reader fails to close, or if a read operation previously
+   *     failed and was not propagated by the caller
+   */
+  @Override
+  public void close() throws IOException {
+    try {
+      super.close();
+    } catch (IOException closeFailure) {
+      if (fault != null) {
+        closeFailure.addSuppressed(fault);
+      }
+      throw closeFailure;
+    }
+    if (fault != null) {
+      throw new IOException(
+          "I/O read failure was suppressed by a downstream consumer: " + fault.getMessage(), fault);
+    }
+  }
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/InvalidInputDataExceptionTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/InvalidInputDataExceptionTest.java
@@ -1,0 +1,68 @@
+package com.streamconverter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for InvalidInputDataException. */
+@DisplayName("InvalidInputDataException Tests")
+class InvalidInputDataExceptionTest {
+
+  @Test
+  @DisplayName("メッセージのみのコンストラクタはmessageを保持すること")
+  void testConstructorWithMessage() {
+    String message = "Invalid value in column 'age'";
+
+    InvalidInputDataException exception = new InvalidInputDataException(message);
+
+    assertEquals(message, exception.getMessage(), "コンストラクタに渡したmessageが保持されること");
+  }
+
+  @Test
+  @DisplayName("メッセージとcauseを指定するコンストラクタは両方を保持すること")
+  void testConstructorWithMessageAndCause() {
+    String message = "Failed to parse CSV row";
+    IllegalArgumentException cause = new IllegalArgumentException("Unexpected token");
+
+    InvalidInputDataException exception = new InvalidInputDataException(message, cause);
+
+    assertEquals(message, exception.getMessage(), "コンストラクタに渡したmessageが保持されること");
+    assertSame(cause, exception.getCause(), "コンストラクタに渡したcauseが同一インスタンスで保持されること");
+  }
+
+  @Test
+  @DisplayName("StreamProcessingExceptionとしてcatchできること")
+  void testCaughtAsStreamProcessingException() {
+    StreamProcessingException caught = null;
+    try {
+      throw new InvalidInputDataException("invalid input");
+    } catch (StreamProcessingException e) {
+      caught = e;
+    }
+
+    assertInstanceOf(
+        InvalidInputDataException.class,
+        caught,
+        "InvalidInputDataExceptionはcatch (StreamProcessingException)で捕捉できること");
+  }
+
+  @Test
+  @DisplayName("IOExceptionとしてcatchできること")
+  void testCaughtAsIOException() {
+    IOException caught = null;
+    try {
+      throw new InvalidInputDataException("invalid input");
+    } catch (IOException e) {
+      caught = e;
+    }
+
+    assertInstanceOf(
+        InvalidInputDataException.class,
+        caught,
+        "InvalidInputDataExceptionはcatch (IOException)で捕捉できること");
+  }
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/StreamConverterMDCIntegrationTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/StreamConverterMDCIntegrationTest.java
@@ -295,7 +295,8 @@ class StreamConverterMDCIntegrationTest {
 
   @Test
   void testAnonymousClassCommandNameInException() {
-    // 匿名クラスで実装したコマンドが失敗したとき、例外メッセージに "IStreamCommand" が含まれる
+    // 匿名クラスで実装したコマンドが失敗したとき、suppressed コンテキストに "IStreamCommand" が含まれる。
+    // 例外規定: I/O 障害（分類 B）はラップされず素の IOException のまま伝播する
     IStreamCommand failingCommand =
         new IStreamCommand() {
           @Override
@@ -306,17 +307,19 @@ class StreamConverterMDCIntegrationTest {
 
     StreamConverter converter = StreamConverter.create(failingCommand);
 
-    StreamProcessingException ex =
+    IOException ex =
         assertThrows(
-            StreamProcessingException.class,
+            IOException.class,
             () ->
                 converter.run(
                     new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8)),
                     new ByteArrayOutputStream()));
 
+    assertEquals("intentional failure", ex.getMessage(), "I/O 障害がラップされずそのまま伝播すること");
     assertTrue(
-        ex.getMessage().contains("IStreamCommand"),
-        "Exception message should contain 'IStreamCommand' for anonymous class, but was: "
-            + ex.getMessage());
+        java.util.Arrays.stream(ex.getSuppressed())
+            .anyMatch(s -> String.valueOf(s.getMessage()).contains("IStreamCommand")),
+        "Suppressed context should contain 'IStreamCommand' for anonymous class, but was: "
+            + java.util.Arrays.toString(ex.getSuppressed()));
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/StreamConverterTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/StreamConverterTest.java
@@ -183,7 +183,8 @@ class StreamConverterTest {
   @Timeout(10)
   @DisplayName("Downstream failure unblocks upstream within 10 seconds (no 60s timeout)")
   void testDownstreamFailureUnblocksUpstreamQuickly() {
-    // 後段が即時失敗した場合、前段が 60 秒待たずに StreamProcessingException を受け取る
+    // 後段が即時失敗した場合、前段が 60 秒待たずに失敗例外を受け取る
+    // （例外規定: RuntimeException は分類 C としてラップされずそのまま伝播する）
     IStreamCommand upstreamCommand =
         (in, out) -> {
           // 大量データを書き込もうとして、後段が失敗したときにブロックしないことを確認
@@ -202,8 +203,8 @@ class StreamConverterTest {
     InputStream input = new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8));
     OutputStream output = new ByteArrayOutputStream();
 
-    StreamProcessingException ex =
-        assertThrows(StreamProcessingException.class, () -> converter.run(input, output));
+    RuntimeException ex = assertThrows(RuntimeException.class, () -> converter.run(input, output));
+    assertEquals("Downstream failed immediately", ex.getMessage(), "後段の失敗例外がラップされずそのまま伝播すること");
     assertFalse(
         StreamConverter.isPipeAbortedCause(ex),
         "Root cause should not be a pipe-aborted cause. Got: " + ex);
@@ -233,8 +234,8 @@ class StreamConverterTest {
     InputStream input = new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8));
     OutputStream output = new ByteArrayOutputStream();
 
-    StreamProcessingException ex =
-        assertThrows(StreamProcessingException.class, () -> converter.run(input, output));
+    RuntimeException ex = assertThrows(RuntimeException.class, () -> converter.run(input, output));
+    assertEquals("Middle stage failed", ex.getMessage(), "中段の失敗例外がラップされずそのまま伝播すること");
     assertFalse(
         StreamConverter.isPipeAbortedCause(ex),
         "Root cause should not be a pipe-aborted cause. Got: " + ex);
@@ -265,10 +266,10 @@ class StreamConverterTest {
     InputStream input = new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8));
     OutputStream output = new ByteArrayOutputStream();
 
-    StreamProcessingException ex =
-        assertThrows(StreamProcessingException.class, () -> converter.run(input, output));
+    RuntimeException ex = assertThrows(RuntimeException.class, () -> converter.run(input, output));
 
     // pipe 系の二次エラーではなく、後段の失敗が根本原因として伝播すること
+    assertEquals("Root cause: downstream failed", ex.getMessage(), "後段の失敗例外がラップされずそのまま伝播すること");
     assertFalse(
         StreamConverter.isPipeAbortedCause(ex),
         "Root cause should not be a pipe-aborted cause. Got: " + ex);
@@ -412,9 +413,12 @@ class StreamConverterTest {
     InputStream input = new ByteArrayInputStream("AB".getBytes(StandardCharsets.UTF_8));
     OutputStream output = new ByteArrayOutputStream();
 
-    StreamProcessingException ex =
-        assertThrows(StreamProcessingException.class, () -> converter.run(input, output));
+    RuntimeException ex = assertThrows(RuntimeException.class, () -> converter.run(input, output));
 
+    assertEquals(
+        "Root cause: downstream failed while upstream blocked in read",
+        ex.getMessage(),
+        "後段の失敗例外がラップされずそのまま伝播すること");
     assertFalse(
         StreamConverter.isPipeAbortedCause(ex),
         "Root cause should not be a pipe-aborted cause. Got: " + ex);
@@ -469,7 +473,7 @@ class StreamConverterTest {
 
   @Test
   @Timeout(10)
-  @DisplayName("エラーメッセージにコマンド名が含まれる（命名リグレッション防止）")
+  @DisplayName("suppressed コンテキストにコマンド名が含まれる（命名リグレッション防止）")
   void testErrorMessageContainsConcreteCommandName() throws IOException {
     class FailingCommand implements IStreamCommand {
       @Override
@@ -482,12 +486,13 @@ class StreamConverterTest {
     InputStream input = new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8));
     OutputStream output = new ByteArrayOutputStream();
 
-    StreamProcessingException ex =
-        assertThrows(StreamProcessingException.class, () -> converter.run(input, output));
+    // 例外規定: 失敗例外はラップされず、コマンド名は suppressed コンテキストで報告される
+    RuntimeException ex = assertThrows(RuntimeException.class, () -> converter.run(input, output));
 
     assertTrue(
-        ex.getMessage().contains("FailingCommand"),
-        "エラーメッセージに 'FailingCommand' が含まれるべき: " + ex.getMessage());
+        Arrays.stream(ex.getSuppressed())
+            .anyMatch(s -> String.valueOf(s.getMessage()).contains("FailingCommand")),
+        "suppressed コンテキストに 'FailingCommand' が含まれるべき: " + Arrays.toString(ex.getSuppressed()));
   }
 
   @Test
@@ -504,9 +509,9 @@ class StreamConverterTest {
     InputStream input = new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8));
     OutputStream output = new ByteArrayOutputStream();
 
-    StreamProcessingException ex =
-        assertThrows(StreamProcessingException.class, () -> converter.run(input, output));
+    // 例外規定: RuntimeException はラップされないため、根本原因の例外そのものが伝播する
+    RuntimeException ex = assertThrows(RuntimeException.class, () -> converter.run(input, output));
 
-    assertSame(originalCause, ex.getCause(), "exceptionally コールバックが根本原因を上書きしていないこと");
+    assertSame(originalCause, ex, "exceptionally コールバックが根本原因を上書きしていないこと");
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/UncheckedStreamExceptionTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/UncheckedStreamExceptionTest.java
@@ -1,0 +1,33 @@
+package com.streamconverter;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for UncheckedStreamException. */
+@DisplayName("UncheckedStreamException Tests")
+class UncheckedStreamExceptionTest {
+
+  @Test
+  @DisplayName("getCause()は渡したIOExceptionと同一インスタンスをIOException型で返すこと")
+  void testGetCauseReturnsSameIOExceptionInstance() {
+    IOException original = new IOException("underlying I/O failure");
+
+    UncheckedStreamException exception = new UncheckedStreamException(original);
+
+    IOException cause = exception.getCause();
+    assertSame(original, cause, "getCause()はコンストラクタに渡したIOExceptionと同一インスタンスを返すこと");
+  }
+
+  @Test
+  @DisplayName("cause がnullの場合はNullPointerExceptionになること")
+  void testNullCauseThrowsNullPointerException() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new UncheckedStreamException(null),
+        "cause にnullを渡した場合はNullPointerExceptionがスローされること");
+  }
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/UncheckedStreamExceptionTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/UncheckedStreamExceptionTest.java
@@ -25,9 +25,13 @@ class UncheckedStreamExceptionTest {
   @Test
   @DisplayName("cause がnullの場合はNullPointerExceptionになること")
   void testNullCauseThrowsNullPointerException() {
+    // SpotBugs RV_EXCEPTION_NOT_THROWN 対策: 構築した例外は throw する形にする
+    // （コンストラクタが NullPointerException をスローするため throw には到達しない）
     assertThrows(
         NullPointerException.class,
-        () -> new UncheckedStreamException(null),
+        () -> {
+          throw new UncheckedStreamException(null);
+        },
         "cause にnullを渡した場合はNullPointerExceptionがスローされること");
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** CsvValidateCommandクラスのテスト */

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/FaultReportingReaderTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/FaultReportingReaderTest.java
@@ -1,0 +1,226 @@
+package com.streamconverter.command.impl.csv;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.opencsv.CSVReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for FaultReportingReader. */
+@DisplayName("FaultReportingReader Tests")
+class FaultReportingReaderTest {
+
+  @Test
+  @DisplayName("read()で発生したIOExceptionは伝播し、記録もされること")
+  void testReadSingleCharPropagatesAndRecordsFault() {
+    IOException failure = new IOException("simulated failure on read()");
+    FaultReportingReader reader = new FaultReportingReader(new AlwaysFailingReader(failure));
+
+    IOException thrown = assertThrows(IOException.class, reader::read, "read()の例外がそのまま伝播すること");
+    assertSame(failure, thrown, "read()がスローする例外は下位readerの例外と同一インスタンスであること");
+
+    // The recorded fault must be rethrown (wrapped) on close, proving it was recorded.
+    IOException closeFailure =
+        assertThrows(IOException.class, reader::close, "記録されたfaultがclose()で再スローされること");
+    assertSame(failure, closeFailure.getCause(), "close()がスローする例外のcauseは記録されたfaultであること");
+  }
+
+  @Test
+  @DisplayName("read(char[],int,int)で発生したIOExceptionは伝播し、記録もされること")
+  void testReadBufferPropagatesAndRecordsFault() {
+    IOException failure = new IOException("simulated failure on read(char[],int,int)");
+    FaultReportingReader reader = new FaultReportingReader(new AlwaysFailingReader(failure));
+    char[] buf = new char[16];
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> reader.read(buf, 0, buf.length),
+            "read(char[],int,int)の例外がそのまま伝播すること");
+    assertSame(failure, thrown, "read(char[],int,int)がスローする例外は下位readerの例外と同一インスタンスであること");
+
+    IOException closeFailure =
+        assertThrows(IOException.class, reader::close, "記録されたfaultがclose()で再スローされること");
+    assertSame(failure, closeFailure.getCause(), "close()がスローする例外のcauseは記録されたfaultであること");
+  }
+
+  @Test
+  @DisplayName("黙殺シナリオ: read失敗をEOF扱いした後でもclose()がfaultを伴う例外をスローすること")
+  void testCloseReportsSuppressedFaultAfterCallerTreatsFailureAsEof() throws IOException {
+    IOException failure = new IOException("simulated failure during read");
+    FaultReportingReader reader = new FaultReportingReader(new AlwaysFailingReader(failure));
+    char[] buf = new char[16];
+
+    // Caller catches the IOException and treats it as EOF (the opencsv-like behaviour),
+    // i.e. it does NOT rethrow.
+    try {
+      reader.read(buf, 0, buf.length);
+    } catch (IOException ignored) {
+      // simulate a caller that swallows the failure as if it were EOF
+    }
+
+    IOException closeFailure =
+        assertThrows(IOException.class, reader::close, "黙殺されたfaultはclose()で新たな例外として検出されること");
+    assertSame(failure, closeFailure.getCause(), "close()がスローする例外のcauseは記録されたfaultであること");
+    assertTrue(
+        closeFailure.getMessage().contains(failure.getMessage()),
+        "close()の例外メッセージは記録されたfaultのメッセージを含むこと");
+  }
+
+  @Test
+  @DisplayName("障害が発生しなければclose()は何もスローしないこと")
+  void testCloseDoesNothingWhenNoFaultRecorded() throws IOException {
+    FaultReportingReader reader = new FaultReportingReader(new StringReader("hello"));
+
+    char[] buf = new char[16];
+    int read = reader.read(buf, 0, buf.length);
+    assertEquals(5, read, "正常なreaderからは期待した文字数が読み取れること");
+
+    assertDoesNotThrow(reader::close, "障害が記録されていない場合、close()は例外をスローしないこと");
+  }
+
+  @Test
+  @DisplayName("close()自体が失敗し、かつfault記録済みの場合、close失敗例外にfaultがsuppressedとして付くこと")
+  void testCloseFailureSuppressesRecordedFault() {
+    IOException readFailure = new IOException("simulated read failure");
+    IOException closeFailure = new IOException("simulated close failure");
+    FaultReportingReader reader =
+        new FaultReportingReader(new AlwaysFailingReader(readFailure, closeFailure));
+
+    assertThrows(IOException.class, reader::read, "read()の失敗が伝播すること");
+
+    IOException thrown = assertThrows(IOException.class, reader::close, "close()自体の失敗が伝播すること");
+    assertSame(closeFailure, thrown, "close()がスローする例外はclose失敗の例外そのものであること");
+
+    Throwable[] suppressed = thrown.getSuppressed();
+    assertEquals(1, suppressed.length, "close失敗例外には1件のsuppressed例外が付与されること");
+    assertSame(readFailure, suppressed[0], "suppressedされた例外は記録済みのread失敗であること");
+  }
+
+  @Test
+  @DisplayName("forUtf8(InputStream)はUTF-8コンテンツ(日本語含む)を正しく読めること")
+  void testForUtf8ReadsUtf8Content() throws IOException {
+    String content = "name,note\nAlice,こんにちは\n";
+    ByteArrayInputStream input = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+    FaultReportingReader reader = FaultReportingReader.forUtf8(input);
+    char[] buf = new char[256];
+    int read;
+    StringBuilder result = new StringBuilder();
+    while ((read = reader.read(buf, 0, buf.length)) != -1) {
+      result.append(buf, 0, read);
+    }
+    reader.close();
+
+    assertEquals(content, result.toString(), "forUtf8で読み込んだ内容はUTF-8として元の文字列と一致すること");
+  }
+
+  @Test
+  @DisplayName("opencsv実証: readNext()がnullを返して握りつぶしても、close()で記録済み障害がスローされること")
+  void testOpenCsvSwallowsReadFailureButCloseDetectsIt() throws IOException {
+    // The whole content fits in CSVReader's internal BufferedReader in a single underlying
+    // read(char[],int,int) call, so the header row and the data row are both served from that
+    // buffer without any further calls to the underlying reader.
+    String csvData = "name,age\nAlice,30\n";
+    IOException simulatedFailure = new IOException("simulated disk failure");
+    FailAfterFirstReadReader failingReader =
+        new FailAfterFirstReadReader(csvData, simulatedFailure);
+    FaultReportingReader faultReportingReader = new FaultReportingReader(failingReader);
+
+    IOException closeFailure =
+        assertThrows(
+            IOException.class,
+            () -> {
+              try (CSVReader csvReader = new CSVReader(faultReportingReader)) {
+                // First call returns the header row, served from the initial buffer fill.
+                String[] headers = csvReader.readNext();
+                assertArrayEquals(new String[] {"name", "age"}, headers, "1行目のヘッダーは正常に読めること");
+
+                // Second call returns the data row, also served from the initial buffer fill.
+                String[] dataRow = csvReader.readNext();
+                assertArrayEquals(new String[] {"Alice", "30"}, dataRow, "2行目のデータ行は正常に読めること");
+
+                // Third call: the buffer is exhausted, so CSVReader's verifyReader check
+                // (isClosed()) triggers another underlying read(char[],int,int), which throws.
+                // opencsv swallows the IOException and reports it as a normal EOF (null).
+                String[] next = csvReader.readNext();
+                assertNull(next, "opencsvはIOExceptionをEOF(null)として握りつぶすこと");
+              }
+              // try-with-resources close() must surface the suppressed I/O failure.
+            },
+            "opencsvが握りつぶしたI/O障害はclose()で検出され、IOExceptionがスローされること");
+
+    assertSame(simulatedFailure, closeFailure.getCause(), "close()でスローされる例外のcauseは記録されたI/O障害であること");
+  }
+
+  /** A {@link Reader} that always fails with a given {@link IOException} on every read call. */
+  private static final class AlwaysFailingReader extends Reader {
+    private final IOException readFailure;
+    private final IOException closeFailure;
+
+    AlwaysFailingReader(IOException readFailure) {
+      this(readFailure, null);
+    }
+
+    AlwaysFailingReader(IOException readFailure, IOException closeFailure) {
+      this.readFailure = readFailure;
+      this.closeFailure = closeFailure;
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+      throw readFailure;
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (closeFailure != null) {
+        throw closeFailure;
+      }
+    }
+  }
+
+  /**
+   * A {@link Reader} that returns CSV data on its first {@code read(char[], int, int)} call and
+   * throws a simulated I/O failure on every subsequent call, mimicking a disk that fails partway
+   * through a read.
+   */
+  private static final class FailAfterFirstReadReader extends Reader {
+    private final String firstChunk;
+    private final IOException subsequentFailure;
+    private boolean firstReadDone;
+
+    FailAfterFirstReadReader(String firstChunk, IOException subsequentFailure) {
+      this.firstChunk = firstChunk;
+      this.subsequentFailure = subsequentFailure;
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+      if (!firstReadDone) {
+        firstReadDone = true;
+        char[] chars = firstChunk.toCharArray();
+        int toCopy = Math.min(len, chars.length);
+        System.arraycopy(chars, 0, cbuf, off, toCopy);
+        return toCopy;
+      }
+      throw subsequentFailure;
+    }
+
+    @Override
+    public void close() {
+      // no-op
+    }
+  }
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/FaultReportingReaderTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/FaultReportingReaderTest.java
@@ -46,7 +46,11 @@ class FaultReportingReaderTest {
     IOException thrown =
         assertThrows(
             IOException.class,
-            () -> reader.read(buf, 0, buf.length),
+            () -> {
+              // SpotBugs RR 対策: 戻り値を使用する（この行は例外をスローするため到達しない）
+              int unexpectedCount = reader.read(buf, 0, buf.length);
+              throw new AssertionError("read が失敗せず " + unexpectedCount + " 文字を返した");
+            },
             "read(char[],int,int)の例外がそのまま伝播すること");
     assertSame(failure, thrown, "read(char[],int,int)がスローする例外は下位readerの例外と同一インスタンスであること");
 
@@ -64,11 +68,14 @@ class FaultReportingReaderTest {
 
     // Caller catches the IOException and treats it as EOF (the opencsv-like behaviour),
     // i.e. it does NOT rethrow.
+    int readCount;
     try {
-      reader.read(buf, 0, buf.length);
+      readCount = reader.read(buf, 0, buf.length);
     } catch (IOException ignored) {
       // simulate a caller that swallows the failure as if it were EOF
+      readCount = -1;
     }
+    assertEquals(-1, readCount, "黙殺シナリオでは読み取り結果がEOF扱いになること");
 
     IOException closeFailure =
         assertThrows(IOException.class, reader::close, "黙殺されたfaultはclose()で新たな例外として検出されること");
@@ -109,6 +116,17 @@ class FaultReportingReaderTest {
   }
 
   @Test
+  @DisplayName("close()は冪等であること: faultを報告した後の2回目のclose()は例外をスローしないこと")
+  void testCloseIsIdempotentAfterReportingFault() {
+    IOException failure = new IOException("simulated read failure");
+    FaultReportingReader reader = new FaultReportingReader(new AlwaysFailingReader(failure));
+
+    assertThrows(IOException.class, reader::read, "read()の失敗が伝播すること");
+    assertThrows(IOException.class, reader::close, "1回目のclose()は記録済みfaultを報告すること");
+    assertDoesNotThrow(reader::close, "2回目のclose()は報告済みfaultを再スローしないこと");
+  }
+
+  @Test
   @DisplayName("forUtf8(InputStream)はUTF-8コンテンツ(日本語含む)を正しく読めること")
   void testForUtf8ReadsUtf8Content() throws IOException {
     String content = "name,note\nAlice,こんにちは\n";
@@ -136,13 +154,16 @@ class FaultReportingReaderTest {
     IOException simulatedFailure = new IOException("simulated disk failure");
     FailAfterFirstReadReader failingReader =
         new FailAfterFirstReadReader(csvData, simulatedFailure);
-    FaultReportingReader faultReportingReader = new FaultReportingReader(failingReader);
 
     IOException closeFailure =
         assertThrows(
             IOException.class,
             () -> {
-              try (CSVReader csvReader = new CSVReader(faultReportingReader)) {
+              // FaultReportingReader 自身も resource として登録する（SpotBugs OS 対策）。
+              // CSVReader.close() が先に閉じるが、close() は冪等なので二重 close は安全
+              try (FaultReportingReader faultReportingReader =
+                      new FaultReportingReader(failingReader);
+                  CSVReader csvReader = new CSVReader(faultReportingReader)) {
                 // First call returns the header row, served from the initial buffer fill.
                 String[] headers = csvReader.readNext();
                 assertArrayEquals(new String[] {"name", "age"}, headers, "1行目のヘッダーは正常に読めること");

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/FaultReportingReaderTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/FaultReportingReaderTest.java
@@ -152,16 +152,16 @@ class FaultReportingReaderTest {
     // buffer without any further calls to the underlying reader.
     String csvData = "name,age\nAlice,30\n";
     IOException simulatedFailure = new IOException("simulated disk failure");
-    FailAfterFirstReadReader failingReader =
-        new FailAfterFirstReadReader(csvData, simulatedFailure);
 
     IOException closeFailure =
         assertThrows(
             IOException.class,
             () -> {
-              // FaultReportingReader 自身も resource として登録する（SpotBugs OS 対策）。
-              // CSVReader.close() が先に閉じるが、close() は冪等なので二重 close は安全
-              try (FaultReportingReader faultReportingReader =
+              // 各 Reader を resource として登録する（SpotBugs OS 対策）。
+              // CSVReader.close() が先に内側を閉じるが、close() は冪等なので二重 close は安全
+              try (FailAfterFirstReadReader failingReader =
+                      new FailAfterFirstReadReader(csvData, simulatedFailure);
+                  FaultReportingReader faultReportingReader =
                       new FaultReportingReader(failingReader);
                   CSVReader csvReader = new CSVReader(faultReportingReader)) {
                 // First call returns the header row, served from the initial buffer fill.


### PR DESCRIPTION
## 概要

issue #786 Phase 2: 例外規定（`docs/reference/EXCEPTION_POLICY.md`・**PR #789 に依存**）の共通機構を実装します。

確定方針（https://github.com/3211133/StreamConverter/issues/786#issuecomment-4686252916、Codex plan-review 承認済み）の Phase 2 スコープです。

## 変更内容

### 新設クラス（streamconverter-core）

| クラス | 役割 |
|---|---|
| `InvalidInputDataException extends StreamProcessingException` | 分類 A（入力データ不正）専用の checked 例外型 |
| `UncheckedStreamException extends RuntimeException` | IOException を unchecked 境界（Runnable / IRule）越しに運ぶ内部キャリア。`java.io.UncheckedIOException` と同パターン。境界で必ず unwrap される |
| `FaultReportingReader extends FilterReader`（package-private） | opencsv が黙殺する read 中の IOException を記録し、close() 時に必ず再スローする CSV 連携ヘルパー。close() は冪等（CSVReader との二重 close 安全）。**#783/#784 修正の基盤** |
| `StageFailureContext extends Exception`（package-private） | 伝播例外の型・メッセージを変えずにコマンド名を suppressed で記録する軽量マーカー |

### 境界送出規約の適用

- `CommandStageRunner.toStageFailure()`: 一律 `StreamProcessingException` 包み直し → **分類別送出**に変更
  - 分類 A/B（IOException 系）: 元の型のままキャリアで境界を越え、`PipelineFailureHandler` で unwrap されて素の型で伝播
  - 分類 C（RuntimeException）: 実装バグとして包み直さず素通し
  - コマンド名はラッパーメッセージではなく suppressed `StageFailureContext` で付加
  - `sneakyThrow` を削除
- `PipelineFailureHandler`: root cause 抽出時にキャリアを unwrap

### テスト

- 新規 25 件（例外型 6 + FaultReportingReader 8 + 既存更新 7 + 他）。**opencsv 5.12.0 実機実証テスト**を含む: `readNext()` が I/O 障害を null（EOF）として握りつぶしても、try-with-resources の close() で記録済み障害が必ずスローされることを証明
- 既存テスト 7 件を新送出規約に更新（`StreamConverterTest` 6 件、`StreamConverterMDCIntegrationTest` 1 件）

## ⚠️ BREAKING CHANGE

`StreamConverter.run()` はコマンドの失敗を `StreamProcessingException` に包み直さなくなりました：

- コマンドがスローした `IOException`（環境障害）→ **素の IOException のまま**伝播
- コマンドがスローした `RuntimeException`（実装バグ）→ **そのまま**伝播（`catch (IOException)` では捕捉されなくなる）
- どのコマンドが失敗したかは `getSuppressed()` のコンテキスト、または最外層 `withLogging` の失敗ログ（従来通りコマンド名付き）で特定

streamconverter-web は `catch (IOException)` で受けているため、コマンド由来の RuntimeException が素通りするようになりますが、これは規定（分類 C は包み直さない）通りの意図した挙動です。

## Codex code-review 指摘と対応

| 指摘 | 対応 |
|---|---|
| FaultReportingReader が本番コードに未接続 | **意図的な Phase 分割**。CSV コマンド3クラスへの適用は Phase 3（#783/#784 の修正。証明PRマージ後ゲートあり） |
| 例外契約の後方互換なし変更 | plan-review 承認済みの確定方針。本 PR で BREAKING CHANGE として明示 |
| コマンド名が message から suppressed に移り診断性低下 | 確定方針（型を変えず suppressed で付加）通り。`withLogging` の失敗ログには従来通りコマンド名が出る |
| `UncheckedStreamException` が public なのに internal carrier | 別モジュール（streamconverter-db のルール実装）から使用するため public が必要。Javadoc に理由を明記（指摘反映済み） |
| EXCEPTION_POLICY.md が存在しない | **PR #789 に含まれる**（レビュー待ち）。#789 を先にマージ推奨 |

## スコープ外（Phase 3）

- CSV コマンド3クラスへの `FaultReportingReader` 適用（#783/#784 修正）
- `DatabaseFetchRule` / `PooledDatabaseFetchRule` の sneakyThrow 置換、JsonWalker 境界の unwrap（#740/#741）
- #729/#731/#742/#749 の規定準拠対応

## 検証

- pre-commit（spotless・コンパイル・クイックテスト）: 全コミットでパス
- pre-push（full build: test + SpotBugs + PMD + Javadoc、verifyKnownBugs）: パス。SpotBugs/PMD の新規指摘 6 件（RV/RR/OS/NullAssignment）はすべて修正済み。#784 の known-bug テスト2件は期待通り FAILED のまま（バグ未修正の証明を維持）
- Codex code-review 実施済み（指摘への対応は上表）

## 補足

- `CsvValidateCommandTest` の未使用 import 削除（1行）は PR #789 と同一の変更で、pre-commit フックの spotlessApply が強制するため本 PR にも含まれます。#789 マージ後は差分から消えます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
