### PR TITLE
refactor: sneakyThrow を UncheckedStreamException キャリアに置換する (closes #740, #741)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
@@ -110,10 +110,6 @@ public class CsvWalker implements IStreamCommand {
     }
   }
 
-  @SuppressWarnings("PMD.AvoidCatchingGenericException")
-  // IRule.apply() declares no checked exceptions. Rule-layer I/O failures arrive wrapped in the
-  // UncheckedStreamException carrier and are unwrapped at this command boundary (#741); any other
-  // RuntimeException is wrapped as IOException so the caller's error-handling path is not bypassed.
   private void applyRuleToColumn(CSVReader csvReader, CSVWriter csvWriter)
       throws IOException, CsvValidationException {
     String[] headers = csvReader.readNext();
@@ -134,20 +130,28 @@ public class CsvWalker implements IStreamCommand {
     while ((row = csvReader.readNext()) != null) {
       for (int idx : indices) {
         if (idx < row.length) {
-          String transformed;
-          try {
-            transformed = rule.apply(row[idx]);
-          } catch (UncheckedStreamException carrier) {
-            throw carrier.getCause();
-          } catch (RuntimeException ruleEx) {
-            throw new IOException("Rule application failed at column index " + idx, ruleEx);
-          }
-          row[idx] = transformed;
+          row[idx] = applyRule(row[idx], idx);
         }
       }
       // applyQuotesToAll=false: only quote fields that contain delimiters or quotes
       csvWriter.writeNext(row, false);
     }
     csvWriter.flush();
+  }
+
+  @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.PreserveStackTrace"})
+  // IRule.apply() declares no checked exceptions. Rule-layer I/O failures arrive wrapped in the
+  // UncheckedStreamException carrier and are unwrapped at this command boundary (#741); the cause
+  // already records the rule-site stack trace, so discarding the carrier loses no diagnostics.
+  // Any other RuntimeException is wrapped as IOException so the caller's error-handling path is
+  // not bypassed.
+  private String applyRule(String value, int columnIndex) throws IOException {
+    try {
+      return rule.apply(value);
+    } catch (UncheckedStreamException carrier) {
+      throw carrier.getCause();
+    } catch (RuntimeException ruleEx) {
+      throw new IOException("Rule application failed at column index " + columnIndex, ruleEx);
+    }
   }
 }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
@@ -3,6 +3,7 @@ package com.streamconverter.command.impl.csv;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVWriter;
 import com.opencsv.exceptions.CsvValidationException;
+import com.streamconverter.UncheckedStreamException;
 import com.streamconverter.command.IStreamCommand;
 import com.streamconverter.command.rule.IRule;
 import com.streamconverter.path.CSVPath;
@@ -110,8 +111,9 @@ public class CsvWalker implements IStreamCommand {
   }
 
   @SuppressWarnings("PMD.AvoidCatchingGenericException")
