### PR TITLE
fix: CsvValidateCommand の I/O 障害を検証成功として誤処理するバグを修正 (closes #783)

### DIFF
--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
@@ -150,6 +150,7 @@ public class CsvValidateCommand extends ConsumerCommand {
       InputStream inputStream, CsvRowValidator rowValidator, List<String> validationErrors)
       throws IOException {
     try (InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+        // withVerifyReader(false): prevent OpenCSV from treating IOException as EOF (#783)
         CSVReader csvReader = new CSVReaderBuilder(reader).withVerifyReader(false).build()) {
 
       String[] headers = null;

--- a/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
+++ b/streamconverter-core/src/main/java/com/streamconverter/command/impl/csv/CsvValidateCommand.java
@@ -1,6 +1,7 @@
 package com.streamconverter.command.impl.csv;
 
 import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
 import com.opencsv.exceptions.CsvMalformedLineException;
 import com.opencsv.exceptions.CsvValidationException;
 import com.streamconverter.InternalSystemException;
@@ -149,7 +150,7 @@ public class CsvValidateCommand extends ConsumerCommand {
       InputStream inputStream, CsvRowValidator rowValidator, List<String> validationErrors)
       throws IOException {
     try (InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-        CSVReader csvReader = new CSVReader(reader)) {
+        CSVReader csvReader = new CSVReaderBuilder(reader).withVerifyReader(false).build()) {
 
       String[] headers = null;
       if (hasHeader) {

--- a/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
+++ b/streamconverter-core/src/test/java/com/streamconverter/command/impl/csv/CsvValidateCommandTest.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** CsvValidateCommandクラスのテスト */
@@ -500,7 +499,6 @@ public class CsvValidateCommandTest {
   }
 
   @Test
-  @Tag("known-bug") // #783
   @DisplayName("読み取り中に I/O 障害が発生した場合は検証成功として扱われない")
   void midStreamIoErrorIsNotTreatedAsSuccess() throws IOException {
     // ネットワーク切断・ディスクエラー等で入力が途中で切断された場合、


### PR DESCRIPTION
## 概要

`CsvValidateCommand` が読み取り中の I/O 障害を EOF として扱い、途中で切断された入力を検証成功にするバグを修正します（closes #783）。

## 根本原因

opencsv 5.12.0 の `CSVReader` はデフォルトで `verifyReader=true` が有効になっており、`getNextLine()` が `IOException` を EOF（null）に変換して握りつぶす。このため `readNext()` が null を返して正常ループ終了扱いになっていた。

## 修正内容

`new CSVReader(reader)` を `new CSVReaderBuilder(reader).withVerifyReader(false).build()` に切り替え。`verifyReader=false` にすると `readLine()` の `IOException` がそのまま上位に伝播し、既存の `catch (IOException e)` ブロックで `InternalSystemException` に変換される。

## 確認

- `verifyKnownBugs` が BUILD FAILED（known-bug テスト `midStreamIoErrorIsNotTreatedAsSuccess` がパスに転換）
- `streamconverter-core:test` 全 469 件パス
- Codex plan-review・code review ともに承認済み

Closes #783
