### PR TITLE
test: add known-bug proof test: DatabaseConnectionPool returnConnection decrement leak (#817)

### DIFF
--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.when;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -20,7 +22,52 @@ import org.mockito.Mockito;
 class DatabaseConnectionPoolTest {
 
   @Test
-  @org.junit.jupiter.api.DisplayName("プール内の接続が無効化された後でも新しい接続を取得できる")
+  @Tag("known-bug") // #817
+  @DisplayName("returnConnection が close() 失敗後も activeConnections をデクリメントして次の接続取得を可能にする")
+  void returnConnection_decrementsActiveConnectionsEvenWhenCloseFails() throws SQLException {
+    // returnConnection() は close() が SQLException をスローしても activeConnections を減算すべき。
+    // close() 失敗後にデクリメントされないと、以降の getConnection() で
+    // activeConnections >= maxPoolSize と判定されて新規接続を作れなくなる。
+    Connection closeFailingConnection = mock(Connection.class);
+    Connection nextConnection = mock(Connection.class);
+
+    // closeFailingConnection: 返却時に isConnectionValid() == false を返し、close() で例外をスロー
+    // returnConnection() は isConnectionValid()==false の場合に close() を試みるが、
+    // close() が SQLException をスローするとデクリメントが行われない
+    when(closeFailingConnection.isValid(1)).thenReturn(false);
+    when(closeFailingConnection.isClosed()).thenReturn(false);
+    Mockito.doThrow(new SQLException("simulated close failure"))
+        .when(closeFailingConnection)
+        .close();
+
+    when(nextConnection.isValid(1)).thenReturn(true);
+    when(nextConnection.isClosed()).thenReturn(false);
+    Mockito.doNothing().when(nextConnection).close();
+
+    try (MockedStatic<DriverManager> mockedDriverManager =
+        Mockito.mockStatic(DriverManager.class)) {
+      mockedDriverManager
+          .when(() -> DriverManager.getConnection(anyString()))
+          .thenReturn(closeFailingConnection, nextConnection);
+
+      DatabaseConnectionPool pool = new DatabaseConnectionPool("jdbc:mock:db", 1, 200);
+
+      // 1回目: 新規接続(closeFailingConnection)を取得
+      Connection c1 = pool.getConnection();
+      // 返却時に isConnectionValid() は false (isValid が false を返す) → close() が呼ばれ SQLException
+      // activeConnections がデクリメントされれば空きスロットが生まれ、次の getConnection() で新規接続を作れる
+      c1.close();
+
+      // バグがある場合: activeConnections == 1 のまま → getConnection() がタイムアウトして SQLException
+      // 修正後: activeConnections == 0 → 新規接続(nextConnection)が作成されて返却される
+      assertDoesNotThrow(
+          pool::getConnection,
+          "returnConnection で close() が失敗した後も activeConnections がデクリメントされ、新規接続を取得できるべき");
+    }
+  }
+
+  @Test
+  @DisplayName("プール内の接続が無効化された後でも新しい接続を取得できる")
   void getConnection_createsNewConnectionAfterPooledConnectionBecomesInvalid() throws SQLException {
     Connection mockConnection1 = mock(Connection.class);
     Connection mockConnection2 = mock(Connection.class);


### PR DESCRIPTION
## バグの概要

関連 issue: #817

`DatabaseConnectionPool.returnConnection()` が接続の `close()` 失敗時に `activeConnections` をデクリメントしない。
これにより、以降の `getConnection()` で `activeConnections >= maxPoolSize` と判定され、タイムアウトして `SQLException` が発生する。

## 証明方法

方法 A（失敗するテスト）: `close()` が `SQLException` をスローするモック接続を使用して、返却後に新規接続取得がタイムアウトすることを確認。

Codex 承認済み（承認: バグの存在を証明できている）。

## 証明テスト

```
AssertionFailedError: returnConnection で close() が失敗した後も activeConnections がデクリメントされ、
新規接続を取得できるべき ==> Unexpected exception thrown: 
java.sql.SQLException: Failed to get connection within timeout
```

## 確認済み

- `verifyKnownBugs`: BUILD SUCCESSFUL（known-bug テストが期待通り FAIL = バグ存在確認）
- `streamconverter-db:test`: 全 39 件パス（known-bug タグで除外）

修正 PR で `verifyKnownBugs` が BUILD FAILED になることがバグ修正の証明になります。