-  // IRule.apply() declares no checked exceptions; any RuntimeException must be caught and
-  // re-thrown as IOException so the caller's error-handling path is not bypassed.
+  // IRule.apply() declares no checked exceptions. Rule-layer I/O failures arrive wrapped in the
+  // UncheckedStreamException carrier and are unwrapped at this command boundary (#741); any other
+  // RuntimeException is wrapped as IOException so the caller's error-handling path is not bypassed.
   private void applyRuleToColumn(CSVReader csvReader, CSVWriter csvWriter)
       throws IOException, CsvValidationException {
     String[] headers = csvReader.readNext();
@@ -135,6 +137,8 @@ public class CsvWalker implements IStreamCommand {
           String transformed;
           try {
             transformed = rule.apply(row[idx]);
+          } catch (UncheckedStreamException carrier) {
+            throw carrier.getCause();
           } catch (RuntimeException ruleEx) {
             throw new IOException("Rule application failed at column index " + idx, ruleEx);
           }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonWalker.java
@@ -118,26 +118,28 @@ public class JsonWalker implements IStreamCommand {
     return depth;
   }
 
-  @SuppressWarnings("PMD.AvoidCatchingGenericException")
   private void handleValueString(
       JsonParser parser, JsonGenerator generator, List<String> currentPath) throws IOException {
-    // IRule.apply() declares no checked exceptions. Rule-layer I/O failures arrive wrapped in the
-    // UncheckedStreamException carrier and are unwrapped here at the command boundary (#741);
-    // any other RuntimeException is an implementation failure of the rule and is wrapped with
-    // path context.
     String originalValue = parser.getText();
     if (isMatchingPath(currentPath)) {
-      String transformed;
-      try {
-        transformed = rule.apply(originalValue);
-      } catch (UncheckedStreamException carrier) {
-        throw carrier.getCause();
-      } catch (RuntimeException ruleEx) {
-        throw new IOException("Rule application failed at path " + currentPath, ruleEx);
-      }
-      generator.writeString(transformed);
+      generator.writeString(applyRule(originalValue, currentPath));
     } else {
       generator.writeString(originalValue);
+    }
+  }
+
+  @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.PreserveStackTrace"})
+  // IRule.apply() declares no checked exceptions. Rule-layer I/O failures arrive wrapped in the
+  // UncheckedStreamException carrier and are unwrapped at this command boundary (#741); the cause
+  // already records the rule-site stack trace, so discarding the carrier loses no diagnostics.
+  // Any other RuntimeException is wrapped as IOException with path context.
+  private String applyRule(String value, List<String> currentPath) throws IOException {
+    try {
+      return rule.apply(value);
+    } catch (UncheckedStreamException carrier) {
+      throw carrier.getCause();
+    } catch (RuntimeException ruleEx) {
+      throw new IOException("Rule application failed at path " + currentPath, ruleEx);
     }
   }
 

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonWalker.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.streamconverter.UncheckedStreamException;
 import com.streamconverter.command.IStreamCommand;
 import com.streamconverter.command.rule.IRule;
 import com.streamconverter.path.TreePath;
@@ -120,15 +121,17 @@ public class JsonWalker implements IStreamCommand {
   @SuppressWarnings("PMD.AvoidCatchingGenericException")
   private void handleValueString(
       JsonParser parser, JsonGenerator generator, List<String> currentPath) throws IOException {
-    // IRule.apply() declares no checked exceptions; RuntimeException catch wraps any rule failure.
-    // NOTE: DatabaseFetchRule/PooledDatabaseFetchRule throw StreamProcessingException (IOException)
-    // via sneakyThrow, which escapes this catch. Fix tracked in #741 (IRule.apply throws
-    // IOException).
+    // IRule.apply() declares no checked exceptions. Rule-layer I/O failures arrive wrapped in the
+    // UncheckedStreamException carrier and are unwrapped here at the command boundary (#741);
+    // any other RuntimeException is an implementation failure of the rule and is wrapped with
+    // path context.
     String originalValue = parser.getText();
     if (isMatchingPath(currentPath)) {
       String transformed;
       try {
         transformed = rule.apply(originalValue);
+      } catch (UncheckedStreamException carrier) {
+        throw carrier.getCause();
       } catch (RuntimeException ruleEx) {
         throw new IOException("Rule application failed at path " + currentPath, ruleEx);
       }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlWalker.java
@@ -90,7 +90,7 @@ public class XmlWalker implements IStreamCommand {
     try {
       eventReader = createXMLEventReader(inputStream);
       eventWriter = createXMLEventWriter(outputStream);
-      navigateXmlWithRule(eventReader, eventWriter, treePath, rule);
+      navigateXmlWithRule(eventReader, eventWriter, treePath);
       eventWriter.flush();
     } catch (XMLStreamException e) {
       primaryException = buildXmlException(e);
@@ -107,13 +107,8 @@ public class XmlWalker implements IStreamCommand {
     }
   }
 
-  @SuppressWarnings("PMD.AvoidCatchingGenericException")
-  // IRule.apply() declares no checked exceptions. Rule-layer I/O failures arrive wrapped in the
-  // UncheckedStreamException carrier and are unwrapped at this command boundary (#741); any other
-  // RuntimeException is wrapped as XMLStreamException so the caller's error-handling path is not
-  // bypassed.
   private void navigateXmlWithRule(
-      XMLEventReader eventReader, XMLEventWriter eventWriter, TreePath treePath, IRule rule)
+      XMLEventReader eventReader, XMLEventWriter eventWriter, TreePath treePath)
       throws XMLStreamException, IOException {
     XMLEventFactory eventFactory = XMLEventFactory.newInstance();
     List<String> currentPath = new ArrayList<>();
@@ -132,21 +127,30 @@ public class XmlWalker implements IStreamCommand {
           currentPath.remove(currentPath.size() - 1);
         }
       } else if (event.isCharacters() && treePath.matches(currentPath)) {
-        String data = event.asCharacters().getData();
-        String transformed;
-        try {
-          transformed = rule.apply(data);
-        } catch (UncheckedStreamException carrier) {
-          throw carrier.getCause();
-        } catch (RuntimeException ruleEx) {
-          throw new XMLStreamException("Rule application failed at path " + currentPath, ruleEx);
-        }
+        String transformed = applyRule(event.asCharacters().getData(), currentPath);
         // Write every event unconditionally; character events at the target path are replaced
         // above.
         event = eventFactory.createCharacters(transformed);
       }
 
       eventWriter.add(event);
+    }
+  }
+
+  @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.PreserveStackTrace"})
+  // IRule.apply() declares no checked exceptions. Rule-layer I/O failures arrive wrapped in the
+  // UncheckedStreamException carrier and are unwrapped at this command boundary (#741); the cause
+  // already records the rule-site stack trace, so discarding the carrier loses no diagnostics.
+  // Any other RuntimeException is wrapped as XMLStreamException so the caller's error-handling
+  // path is not bypassed.
+  private String applyRule(String data, List<String> currentPath)
+      throws XMLStreamException, IOException {
+    try {
+      return rule.apply(data);
+    } catch (UncheckedStreamException carrier) {
+      throw carrier.getCause();
+    } catch (RuntimeException ruleEx) {
+      throw new XMLStreamException("Rule application failed at path " + currentPath, ruleEx);
     }
   }
 

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlWalker.java
@@ -1,5 +1,6 @@
 package com.streamconverter.command.impl.xml;
 
+import com.streamconverter.UncheckedStreamException;
 import com.streamconverter.command.IStreamCommand;
 import com.streamconverter.command.rule.IRule;
 import com.streamconverter.path.TreePath;
@@ -93,6 +94,10 @@ public class XmlWalker implements IStreamCommand {
       eventWriter.flush();
     } catch (XMLStreamException e) {
       primaryException = buildXmlException(e);
+    } catch (IOException e) {
+      // ルール層から unwrap された I/O 障害（分類 B）。型を変えず、close 失敗の suppressed 連結
+      // を XMLStreamException 経路と同様に行うため primaryException に乗せる
+      primaryException = e;
     } finally {
       primaryException = XmlStreamResources.closeAll(eventReader, eventWriter, primaryException);
     }
@@ -103,11 +108,13 @@ public class XmlWalker implements IStreamCommand {
   }
 
   @SuppressWarnings("PMD.AvoidCatchingGenericException")
-  // IRule.apply() declares no checked exceptions; any RuntimeException must be caught and
-  // re-thrown as XMLStreamException so the caller's error-handling path is not bypassed.
+  // IRule.apply() declares no checked exceptions. Rule-layer I/O failures arrive wrapped in the
+  // UncheckedStreamException carrier and are unwrapped at this command boundary (#741); any other
+  // RuntimeException is wrapped as XMLStreamException so the caller's error-handling path is not
+  // bypassed.
   private void navigateXmlWithRule(
       XMLEventReader eventReader, XMLEventWriter eventWriter, TreePath treePath, IRule rule)
-      throws XMLStreamException {
+      throws XMLStreamException, IOException {
     XMLEventFactory eventFactory = XMLEventFactory.newInstance();
     List<String> currentPath = new ArrayList<>();
 
@@ -129,6 +136,8 @@ public class XmlWalker implements IStreamCommand {
         String transformed;
         try {
           transformed = rule.apply(data);
+        } catch (UncheckedStreamException carrier) {
+          throw carrier.getCause();
         } catch (RuntimeException ruleEx) {
           throw new XMLStreamException("Rule application failed at path " + currentPath, ruleEx);
         }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** CsvValidateCommandクラスのテスト */

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvWalkerTest.java
@@ -5,11 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.opencsv.CSVReader;
 import com.opencsv.exceptions.CsvValidationException;
+import com.streamconverter.StreamProcessingException;
+import com.streamconverter.UncheckedStreamException;
 import com.streamconverter.command.rule.PassThroughRule;
 import com.streamconverter.path.CSVPath;
 import com.streamconverter.test.StreamingTestUtils.MonitoringOutputStream;
@@ -427,5 +430,28 @@ class CsvWalkerTest {
         IOException.class,
         () -> csvWalker.execute(input, output),
         "存在しない列の指定は IOException をスローするべきだが、IStreamCommand.execute() 契約に違反する例外が伝播する");
+  }
+
+  @Test
+  @DisplayName("[#741] ルール層の UncheckedStreamException キャリアは境界で unwrap され IOException として伝播する")
+  void testRuleCarrierIsUnwrappedToIOException() {
+    StreamProcessingException ruleFailure =
+        new StreamProcessingException("simulated rule I/O failure");
+    CsvWalker walker =
+        CsvWalker.create(
+            CSVPath.of("name"),
+            input -> {
+              throw new UncheckedStreamException(ruleFailure);
+            });
+    ByteArrayInputStream input =
+        new ByteArrayInputStream("name,age\nAlice,30\n".getBytes(StandardCharsets.UTF_8));
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> walker.execute(input, output),
+            "ルール層の I/O 失敗キャリアは IOException として伝播すること");
+    assertSame(ruleFailure, thrown, "キャリアの cause がラップされずそのまま伝播すること");
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/json/JsonWalkerTest.java
@@ -3,9 +3,12 @@ package com.streamconverter.command.impl.json;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.streamconverter.StreamProcessingException;
+import com.streamconverter.UncheckedStreamException;
 import com.streamconverter.command.rule.PassThroughRule;
 import com.streamconverter.command.rule.TestRule;
 import com.streamconverter.path.TreePath;
@@ -309,5 +312,28 @@ class JsonWalkerTest {
         "product_code values should be transformed via $.orders[*].product_code path");
     // order_id should be preserved untouched
     assertTrue(result.contains("ORD-001"), "order_id should be preserved");
+  }
+
+  @Test
+  @DisplayName("[#741] ルール層の UncheckedStreamException キャリアは境界で unwrap され IOException として伝播する")
+  void testRuleCarrierIsUnwrappedToIOException() {
+    StreamProcessingException ruleFailure =
+        new StreamProcessingException("simulated rule I/O failure");
+    JsonWalker walker =
+        JsonWalker.create(
+            TreePath.fromJson("$.test"),
+            input -> {
+              throw new UncheckedStreamException(ruleFailure);
+            });
+    InputStream input =
+        new ByteArrayInputStream("{\"test\":\"value\"}".getBytes(StandardCharsets.UTF_8));
+    OutputStream output = new ByteArrayOutputStream();
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> walker.execute(input, output),
+            "ルール層の I/O 失敗キャリアは IOException として伝播すること");
+    assertSame(ruleFailure, thrown, "キャリアの cause がラップされずそのまま伝播すること");
   }
 }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/XmlWalkerTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/xml/XmlWalkerTest.java
@@ -3,9 +3,12 @@ package com.streamconverter.command.impl.xml;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.streamconverter.StreamProcessingException;
+import com.streamconverter.UncheckedStreamException;
 import com.streamconverter.command.rule.PassThroughRule;
 import com.streamconverter.path.TreePath;
 import java.io.ByteArrayInputStream;
@@ -430,5 +433,30 @@ class XmlWalkerTest {
     assertFalse(
         hasStaticFinalEventFactory,
         "XMLEventFactory should not be held as static final field — thread safety is not guaranteed by the spec");
+  }
+
+  @Test
+  @DisplayName("[#741] ルール層の UncheckedStreamException キャリアは境界で unwrap され IOException として伝播する")
+  void testRuleCarrierIsUnwrappedToIOException() {
+    StreamProcessingException ruleFailure =
+        new StreamProcessingException("simulated rule I/O failure");
+    XmlWalker walker =
+        XmlWalker.create(
+            TreePath.fromXml("root/item"),
+            input -> {
+              throw new UncheckedStreamException(ruleFailure);
+            });
+    InputStream input =
+        new ByteArrayInputStream(
+            "<?xml version=\"1.0\"?><root><item>value</item></root>"
+                .getBytes(StandardCharsets.UTF_8));
+    OutputStream output = new ByteArrayOutputStream();
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> walker.execute(input, output),
+            "ルール層の I/O 失敗キャリアは IOException として伝播すること");
+    assertSame(ruleFailure, thrown, "キャリアの cause がラップされずそのまま伝播すること");
   }
 }

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
@@ -130,6 +130,9 @@ public class DatabaseFetchRule implements IRule {
    *
    * @param input 変換対象の文字列（クエリパラメータとして使用）
    * @return String output クエリ結果の先頭値、または空文字列（結果がない場合）
+   * @throws UncheckedStreamException SQLException が発生した場合、{@link StreamProcessingException} を cause
+   *     として持つキャリアとしてスローされる。コマンド境界（Walker）で IOException として unwrap される。 このメソッドを直接呼び出す場合は呼び出し側が
+   *     unwrap する責務を負う
    */
   @Override
   public String apply(String input) {

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
@@ -1,6 +1,7 @@
 package com.streamconverter.command.rule;
 
 import com.streamconverter.StreamProcessingException;
+import com.streamconverter.UncheckedStreamException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -203,13 +204,8 @@ public class DatabaseFetchRule implements IRule {
           logger.error("クローズ中に追加のエラーが発生しました: {}", s.getMessage(), s);
         }
       }
-      sneakyThrow(new StreamProcessingException("データベースフェッチに失敗しました: " + e.getMessage(), e));
-      throw new AssertionError("unreachable");
+      throw new UncheckedStreamException(
+          new StreamProcessingException("データベースフェッチに失敗しました: " + e.getMessage(), e));
     }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T extends Throwable> void sneakyThrow(Throwable t) throws T {
-    throw (T) t;
   }
 }

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseFetchRule.java
@@ -200,13 +200,8 @@ public class DatabaseFetchRule implements IRule {
         return value;
       }
     } catch (SQLException e) {
-      logger.error("データベース操作中にエラーが発生しました: {}", e.getMessage(), e);
-      Throwable[] suppressed = e.getSuppressed();
-      if (suppressed != null) {
-        for (Throwable s : suppressed) {
-          logger.error("クローズ中に追加のエラーが発生しました: {}", s.getMessage(), s);
-        }
-      }
+      // 例外規定のログ規約: ルール層での log&rethrow は禁止。SQLException（suppressed 含む）は
+      // cause チェーンとして伝播し、最終的に withLogging がスタックトレース付きで記録する
       throw new UncheckedStreamException(
           new StreamProcessingException("データベースフェッチに失敗しました: " + e.getMessage(), e));
     }

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
@@ -118,13 +118,8 @@ public class PooledDatabaseFetchRule implements IRule {
       }
 
     } catch (SQLException e) {
-      logger.error("Database operation failed (pooled connection): {}", e.getMessage(), e);
-      Throwable[] suppressed = e.getSuppressed();
-      if (suppressed != null) {
-        for (Throwable s : suppressed) {
-          logger.error("Additional error during close: {}", s.getMessage(), s);
-        }
-      }
+      // 例外規定のログ規約: ルール層での log&rethrow は禁止。SQLException（suppressed 含む）は
+      // cause チェーンとして伝播し、最終的に withLogging がスタックトレース付きで記録する
       throw new UncheckedStreamException(
           new StreamProcessingException("Database fetch failed: " + e.getMessage(), e));
     }

