### PR TITLE
fix: CSV 読み取り中の I/O 障害を EOF として黙殺する問題を修正する (closes #784)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvFilterCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvFilterCommand.java
@@ -7,7 +7,6 @@ import com.streamconverter.command.IStreamCommand;
 import com.streamconverter.path.IColumnSelector;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
@@ -69,8 +68,10 @@ public class CsvFilterCommand implements IStreamCommand {
 
   @Override
   public void execute(InputStream inputStream, OutputStream outputStream) throws IOException {
-    try (CSVReader csvReader =
-            new CSVReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+    // opencsv の readNext() は下位ストリームの IOException を EOF として握りつぶすため、
+    // FaultReportingReader を介して close 時に記録済み障害を必ず再スローする（#784）
+    try (FaultReportingReader reader = FaultReportingReader.forUtf8(inputStream);
+        CSVReader csvReader = new CSVReader(reader);
         CSVWriter csvWriter =
             new CSVWriter(
                 new OutputStreamWriter(outputStream, StandardCharsets.UTF_8),

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
@@ -10,7 +10,6 @@ import com.streamconverter.path.IColumnSelector;
 import com.streamconverter.path.TreePath;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
@@ -90,8 +89,10 @@ public class CsvWalker implements IStreamCommand {
 
   @Override
   public void execute(InputStream inputStream, OutputStream outputStream) throws IOException {
-    try (CSVReader csvReader =
-            new CSVReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+    // opencsv の readNext() は下位ストリームの IOException を EOF として握りつぶすため、
+    // FaultReportingReader を介して close 時に記録済み障害を必ず再スローする（#784）
+    try (FaultReportingReader reader = FaultReportingReader.forUtf8(inputStream);
+        CSVReader csvReader = new CSVReader(reader);
         CSVWriter csvWriter =
             new CSVWriter(
                 new OutputStreamWriter(outputStream, StandardCharsets.UTF_8),

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/FilterCommandBasicTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/FilterCommandBasicTest.java
@@ -602,7 +602,6 @@ class FilterCommandBasicTest {
   }
 
   @Test
-  @Tag("known-bug") // #784
   @DisplayName("CsvFilterCommand: 読み取り中の入力ストリーム I/O 障害は IOException として呼び出し元に伝播する")
   void testCsvFilterCommand_readIoErrorPropagatesAsIOException() throws IOException {
     // ネットワーク切断・パイプ切断等で読み取り途中に I/O 障害が発生した場合、

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** CsvValidateCommandクラスのテスト */

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for CsvWalker. */
@@ -361,7 +360,6 @@ class CsvWalkerTest {
   }
 
   @Test
-  @Tag("known-bug") // #784
   @DisplayName("読み取り中の入力ストリーム I/O 障害は IOException として呼び出し元に伝播する")
   void testReadIoErrorPropagatesAsIOException() throws IOException {
     // ネットワーク切断・パイプ切断等で読み取り途中に I/O 障害が発生した場合、


### PR DESCRIPTION
## 概要

CsvWalker と CsvFilterCommand が読み取り中の I/O 障害を EOF として扱い、切り詰められた出力を正常な処理結果として確定させるバグを修正します。

Closes #784

## ⚠️ スタックPR（ベース: feat/786-exception-policy-phase2）

修正は **PR #790（#786 Phase 2）の `FaultReportingReader` に依存**するため、ベースブランチを `feat/786-exception-policy-phase2` にしています。マージ順序: **#789 → #790 → 本PR**。#790 マージ後、本PRのベースは develop に自動リターゲットされます。

## バグの内容（known-bug テストが証明したこと）

opencsv 5.12.0 の `CSVReader.readNext()` は下位ストリームの `IOException` を伝播せず EOF（null）として握りつぶします。このため両コマンドの `while ((row = readNext()) != null)` ループは I/O 障害と入力終端を区別できず、ヘッダー + Alice 行供給後に障害が起きると **Bob 行を欠いた切り詰め出力を正常終了として確定**させていました（証明 PR #787・マージ済み）。

## 修正アプローチ（Codex plan-review 承認済み）

`FaultReportingReader`（#786 Phase 2 で導入した CSV 連携ヘルパー）を両コマンドの読み取り経路に適用します。

```java
try (FaultReportingReader reader = FaultReportingReader.forUtf8(inputStream);
    CSVReader csvReader = new CSVReader(reader);
    CSVWriter csvWriter = ...) {
```

- read 中の `IOException` を記録し、try-with-resources の close 連鎖で**必ず**新しい `IOException`（cause = 元障害）として再スロー。opencsv が握りつぶしても `execute()` は失敗を報告する
- 素の `IOException` のまま伝播（例外規定の分類 B: 環境障害は型を変えない）
- `FaultReportingReader.close()` は冪等のため CSVReader 経由との二重 close は安全
- 正常系（真の EOF）は fault 未記録のため挙動不変（core 全テストで確認）

## 修正の証明

1. 修正前: `verifyKnownBugs` BUILD SUCCESSFUL（known-bug テスト2件が FAIL = バグ存在）
2. 修正後: **`verifyKnownBugs` BUILD FAILED**（2件が PASS に転換 = バグ修正の客観的証明）
3. `@Tag("known-bug")` を除去してテストを昇格 → core 全 460 件パス
4. pre-push（full build: SpotBugs / PMD / Javadoc 含む）パス

## Codex code-review 指摘（Medium 1件）と見解

> 切り詰め出力の「確定防止」は達成できていない。CSVWriter が先に close/flush されるため、実ストリーム出力では部分出力が書かれた後に IOException になる

**検知（エラー通知）が本修正のスコープ**です。出力の原子性（部分出力の露出防止）は一時バッファ/一時ファイルへの書き出しが必要になり、本ライブラリの中核設計「メモリに全て持たない」（ストリーミング処理）と相反するため、失敗時の出力破棄は呼び出し側・上位層の責務とします。plan-review でも Codex は「二段階書き込みは今回のバグ修正としては過剰。やるなら別テーマ」と判断しています。

## 残課題（本PRのスコープ外）

- `CsvValidateCommand` の同系統問題は #783 として追跡中（証明 PR #785 のマージ待ちゲートのため、スコープ管理上あえて対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
