### PR TITLE
test: add known-bug proof test for DatabaseConnectionPool maxPoolSize overcommit on close failure (#820)

### DIFF
--- a/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseConnectionPool.java
+++ b/streamconverter-db/src/main/java/com/streamconverter/command/rule/DatabaseConnectionPool.java
@@ -140,9 +140,10 @@ public class DatabaseConnectionPool {
     if (isShutdown.get() || !isConnectionValid(connection)) {
       try {
         connection.close();
-        activeConnections.decrementAndGet();
       } catch (SQLException e) {
         logger.warn("Failed to close returned connection: {}", e.getMessage());
+      } finally {
+        activeConnections.decrementAndGet();
       }
       return;
     }
@@ -151,10 +152,11 @@ public class DatabaseConnectionPool {
       // プールが満杯の場合は接続をクローズ
       try {
         connection.close();
-        activeConnections.decrementAndGet();
         logger.debug("Closed excess connection - Active connections: {}", activeConnections.get());
       } catch (SQLException e) {
         logger.warn("Failed to close excess connection: {}", e.getMessage());
+      } finally {
+        activeConnections.decrementAndGet();
       }
     } else {
       logger.debug("Returned connection to pool");

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
@@ -23,7 +23,6 @@ import org.mockito.Mockito;
 class DatabaseConnectionPoolTest {
 
   @Test
-  @Tag("known-bug") // #817
   @DisplayName("returnConnection が close() 失敗後も activeConnections をデクリメントして次の接続取得を可能にする")
   void returnConnection_decrementsActiveConnectionsEvenWhenCloseFails() throws SQLException {
     // returnConnection() は close() が SQLException をスローしても activeConnections を減算すべき。

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
@@ -3,6 +3,7 @@ package com.streamconverter.command.rule;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
@@ -63,6 +64,47 @@ class DatabaseConnectionPoolTest {
       assertDoesNotThrow(
           pool::getConnection,
           "returnConnection で close() が失敗した後も activeConnections がデクリメントされ、新規接続を取得できるべき");
+    }
+  }
+
+  @Test
+  @Tag("known-bug") // #820
+  @DisplayName("close() 失敗後にスロットを解放する場合、DriverManager.getConnection() の呼び出し回数は maxPoolSize を超えない")
+  void returnConnection_doesNotExceedMaxPoolSizeWhenCloseFails() throws SQLException {
+    // returnConnection() で close() が失敗した場合、activeConnections をデクリメントして
+    // スロットを解放するため、次の getConnection() で新規接続が作られる。
+    // しかし DB 側には 1 本目の接続が残存している可能性があるため、
+    // DriverManager.getConnection() の呼び出し回数は maxPoolSize（=1）を超えてはならない。
+    Connection closeFailingConnection = mock(Connection.class);
+
+    when(closeFailingConnection.isValid(1)).thenReturn(false);
+    when(closeFailingConnection.isClosed()).thenReturn(false);
+    Mockito.doThrow(new SQLException("simulated close failure"))
+        .when(closeFailingConnection)
+        .close();
+
+    try (MockedStatic<DriverManager> mockedDriverManager =
+        Mockito.mockStatic(DriverManager.class)) {
+      mockedDriverManager
+          .when(() -> DriverManager.getConnection(anyString()))
+          .thenReturn(closeFailingConnection);
+
+      DatabaseConnectionPool pool = new DatabaseConnectionPool("jdbc:mock:db", 1, 200);
+
+      // 1回目: maxPoolSize=1 に対して1本目の接続を取得（DriverManager 呼び出し: 1回）
+      Connection c1 = pool.getConnection();
+      // 返却時に isConnectionValid()==false → close() 失敗 → スロット解放
+      c1.close();
+
+      // バグがある場合: スロット解放により 2回目の DriverManager.getConnection() が発生し
+      // maxPoolSize を超えた物理接続要求が生じる（close() 失敗で DB 側に 1 本目が残存したまま）
+      try {
+        pool.getConnection();
+      } catch (SQLException ignored) {
+        // タイムアウト等でも呼び出し回数は 1 回を超えてはならない
+      }
+
+      mockedDriverManager.verify(() -> DriverManager.getConnection(anyString()), times(1));
     }
   }
 

--- a/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
+++ b/streamconverter-db/src/test/java/com/streamconverter/command/rule/DatabaseConnectionPoolTest.java
@@ -10,6 +10,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;


### PR DESCRIPTION
## バグの概要

関連 issue: #820

`DatabaseConnectionPool.returnConnection()` で `close()` が失敗した場合、#817 の修正（`finally` でのデクリメント）によりスロットは解放されるが、DB 側には古い接続が残存する可能性がある。これにより `maxPoolSize` を超えて `DriverManager.getConnection()` が呼ばれ、DB 側の実接続数が `maxPoolSize` を超えうる。

## 証明方法

方法 A（失敗するテスト）: `maxPoolSize=1` のプールで `close()` 失敗後に `DriverManager.getConnection()` が1回しか呼ばれないことをアサート。

- **#817 修正前**（デクリメントなし）: テスト PASS — タイムアウトで2回目に到達しないため `DriverManager` は1回のみ
- **#817 修正後**（`finally` デクリメント）: テスト **FAIL** — スロット解放で2回目に到達し `DriverManager` が2回呼ばれる

この FAIL → PASS の反転が「#820 が #817 修正によって発生する」ことの証明。

Codex 承認済み（承認: バグの存在を証明できている）。

## 証明ログ

```
TooManyActualInvocations:
Wanted: DriverManager.getConnection(anyString()) → times(1)
Actual: 2 invocations
```

## 確認済み

- `verifyKnownBugs`: BUILD SUCCESSFUL（#817 修正前の `origin/develop` ベース）
- `streamconverter-db:test`: 全 39 件パス

## 注意

このバグは `origin/develop` の現時点では **発現しない**（#817 が未マージのため）。
PR #819（#817 修正）がマージされた後に `verifyKnownBugs` が BUILD SUCCESSFUL になることでバグの存在が確認できる。

修正 PR で `verifyKnownBugs` が BUILD FAILED になることがバグ修正の証明になる。