--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/PooledDatabaseFetchRule.java
@@ -1,6 +1,7 @@
 package com.streamconverter.command.rule;
 
 import com.streamconverter.StreamProcessingException;
+import com.streamconverter.UncheckedStreamException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -97,7 +98,8 @@ public class PooledDatabaseFetchRule implements IRule {
    *
    * @param input 変換対象の文字列（クエリパラメータとして使用）
    * @return クエリ結果の先頭値、または空文字列（結果がない場合）
-   * @throws StreamProcessingException SQLExceptionが発生した場合
+   * @throws UncheckedStreamException SQLExceptionが発生した場合、{@link StreamProcessingException} を cause
+   *     として持つキャリアとしてスローされる。コマンド境界（Walker）で IOException として unwrap される
    * @throws IllegalArgumentException inputがnullの場合（sanitizeInput経由）
    */
   @Override
@@ -123,14 +125,9 @@ public class PooledDatabaseFetchRule implements IRule {
           logger.error("Additional error during close: {}", s.getMessage(), s);
         }
       }
-      sneakyThrow(new StreamProcessingException("Database fetch failed: " + e.getMessage(), e));
-      throw new AssertionError("unreachable");
+      throw new UncheckedStreamException(
+          new StreamProcessingException("Database fetch failed: " + e.getMessage(), e));
     }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T extends Throwable> void sneakyThrow(Throwable t) throws T {
-    throw (T) t;
   }
 
   /** クエリにプレースホルダーがある場合に入力値をバインドする。拒否すべき入力なら false を返す。 */

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseFetchRuleTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseFetchRuleTest.java
@@ -1,12 +1,14 @@
 package com.streamconverter.command.rule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.streamconverter.StreamProcessingException;
