### PR TITLE
feat: exception-policy Phase 5 - converter-layer aggregation

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/PipelineFailureHandler.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/PipelineFailureHandler.java
@@ -9,52 +9,77 @@ import java.util.concurrent.ExecutionException;
 /** Translates stage failures into the exception surfaced by {@link StreamConverter}. */
 final class PipelineFailureHandler {
   /**
-   * Re-throws the primary execution failure after all stage futures have been inspected.
+   * Rethrows the pipeline failure after inspecting all completed stage futures.
    *
-   * <p>Secondary failures are attached as suppressed exceptions, while pipe-aborted failures are
-   * treated as downstream consequences and filtered out.
+   * <p>Classified failures ({@link StreamProcessingException} subtypes) are aggregated into a
+   * single {@link AggregatedStreamProcessingException} before being thrown. Unclassified failures
+   * ({@link Error}, {@link RuntimeException}, raw {@link IOException}) propagate unchanged — their
+   * handling in the converter layer is an open question tracked in issue #797 §4.1.1 and no
+   * decision has been made yet.
+   *
+   * <p>Pipe-aborted failures (secondary consequences of another stage's failure) are filtered out
+   * regardless of classification.
    *
    * @param executionException failure reported by {@code CompletableFuture.allOf(...).get()}
    * @param futures completed stage futures to inspect
-   * @throws IOException if the primary root cause is an I/O failure
+   * @throws AggregatedStreamProcessingException when all independent failures are classified
+   * @throws IOException (and its subtypes) for unclassified or empty-collection fallback
    */
   void rethrowExecutionFailure(
       ExecutionException executionException, List<CompletableFuture<Void>> futures)
       throws IOException {
-    List<Throwable> rootCauses = collectRootCauses(futures);
-    if (rootCauses.isEmpty()) {
-      throw new InternalSystemException(
-          "コマンド実行中に予期せぬエラーが発生しました", unwrapCarrier(executionException.getCause()));
+    CollectedFailures collected = collectIndependentFailures(futures);
+
+    // Unclassified failures propagate unchanged (§4.1.1 open question).
+    if (collected.unclassified != null) {
+      throwRaw(collected.unclassified);
     }
 
-    Throwable primary = rootCauses.get(0);
-    for (int i = 1; i < rootCauses.size(); i++) {
-      primary.addSuppressed(rootCauses.get(i));
+    if (collected.classified.isEmpty()) {
+      // No independent failures could be identified; fall back to the original cause.
+      Throwable rawCause = unwrapCarrier(executionException.getCause());
+      if (rawCause instanceof StreamProcessingException spe) {
+        throw new AggregatedStreamProcessingException(List.of(spe));
+      }
+      throwRaw(rawCause);
+      // Unreachable in practice; guards against an unknown Throwable subtype.
+      throw new InternalSystemException("コマンド実行中に予期せぬエラーが発生しました", rawCause);
     }
 
-    throwPrimary(primary);
+    throw new AggregatedStreamProcessingException(collected.classified);
   }
 
-  private static void throwPrimary(Throwable primary) throws IOException {
-    if (primary instanceof Error err) {
+  private static void throwRaw(Throwable cause) throws IOException {
+    if (cause instanceof Error err) {
       throw err;
     }
-    if (primary instanceof IOException ioe) {
+    if (cause instanceof IOException ioe) {
       throw ioe;
     }
-    if (primary instanceof RuntimeException re) {
+    if (cause instanceof RuntimeException re) {
       throw re;
     }
-    throw new InternalSystemException("コマンド実行中に予期せぬエラーが発生しました", primary);
+    throw new InternalSystemException("コマンド実行中に予期せぬエラーが発生しました", cause);
+  }
+
+  /** Holder for the two categories of independent failures found across stage futures. */
+  private static final class CollectedFailures {
+    final List<StreamProcessingException> classified = new ArrayList<>();
+
+    /** The first unclassified failure encountered, or null if all were classified. */
+    Throwable unclassified;
   }
 
   /**
-   * Collects non-secondary failures from already completed stage futures.
+   * Inspects all completed stage futures and separates failures into classified vs. unclassified.
    *
-   * <p>Callers are expected to wait for all futures first so the collected failure set is stable.
+   * <p>Pipe-aborted secondary failures are filtered before categorization. Classified failures
+   * ({@link StreamProcessingException} subtypes) are collected for aggregation. The first
+   * unclassified failure short-circuits further collection and is returned as {@code
+   * CollectedFailures#unclassified}.
    */
-  private List<Throwable> collectRootCauses(List<CompletableFuture<Void>> futures) {
-    List<Throwable> rootCauses = new ArrayList<>();
+  private CollectedFailures collectIndependentFailures(List<CompletableFuture<Void>> futures) {
+    CollectedFailures result = new CollectedFailures();
     for (CompletableFuture<Void> future : futures) {
       if (!future.isCompletedExceptionally()) {
         continue;
@@ -63,15 +88,22 @@ final class PipelineFailureHandler {
         future.get();
       } catch (ExecutionException executionException) {
         Throwable cause = unwrapCarrier(executionException.getCause());
-        if (!isPipeAbortedCause(cause)) {
-          rootCauses.add(cause);
+        if (isPipeAbortedCause(cause)) {
+          continue;
+        }
+        if (cause instanceof StreamProcessingException spe) {
+          result.classified.add(spe);
+        } else {
+          result.unclassified = cause;
+          return result;
         }
       } catch (InterruptedException interruptedException) {
         Thread.currentThread().interrupt();
-        rootCauses.add(interruptedException);
+        result.classified.add(
+            new InternalSystemException("コマンド実行中に予期せぬエラーが発生しました", interruptedException));
       }
     }
-    return rootCauses;
+    return result;
   }
 
   /**

--- a/streamconverter-core/src/test/java/com/streamconverter/StreamConverterMDCIntegrationTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/StreamConverterMDCIntegrationTest.java
@@ -272,8 +272,9 @@ class StreamConverterMDCIntegrationTest {
   }
 
   @Test
-  void testStreamProcessingExceptionIsNotDoubleWrapped() {
-    // コマンドが StreamProcessingException を投げたとき、同じ例外がそのまま伝播する（二重ラップなし）
+  void testStreamProcessingExceptionIsAggregatedNotDoubleWrapped() {
+    // Phase 5: 分類済み例外は AggregatedStreamProcessingException にラップされて届く。
+    // getAllFailures() の要素が同一オブジェクトであること（Aggregated の入れ子でないこと）を検証する。
     StreamProcessingException original = new StreamProcessingException("original error");
     IStreamCommand failingCommand =
         (in, out) -> {
@@ -282,15 +283,16 @@ class StreamConverterMDCIntegrationTest {
 
     StreamConverter converter = StreamConverter.create(failingCommand);
 
-    StreamProcessingException thrown =
+    AggregatedStreamProcessingException thrown =
         assertThrows(
-            StreamProcessingException.class,
+            AggregatedStreamProcessingException.class,
             () ->
                 converter.run(
                     new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8)),
                     new ByteArrayOutputStream()));
 
-    assertSame(original, thrown, "StreamProcessingException must not be double-wrapped");
+    assertEquals(1, thrown.getAllFailures().size(), "単一失敗もリスト化される");
+    assertSame(original, thrown.getAllFailures().get(0), "元の例外が二重ラップなしで格納される");
   }
 
   @Test

--- a/streamconverter-core/src/test/java/com/streamconverter/StreamConverterTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/StreamConverterTest.java
@@ -428,6 +428,68 @@ class StreamConverterTest {
   // isPipeAbortedCause のカバレッジテスト
   // -------------------------------------------------------------------------
 
+  // -------------------------------------------------------------------------
+  // Phase 5: AggregatedStreamProcessingException aggregation tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  @Timeout(10)
+  @DisplayName("UserInputException from command is wrapped in AggregatedStreamProcessingException")
+  void testClassifiedFailureIsAggregated() {
+    UserInputException original = new UserInputException("入力データが不正です");
+    IStreamCommand failingCommand =
+        (in, out) -> {
+          throw original;
+        };
+
+    StreamConverter converter = StreamConverter.create(failingCommand);
+    InputStream input = new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8));
+    OutputStream output = new ByteArrayOutputStream();
+
+    AggregatedStreamProcessingException ex =
+        assertThrows(AggregatedStreamProcessingException.class, () -> converter.run(input, output));
+    assertEquals(1, ex.getAllFailures().size(), "単一失敗もリスト化される");
+    assertSame(original, ex.getAllFailures().get(0), "元の例外がそのまま格納される");
+  }
+
+  @Test
+  @Timeout(10)
+  @DisplayName(
+      "InternalSystemException from command is wrapped in AggregatedStreamProcessingException")
+  void testInternalSystemExceptionIsAggregated() {
+    IStreamCommand failingCommand =
+        (in, out) -> {
+          throw new InternalSystemException("内部障害が発生しました");
+        };
+
+    StreamConverter converter = StreamConverter.create(failingCommand);
+    InputStream input = new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8));
+    OutputStream output = new ByteArrayOutputStream();
+
+    AggregatedStreamProcessingException ex =
+        assertThrows(AggregatedStreamProcessingException.class, () -> converter.run(input, output));
+    assertEquals(1, ex.getAllFailures().size());
+    assertInstanceOf(InternalSystemException.class, ex.getAllFailures().get(0));
+  }
+
+  @Test
+  @Timeout(10)
+  @DisplayName("Unclassified RuntimeException still propagates unwrapped (§4.1.1 open)")
+  void testUnclassifiedRuntimeExceptionPropagatesUnwrapped() {
+    RuntimeException original = new RuntimeException("unclassified failure");
+    IStreamCommand failingCommand =
+        (in, out) -> {
+          throw original;
+        };
+
+    StreamConverter converter = StreamConverter.create(failingCommand);
+    InputStream input = new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8));
+    OutputStream output = new ByteArrayOutputStream();
+
+    RuntimeException ex = assertThrows(RuntimeException.class, () -> converter.run(input, output));
+    assertSame(original, ex, "未分類 RuntimeException はラップされないこと（§4.1.1 未決）");
+  }
+
   @Test
   @DisplayName("PipeAbortedException is recognized as pipe-aborted cause")
   void testPipeAbortedExceptionIsSecondaryCause() {


### PR DESCRIPTION
## Summary

実装完了: exception-policy Phase 5

Phase 4 で分類済みの例外型（`UserInputException` / `InternalSystemException` 等）を converter 層で `AggregatedStreamProcessingException` に集約して main 層へ届けるようにした。

## Changes

### `PipelineFailureHandler` — 集約ロジックの実装

`rethrowExecutionFailure` を再設計:

- **分類済み失敗**（`StreamProcessingException` サブタイプ = U/T/A）: すべてを `AggregatedStreamProcessingException` に集約してスロー。単独失敗もリスト要素1件として正規化（main 側の分岐なし）
- **未分類失敗**（`RuntimeException` / 生 `IOException`）: 変更なく伝播（§4.1.1 未決 → issue #797。既存テスト5件がこの動作を文書化）
- **`InterruptedException`**: `InternalSystemException` に昇格してから集約
- **`Error`**: バイパスして直接 rethrow

内部クラス `CollectedFailures` を導入して分類済み/未分類を区別し、未分類を検出した時点で早期リターン。

### テスト更新

- **`StreamConverterTest`**: 3テスト追加
  - `UserInputException` が `AggregatedStreamProcessingException` に集約される
  - `InternalSystemException` が集約される
  - 未分類 `RuntimeException` は §4.1.1 未決としてラップなく伝播する
- **`StreamConverterMDCIntegrationTest`**: `testStreamProcessingExceptionIsNotDoubleWrapped` を Phase 5 後の期待動作に更新（`getAllFailures()` で元の例外が取得できること）

## Test Results

✅ **全テスト通過**
- streamconverter-core: 466/466 tests passed
- pmdMain: 0 violations
- spotbugsMain: no findings

## Stacked PR Note

このPRは `feat/exception-policy-phase4` を基にした Stacked PR です。
- Phase 4 PR #799 がマージされたら、本PR のベースを `develop` にリベースします

## Design Decision Reference

docs/reference/EXCEPTION_POLICY.md § 並行例外集約より:

> 届くのは**1つの `AggregatedStreamProcessingException`** オブジェクト
> 単独失敗時もリスト要素1件として正規化（list 化のオーバーヘッドを払ってでも main 側の場合分けを消す）

**§4.1.1 未決事項（issue #797）**: 未分類 `RuntimeException` を converter が A 化（`InternalSystemException` でラップ）すべきか、そのまま伝播するかは未決定。既存5テストがラップなし動作を文書化しており、#797 の決定後に対応する。

🤖 Generated with Claude Code
