### PR TITLE
feat: implement exception-policy Phase 6 - rule-layer U/T/A classification

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvWalker.java
@@ -141,11 +141,11 @@ public class CsvWalker implements IStreamCommand {
   }
 
   @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.PreserveStackTrace"})
-  // IRule.apply() declares no checked exceptions. Rule-layer I/O failures arrive wrapped in the
-  // UncheckedStreamException carrier and are unwrapped at this command boundary (#741); the cause
-  // already records the rule-site stack trace, so discarding the carrier loses no diagnostics.
-  // Any other RuntimeException is wrapped as IOException so the caller's error-handling path is
-  // not bypassed.
+  // IRule.apply() may throw StreamProcessingException (IOException subtype) — propagates via
+  // throws IOException without wrapping. UncheckedStreamException carrier is unwrapped at this
+  // command boundary (#741); the cause already records the rule-site stack trace. Any other
+  // RuntimeException is wrapped as IOException so the caller's error-handling path is not
+  // bypassed.
   private String applyRule(String value, int columnIndex) throws IOException {
     try {
       return rule.apply(value);

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/json/JsonWalker.java
@@ -129,10 +129,10 @@ public class JsonWalker implements IStreamCommand {
   }
 
   @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.PreserveStackTrace"})
-  // IRule.apply() declares no checked exceptions. Rule-layer I/O failures arrive wrapped in the
-  // UncheckedStreamException carrier and are unwrapped at this command boundary (#741); the cause
-  // already records the rule-site stack trace, so discarding the carrier loses no diagnostics.
-  // Any other RuntimeException is wrapped as IOException with path context.
+  // IRule.apply() may throw StreamProcessingException (IOException subtype) — propagates via
+  // throws IOException without wrapping. UncheckedStreamException carrier is unwrapped at this
+  // command boundary (#741); the cause already records the rule-site stack trace. Any other
+  // RuntimeException is wrapped as IOException with path context.
   private String applyRule(String value, List<String> currentPath) throws IOException {
     try {
       return rule.apply(value);

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlWalker.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/xml/XmlWalker.java
@@ -138,11 +138,11 @@ public class XmlWalker implements IStreamCommand {
   }
 
   @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.PreserveStackTrace"})
-  // IRule.apply() declares no checked exceptions. Rule-layer I/O failures arrive wrapped in the
-  // UncheckedStreamException carrier and are unwrapped at this command boundary (#741); the cause
-  // already records the rule-site stack trace, so discarding the carrier loses no diagnostics.
-  // Any other RuntimeException is wrapped as XMLStreamException so the caller's error-handling
-  // path is not bypassed.
+  // IRule.apply() may throw StreamProcessingException (IOException subtype) — propagates via
+  // throws IOException without wrapping. UncheckedStreamException carrier is unwrapped at this
+  // command boundary (#741); the cause already records the rule-site stack trace. Any other
+  // RuntimeException is wrapped as XMLStreamException so the caller's error-handling path is not
+  // bypassed.
   private String applyRule(String data, List<String> currentPath)
       throws XMLStreamException, IOException {
     try {

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/IRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/IRule.java
@@ -1,5 +1,7 @@
 package com.streamconverter.command.rule;
 
+import com.streamconverter.StreamProcessingException;
+
 /**
  * ルールインターフェース
  *
@@ -11,7 +13,7 @@ package com.streamconverter.command.rule;
  * <p>使用例:
  *
  * <pre>{@code
- * // 単純な変換ルール
+ * // 単純な変換ルール（例外を投げない場合はラムダのまま使用可）
  * IRule upperCaseRule = input -> input.toUpperCase();
  * IRule trimRule = String::trim;
  *
@@ -35,8 +37,12 @@ public interface IRule {
    * <p>このメソッドは、ストリーム変換の際にルールを適用するために使用されます。 具体的なルールの実装は、このメソッドをオーバーライドして定義します。
    * 変換対象とする箇所を特定したあとにこのメソッドを呼び出すことを想定しています。
    *
+   * <p>実装がU/T/A分類済みの例外をスローする場合は {@link StreamProcessingException} のサブタイプを
+   * 直接throwすること。walker層がこれをIOExceptionとして伝播し、converter層が集約する。
+   *
    * @param input 変換対象の文字列
    * @return String output 変換結果を格納する文字列
+   * @throws StreamProcessingException 入力エラー（U）・外部障害（T/A）・内部障害（A）の場合
    */
-  String apply(String input);
+  String apply(String input) throws StreamProcessingException;
 }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/MdcPropagatingRule.java
@@ -1,5 +1,6 @@
 package com.streamconverter.command.rule;
 
+import com.streamconverter.UserInputException;
 import com.streamconverter.context.PipelineContext;
 
 /**
@@ -64,12 +65,12 @@ public final class MdcPropagatingRule implements IRule {
    *
    * @param input 変換対象の文字列
    * @return 入力値をそのまま返す
-   * @throws IllegalArgumentException inputがnullの場合
+   * @throws com.streamconverter.UserInputException inputがnullの場合
    */
   @Override
-  public String apply(String input) {
+  public String apply(String input) throws UserInputException {
     if (input == null) {
-      throw new IllegalArgumentException("Input cannot be null");
+      throw new UserInputException("入力値がnullです");
     }
     PipelineContext.putShared(mdcKey, input);
     return input;

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/PassThroughRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/PassThroughRule.java
@@ -1,5 +1,7 @@
 package com.streamconverter.command.rule;
 
+import com.streamconverter.UserInputException;
+
 /**
  * Pass-through rule implementation
  *
@@ -16,12 +18,12 @@ public class PassThroughRule implements IRule {
    *
    * @param input the input string to process
    * @return the same input string without any modifications
-   * @throws IllegalArgumentException if input is null
+   * @throws UserInputException if input is null
    */
   @Override
-  public String apply(String input) {
+  public String apply(String input) throws UserInputException {
     if (input == null) {
-      throw new IllegalArgumentException("Input cannot be null");
+      throw new UserInputException("入力値がnullです");
     }
     return input;
   }

--- a/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/composite/ChainRule.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/rule/impl/composite/ChainRule.java
@@ -1,5 +1,6 @@
 package com.streamconverter.command.rule.impl.composite;
 
+import com.streamconverter.StreamProcessingException;
 import com.streamconverter.command.rule.IRule;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,14 +46,11 @@ public class ChainRule implements IRule {
   }
 
   @Override
-  public String apply(String input) {
+  public String apply(String input) throws StreamProcessingException {
     String result = input;
-
-    // Apply each rule in sequence
     for (IRule rule : rules) {
       result = rule.apply(result);
     }
-
     return result;
   }
 

--- a/streamconverter-core/src/test/java/com/streamconverter/command/rule/MdcPropagatingRuleTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/rule/MdcPropagatingRuleTest.java
@@ -2,6 +2,8 @@ package com.streamconverter.command.rule;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.streamconverter.StreamProcessingException;
+import com.streamconverter.UserInputException;
 import com.streamconverter.context.PipelineContext;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -20,7 +22,7 @@ class MdcPropagatingRuleTest {
   }
 
   @Test
-  void applyPutsValueIntoSharedContext() {
+  void applyPutsValueIntoSharedContext() throws StreamProcessingException {
     PipelineContext ctx = new PipelineContext();
     PipelineContext.set(ctx);
 
@@ -33,7 +35,7 @@ class MdcPropagatingRuleTest {
   }
 
   @Test
-  void applyReturnsInputUnchanged() {
+  void applyReturnsInputUnchanged() throws StreamProcessingException {
     PipelineContext ctx = new PipelineContext();
     PipelineContext.set(ctx);
 
@@ -48,7 +50,7 @@ class MdcPropagatingRuleTest {
   void applyWithNullInputThrowsException() {
     MdcPropagatingRule rule = MdcPropagatingRule.create("key");
 
-    assertThrows(IllegalArgumentException.class, () -> rule.apply(null));
+    assertThrows(UserInputException.class, () -> rule.apply(null));
   }
 
   @Test
@@ -65,7 +67,7 @@ class MdcPropagatingRuleTest {
 
   @Test
   @DisplayName("create_returnsRuleThatStoresValueInPipelineContext")
-  void create_returnsRuleThatStoresValueInPipelineContext() {
+  void create_returnsRuleThatStoresValueInPipelineContext() throws StreamProcessingException {
     PipelineContext ctx = new PipelineContext();
     PipelineContext.set(ctx);
 
@@ -77,7 +79,7 @@ class MdcPropagatingRuleTest {
   }
 
   @Test
-  void applyWithoutPipelineContextIsNoOp() {
+  void applyWithoutPipelineContextIsNoOp() throws StreamProcessingException {
     MdcPropagatingRule rule = MdcPropagatingRule.create("key");
     String result = rule.apply("value");
 

--- a/streamconverter-core/src/test/java/com/streamconverter/command/rule/PassThroughRuleTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/rule/PassThroughRuleTest.java
@@ -1,0 +1,22 @@
+package com.streamconverter.command.rule;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.streamconverter.UserInputException;
+import org.junit.jupiter.api.Test;
+
+class PassThroughRuleTest {
+
+  @Test
+  void applyReturnsInputUnchanged() throws UserInputException {
+    PassThroughRule rule = new PassThroughRule();
+    assertEquals("hello", rule.apply("hello"));
+    assertEquals("", rule.apply(""));
+  }
+
+  @Test
+  void applyWithNullInputThrowsUserInputException() {
+    PassThroughRule rule = new PassThroughRule();
+    assertThrows(UserInputException.class, () -> rule.apply(null));
+  }
+}

--- a/streamconverter-core/src/test/java/com/streamconverter/command/rule/TestRule.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/rule/TestRule.java
@@ -1,5 +1,6 @@
 package com.streamconverter.command.rule;
 
+import com.streamconverter.StreamProcessingException;
 import java.util.Objects;
 
 /**
@@ -24,7 +25,7 @@ public class TestRule implements IRule {
   }
 
   @Override
-  public String apply(String input) {
+  public String apply(String input) throws StreamProcessingException {
     Objects.requireNonNull(input, "input cannot be null");
     return input.replace(searchPattern, replacement);
   }

--- a/streamconverter-core/src/test/java/com/streamconverter/command/rule/impl/composite/ChainRuleTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/rule/impl/composite/ChainRuleTest.java
@@ -2,6 +2,7 @@ package com.streamconverter.command.rule.impl.composite;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.streamconverter.StreamProcessingException;
 import com.streamconverter.command.rule.IRule;
 import com.streamconverter.command.rule.impl.casing.CamelToSnakeCaseRule;
 import com.streamconverter.command.rule.impl.string.LowerCaseRule;
@@ -13,7 +14,7 @@ import org.junit.jupiter.api.Test;
 class ChainRuleTest {
 
   @Test
-  void testBasicChaining() {
+  void testBasicChaining() throws StreamProcessingException {
     ChainRule rule =
         ChainRule.of(new TrimRule(), CamelToSnakeCaseRule.create(), new LowerCaseRule());
 
@@ -22,7 +23,7 @@ class ChainRuleTest {
   }
 
   @Test
-  void testBuilderPattern() {
+  void testBuilderPattern() throws StreamProcessingException {
     ChainRule rule =
         ChainRule.builder()
             .addRule(new TrimRule())
@@ -34,7 +35,7 @@ class ChainRuleTest {
   }
 
   @Test
-  void testOfMethods() {
+  void testOfMethods() throws StreamProcessingException {
     // Test varargs method
     ChainRule rule1 = ChainRule.of(new TrimRule(), new LowerCaseRule());
     assertEquals("hello", rule1.apply("  HELLO  "));
@@ -45,14 +46,14 @@ class ChainRuleTest {
   }
 
   @Test
-  void testSingleRule() {
+  void testSingleRule() throws StreamProcessingException {
     ChainRule rule = ChainRule.of(new TrimRule());
     assertEquals("hello", rule.apply("  hello  "));
     assertEquals(1, rule.size());
   }
 
   @Test
-  void testNullHandling() {
+  void testNullHandling() throws StreamProcessingException {
     // Test null input
     ChainRule rule = ChainRule.of(new TrimRule(), new LowerCaseRule());
     assertNull(rule.apply(null));
@@ -110,7 +111,7 @@ class ChainRuleTest {
   }
 
   @Test
-  void testComplexTransformation() {
+  void testComplexTransformation() throws StreamProcessingException {
     // Create a complex transformation: trim -> camel to snake -> lowercase
     ChainRule rule =
         ChainRule.builder()
@@ -125,7 +126,7 @@ class ChainRuleTest {
   }
 
   @Test
-  void testGetRules() {
+  void testGetRules() throws StreamProcessingException {
     TrimRule trim = new TrimRule();
     LowerCaseRule lower = new LowerCaseRule();
 
@@ -199,7 +200,7 @@ class ChainRuleTest {
   }
 
   @Test
-  void testCustomRule() {
+  void testCustomRule() throws StreamProcessingException {
     // Create custom rule for testing
     IRule doubleRule = input -> input != null ? input + input : null;
 


### PR DESCRIPTION
## Summary

実装完了: exception-policy Phase 6

rule 層 U/T/A 分類の基盤を確立した。`IRule.apply` に `throws StreamProcessingException` を追加し、ルール実装が分類済み例外を直接スローできるようにした。

## Changes

### `IRule.apply` — checked exception の追加（§4.1.11 確定）

```java
// Before
String apply(String input);

// After
String apply(String input) throws StreamProcessingException;
```

`StreamProcessingException extends IOException` のため、walker 側の `applyRule`（`throws IOException` 宣言済み）はキャッチ節の変更なしに分類済み例外を伝播できる。

### `PassThroughRule` / `MdcPropagatingRule` — null 時の例外を分類

| ルール | Before | After |
|---|---|---|
| PassThroughRule.apply(null) | `IllegalArgumentException` | `UserInputException`（U分類） |
| MdcPropagatingRule.apply(null) | `IllegalArgumentException` | `UserInputException`（U分類） |

### `ChainRule.apply` — throws 節を追加

チェーン内ルールの分類済み例外をそのまま伝播。

### walker 3ファイル — applyRule コメント更新

「`IRule.apply()` declares no checked exceptions」→「may throw `StreamProcessingException` (IOException subtype)」に更新。

### テスト更新

- `PassThroughRuleTest`（新規）: null 時 `UserInputException` を検証
- `MdcPropagatingRuleTest`: null 時 `UserInputException` に期待を変更
- `ChainRuleTest` / `TestRule`: `throws StreamProcessingException` を追加

## Test Results

✅ **全テスト通過**
- streamconverter-core: 468/468 tests passed
- streamconverter-db: 39/39 tests passed
- streamconverter-web: 13/13 tests passed

## Design Note — §4.1.11（IRule と @FunctionalInterface の両立）

`throws StreamProcessingException` を checked exception として宣言しても `@FunctionalInterface` との両立は保たれる。Java では関数型インターフェースが checked exception を宣言していても、その例外をスローしないラムダであれば引き続きラムダ構文で実装できる。既存の 468 テスト（ラムダを多用）が問題なく通過していることが証明。

## Stacked PR Note

このPRは `feat/exception-policy-phase5` を基にした Stacked PR です。
- Phase 5 PR #800 がマージされたら、本PR のベースを `develop` にリベースします

🤖 Generated with Claude Code