+import com.streamconverter.UncheckedStreamException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -204,11 +206,16 @@ public class DatabaseFetchRuleTest {
       // テスト対象のインスタンスを作成
       DatabaseFetchRule rule = new DatabaseFetchRule(databaseUrl, query);
 
-      // SQLエラーは StreamProcessingException としてスローされることを検証
-      assertThrows(
+      // SQLエラーは UncheckedStreamException（cause=StreamProcessingException）としてスローされることを検証
+      UncheckedStreamException thrown =
+          assertThrows(
+              UncheckedStreamException.class,
+              () -> rule.apply(input),
+              "SQLエラーが発生した場合は UncheckedStreamException がスローされること");
+      assertInstanceOf(
           StreamProcessingException.class,
-          () -> rule.apply(input),
-          "SQLエラーが発生した場合は StreamProcessingException がスローされること");
+          thrown.getCause(),
+          "UncheckedStreamException の cause は StreamProcessingException であること");
     }
   }
 

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/PooledDatabaseFetchRuleIntegrationTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/PooledDatabaseFetchRuleIntegrationTest.java
@@ -1,10 +1,12 @@
 package com.streamconverter.command.rule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.streamconverter.StreamProcessingException;
+import com.streamconverter.UncheckedStreamException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
@@ -279,10 +281,15 @@ public class PooledDatabaseFetchRuleIntegrationTest {
     // プールをシャットダウン
     testPool.close();
 
-    // シャットダウン後は StreamProcessingException がスローされることを確認
-    assertThrows(
+    // シャットダウン後は UncheckedStreamException（cause=StreamProcessingException）がスローされることを確認
+    UncheckedStreamException thrown =
+        assertThrows(
+            UncheckedStreamException.class,
+            () -> rule.apply("2"),
+            "Should throw UncheckedStreamException after pool shutdown");
+    assertInstanceOf(
         StreamProcessingException.class,
-        () -> rule.apply("2"),
-        "Should throw StreamProcessingException after pool shutdown");
+        thrown.getCause(),
+        "UncheckedStreamException の cause は StreamProcessingException であること");
   }
 }


