### PR TITLE
fix: decrement activeConnections in finally to prevent pool exhaustion on close failure (closes #817)

### DIFF
--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseConnectionPool.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseConnectionPool.java
@@ -140,9 +140,10 @@ public class DatabaseConnectionPool {
     if (isShutdown.get() || !isConnectionValid(connection)) {
       try {
         connection.close();
-        activeConnections.decrementAndGet();
       } catch (SQLException e) {
         logger.warn("Failed to close returned connection: {}", e.getMessage());
+      } finally {
+        activeConnections.decrementAndGet();
       }
       return;
     }
@@ -151,10 +152,11 @@ public class DatabaseConnectionPool {
       // プールが満杯の場合は接続をクローズ
       try {
         connection.close();
-        activeConnections.decrementAndGet();
         logger.debug("Closed excess connection - Active connections: {}", activeConnections.get());
       } catch (SQLException e) {
         logger.warn("Failed to close excess connection: {}", e.getMessage());
+      } finally {
+        activeConnections.decrementAndGet();
       }
     } else {
       logger.debug("Returned connection to pool");

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
@@ -9,7 +9,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -22,7 +21,6 @@ import org.mockito.Mockito;
 class DatabaseConnectionPoolTest {
 
   @Test
-  @Tag("known-bug") // #817
   @DisplayName("returnConnection が close() 失敗後も activeConnections をデクリメントして次の接続取得を可能にする")
   void returnConnection_decrementsActiveConnectionsEvenWhenCloseFails() throws SQLException {
     // returnConnection() は close() が SQLException をスローしても activeConnections を減算すべき。


### PR DESCRIPTION
## 概要

`DatabaseConnectionPool.returnConnection()` で `close()` 失敗時に `activeConnections` がデクリメントされないバグを修正します（closes #817）。

## 根本原因

`returnConnection()` の2箇所の try-catch ブロックで `activeConnections.decrementAndGet()` が `close()` 成功時のみ呼ばれていた。`close()` が `SQLException` をスローした場合にデクリメントされず、`activeConnections` が実態より大きくなる。これにより以降の `getConnection()` が `activeConnections >= maxPoolSize` と判定して永続的にタイムアウトする。

## 修正内容

`decrementAndGet()` を `finally` ブロックに移動し、`close()` の成否にかかわらずスロットを解放するようにした。

## 設計上の残留リスク（承認済み）

`close()` が失敗した場合、DB 側では接続が残存する可能性があるため、修正後の `maxPoolSize` は「管理中の接続スロット数」の上限であって「DB 側の実接続数」の厳密な上限ではなくなる。

plan-review で Codex がこのトレードオフを認識した上で「既知バグ修正としては受け入れやすい」と承認しており、実装後の code-review で同トレードオフが P2 として再指摘されたが、その指摘に従うと #817 の known-bug テストが再現する（永続的なプール枯渇）ため、本修正の方針を維持する。実際の接続プール実装（HikariCP 等）も `close()` 成否にかかわらずスロットを解放する方針を採用している。

## 証明の状態

**注意**: 証明 PR（#818）がまだ develop にマージされていないため、本修正ブランチには known-bug テストが含まれない（`verifyKnownBugs: no known-bug tests found`）。fix の正しさは現時点で以下に依拠する：
- ローカルでの論理検証
- PR #818 の証明テスト（`returnConnection_decrementsActiveConnectionsEvenWhenCloseFails`）が本修正後にパスすることで `verifyKnownBugs BUILD FAILED` が確認できる

PR #818 がマージされた後に `verifyKnownBugs BUILD FAILED` による客観的証明が完成する。

Closes #817