### PR DESCRIPTION
## 概要

IRule 実装の checked 例外伝搬を `UncheckedStreamException` キャリア方式に統一し、`sneakyThrow` をリポジトリ全体から全廃します。

Closes #740
Closes #741

## ⚠️ スタックPR（ベース: feat/786-exception-policy-phase2）

`UncheckedStreamException` は **PR #790（#786 Phase 2）で導入**のため、ベースを `feat/786-exception-policy-phase2` にしています。PR #791 と並列のスタックです（変更ファイルのハンクは重複なし）。マージ順序: **#789 → #790 → 本PR / #791（順不同）**。

## 変更内容

### ルール側（streamconverter-db）— #740

- `DatabaseFetchRule` / `PooledDatabaseFetchRule`: SQLException 時の `sneakyThrow(StreamProcessingException) + AssertionError("unreachable")` を `throw new UncheckedStreamException(new StreamProcessingException(...))` に置換し、`sneakyThrow` メソッドを削除
- `grep -rn sneakyThrow` で全モジュール残存ゼロを確認（CommandStageRunner 分は #790 で削除済み）

### 境界側（streamconverter-core の Walker 3クラス）— #741

- `CsvWalker` / `JsonWalker` / `XmlWalker` のルール適用を `applyRule` ヘルパーに抽出し、`catch (UncheckedStreamException) → throw carrier.getCause()` を追加。**ルール層の I/O 障害が IOException のまま型を変えずに伝播**する
- `XmlWalker` は `navigateXmlWithRule` に `throws IOException` を追加し、`execute()` で catch して `primaryException` 経路に乗せる（close 失敗の suppressed 連結を `XMLStreamException` 経路と統一）
- `JsonWalker` の古い NOTE コメント（sneakyThrow がこの catch をすり抜ける問題＝#741 の言及）を解消後の記述に更新
- `ChainRule` は catch を持たないためキャリアは素通し（変更不要）

### #741 の決着

`IRule.apply()` への `throws IOException` 追加（公開関数型インターフェースの破壊的変更）は**行いません**。キャリア＋境界 unwrap が規定（EXCEPTION_POLICY.md）の解決策であり、将来 checked 例外を型で表現する場合は `ThrowingRule` 等の別インターフェース追加を本命とします。

## テスト

- Walker 3クラスに境界 unwrap テストを追加（キャリアの cause が**同一インスタンスのまま** IOException として伝播することを `assertSame` で検証）
- db テスト2件を `UncheckedStreamException` 期待 + cause 検証に更新
- core 461 件・db 39 件全パス。pre-push（full build + verifyKnownBugs）パス

## Codex code-review 指摘と見解

> `UncheckedStreamException` が公開 API（db ルールの `apply()`）まで漏れており、実質的な破壊的変更。「公開 API では StreamProcessingException を維持する」か「checked-exception を持てる rule 契約の導入」を検討すべき

**規定通りの意図された契約変更**と判断します：

1. **変更前の挙動こそが欠陥**でした。`sneakyThrow` は宣言なしの checked 例外を投げており、直接呼び出し側は `catch (StreamProcessingException)` を**コンパイルできない**（unreachable catch 扱い）病的な契約だった — これが #740/#741 の起票理由そのものです
2. 「公開 API で SPE を維持」する唯一の手段は sneakyThrow の温存であり #740 と矛盾。「別の rule 契約（ThrowingRule）」は規定で将来の本命として明示的に先送り済み
3. ルール実装は「本体はエンジン、command/rule はサンプル」という本プロジェクトの位置づけであり、破壊的変更の前例（MdcPropagatingRule）に沿う
4. 対応として、両ルールの `apply()` Javadoc に `@throws UncheckedStreamException`（直接呼び出し時は呼び出し側が unwrap する責務）を明文化し、漏洩ではなく documented contract として固定しました

Walker 側の unwrap については Codex も「大きな問題は見当たらない」と評価。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
